### PR TITLE
Pass the blade info from `BladeNodeAero` to Aerodyn (issue38)

### DIFF
--- a/include/seahowl/aero/blade_aero.h
+++ b/include/seahowl/aero/blade_aero.h
@@ -13,9 +13,12 @@ namespace aero {
 
 /**@brief Blade aerodynamic node */
 struct BladeNodeAero {
-    chrono::ChVector<double> coordinates;   ///< Point coordinates
-    chrono::ChQuaternion<double> rotation;  ///< Rotation
-    chrono::ChVector<double> velocity;      ///< Velocity
+    chrono::ChVector<double> coordinates;       ///< Point coordinates
+    chrono::ChQuaternion<double> rotation;      ///< Rotation
+    chrono::ChVector<double> velocity;          ///< Translational Velocity
+    chrono::ChVector<double> rot_velocity;      ///< Rotational Velocity
+    chrono::ChVector<double> acceleration;      ///< Translational acceleration
+    chrono::ChVector<double> rot_acceleration;  ///< Rotational acceleration
     chrono::ChVector<double> load;
     chrono::ChVector<double> wind_velocity;              ///< Uninduced wind velocities on blade nodes
     chrono::ChVector<double> wind_velocity_shadowed;     ///< Wind velocities on blade nodes with tower shadow effect

--- a/src/aero/aerodyn_adapter.cpp
+++ b/src/aero/aerodyn_adapter.cpp
@@ -145,12 +145,12 @@ void seahowl::aero::AeroDynAdapter::setMotionRoot(seahowl::core::Turbine& turbin
     float* bldRootAcc_C = new float[6 * nblades];
 
     for (int i = 0; i < nblades; i++) {
-        auto bldRootPos = turbine.rotor.blades[i]->elasto->nodes[0]->GetPos();
-        auto bldRootOri = turbine.rotor.blades[i]->elasto->nodes[0]->GetA();
-        auto bldRootTranVel = turbine.rotor.blades[i]->elasto->nodes[0]->GetPos_dt();
-        auto bldRootRotVel = turbine.rotor.blades[i]->elasto->nodes[0]->GetWvel_par();
-        auto bldRootTranAcc = turbine.rotor.blades[i]->elasto->nodes[0]->GetPos_dtdt();
-        auto bldRootRotAcc = turbine.rotor.blades[i]->elasto->nodes[0]->GetWacc_par();
+        auto bldRootPos = turbine.rotor.blades[i]->aero->nodes[0].coordinates;
+        auto bldRootOri = chrono::ChMatrix33(turbine.rotor.blades[i]->aero->nodes[0].rotation);
+        auto bldRootTranVel = turbine.rotor.blades[i]->aero->nodes[0].velocity;
+        auto bldRootRotVel = turbine.rotor.blades[i]->aero->nodes[0].rot_velocity;
+        auto bldRootTranAcc = turbine.rotor.blades[i]->aero->nodes[0].acceleration;
+        auto bldRootRotAcc = turbine.rotor.blades[i]->aero->nodes[0].rot_acceleration;
         for (int j = 0; j < 3; j++) {
             int p = i * 3 + j;
             int q = i * 6 + j;
@@ -193,12 +193,12 @@ void seahowl::aero::AeroDynAdapter::setMotionMesh(seahowl::core::Turbine& turbin
 
     for (int i = 0; i < nblades; i++) {
         for (int j = 0; j < nMeshPerBlade; j++) {
-            auto meshPos = turbine.rotor.blades[i]->elasto->nodes[j]->GetPos();
-            auto meshOri = turbine.rotor.blades[i]->elasto->nodes[j]->GetA();
-            auto meshTranVel = turbine.rotor.blades[i]->elasto->nodes[j]->GetPos_dt();
-            auto meshRotVel = turbine.rotor.blades[i]->elasto->nodes[j]->GetWvel_par();
-            auto meshTranAcc = turbine.rotor.blades[i]->elasto->nodes[j]->GetPos_dtdt();
-            auto meshRotAcc = turbine.rotor.blades[i]->elasto->nodes[j]->GetWacc_par();
+            auto meshPos = turbine.rotor.blades[i]->aero->nodes[j].coordinates;
+            auto meshOri = chrono::ChMatrix33(turbine.rotor.blades[i]->aero->nodes[j].rotation);
+            auto meshTranVel = turbine.rotor.blades[i]->aero->nodes[j].velocity;
+            auto meshRotVel = turbine.rotor.blades[i]->aero->nodes[j].rot_velocity;
+            auto meshTranAcc = turbine.rotor.blades[i]->aero->nodes[j].acceleration;
+            auto meshRotAcc = turbine.rotor.blades[i]->aero->nodes[j].rot_acceleration;
 
             auto ii = i * nMeshPerBlade + j;
             for (int k = 0; k < 3; k++) {
@@ -375,10 +375,10 @@ void seahowl::aero::AeroDynInflowLib::Init() {
     // VTK
     WrVTK = 2;       // default of no vtk output
     WrVTK_Type = 1;  // defautl of surface meshes
-    VTKNacDim = new float[6]{
-        0,  -4.2751, -4.2751,
-        12, 8.552,   8.552};  // default nacelle dimension for VTK surface rendering [x0,y0,z0,Lx,Ly,Lz] (m)
-    VTKHubRad = 3.97;         // default hub radius for VTK surface rendering
+    VTKNacDim =
+        new float[6]{0,     -4.2751, -4.2751, 12,
+                     8.552, 8.552};  // default nacelle dimension for VTK surface rendering [x0,y0,z0,Lx,Ly,Lz] (m)
+    VTKHubRad = 3.97;                // default hub radius for VTK surface rendering
 
     // NumBlades    = 3;
     // NumMeshPts   = 1;

--- a/src/aero/blade_aero.cpp
+++ b/src/aero/blade_aero.cpp
@@ -11,6 +11,9 @@ BladeNodeAero::BladeNodeAero(BladeReferencePointAero& point) {
     coordinates = point.coordinates;
     rotation = point.rotation;
     velocity = chrono::ChVector<double>(0.0, 0.0, 0.0);
+    rot_velocity = chrono::ChVector<double>(0.0, 0.0, 0.0);
+    acceleration = chrono::ChVector<double>(0.0, 0.0, 0.0);
+    rot_acceleration = chrono::ChVector<double>(0.0, 0.0, 0.0);
     load = chrono::ChVector<double>(0.0, 0.0, 0.0);
     wind_velocity = chrono::ChVector<double>(0.0, 0.0, 0.0);
     wind_velocity_shadowed = chrono::ChVector<double>(0.0, 0.0, 0.0);

--- a/src/aero/rotor_aero.cpp
+++ b/src/aero/rotor_aero.cpp
@@ -160,7 +160,7 @@ void RotorAero::compute_wind_loads_bemt(const WindModel& wind_model,
     }
 }
 
-void RotorAero::compute_wind_loads_aerodyn(float *LoadAeroDyn,
+void RotorAero::compute_wind_loads_aerodyn(float* LoadAeroDyn,
                                            const WindModel& wind_model,
                                            double time,
                                            const TowerAero& tower_aero,
@@ -168,28 +168,25 @@ void RotorAero::compute_wind_loads_aerodyn(float *LoadAeroDyn,
                                            bool tip_loss,
                                            bool hub_loss) {
     double density = wind_model.get_density();
-    for (int kk = 0; kk < 3; kk++) {
-        auto& blade = blades[kk];
+    int count_blade = -1;
+    for (auto& blade : blades) {
+        count_blade += 1;
         auto blade_azimuth = azimuth + blade->azimuth0;
         // check that blade_azimuth is between pi and -pi
         if (blade_azimuth < -chrono::CH_C_PI || blade_azimuth > chrono::CH_C_PI) {
             blade_azimuth =
                 abs(std::fmod((blade_azimuth + 3 * chrono::CH_C_PI), 2 * chrono::CH_C_PI)) - chrono::CH_C_PI;
         }
-        for (int ii = 0; ii < blade->elements.size(); ii++) {
-
-            auto& element = blade->elements[ii];
-            auto length = element.length;
-
+        int count_node = -1;
+        for (auto& node : blade->nodes) {
+            count_node += 1;
             // store load in global frame
-            int indp = kk * blade->elements.size() + ii;
-            int pp = (kk * (blade->elements.size() + 1) + ii) * 6;
-            int qq = (kk * (blade->elements.size() + 1) + ii + 1) * 6;
-
-            auto loadx = (LoadAeroDyn[pp]   + LoadAeroDyn[qq]  ) / 2.0 * length ;
-            auto loady = (LoadAeroDyn[pp+1] + LoadAeroDyn[qq+1]) / 2.0 * length ;
-            auto loadz = (LoadAeroDyn[pp+2] + LoadAeroDyn[qq+2]) / 2.0 * length ;
-            blade->loads[ii].Set(loadx, loady, loadz);
+            int pp = (count_blade * (blade->elements.size() + 1) + count_node) * 6;
+            node.load = chrono::ChVector<double>(LoadAeroDyn[pp], LoadAeroDyn[pp + 1], LoadAeroDyn[pp + 2]);
+        }
+        // update loads of blade
+        for (int ii = 0; ii < blade->elements.size(); ii++) {
+            blade->loads[ii] = blade->elements[ii].get_load();
         }
     }
 }

--- a/src/core/blade.cpp
+++ b/src/core/blade.cpp
@@ -104,9 +104,27 @@ void Blade::update_positions_aero() {
         node_aero.coordinates = coordsys.TransformLocalToParent(offset3D);
 
         // update velocity of aero elements
+        double eta_scaled = 0.5 * (eta + 1.0);
         node_aero.velocity =
-            0.5 * (std::dynamic_pointer_cast<chrono::fea::ChNodeFEAxyzrot>(element_elasto->GetNodeN(0))->GetPos_dt() +
-                   std::dynamic_pointer_cast<chrono::fea::ChNodeFEAxyzrot>(element_elasto->GetNodeN(1))->GetPos_dt());
+            ((1.0 - eta_scaled) *
+                 std::dynamic_pointer_cast<chrono::fea::ChNodeFEAxyzrot>(element_elasto->GetNodeN(0))->GetPos_dt() +
+             eta_scaled *
+                 std::dynamic_pointer_cast<chrono::fea::ChNodeFEAxyzrot>(element_elasto->GetNodeN(1))->GetPos_dt());
+        node_aero.rot_velocity =
+            ((1.0 - eta_scaled) *
+                 std::dynamic_pointer_cast<chrono::fea::ChNodeFEAxyzrot>(element_elasto->GetNodeN(0))->GetWvel_par() +
+             eta_scaled *
+                 std::dynamic_pointer_cast<chrono::fea::ChNodeFEAxyzrot>(element_elasto->GetNodeN(1))->GetWvel_par());
+        node_aero.acceleration =
+            ((1.0 - eta_scaled) *
+                 std::dynamic_pointer_cast<chrono::fea::ChNodeFEAxyzrot>(element_elasto->GetNodeN(0))->GetPos_dtdt() +
+             eta_scaled *
+                 std::dynamic_pointer_cast<chrono::fea::ChNodeFEAxyzrot>(element_elasto->GetNodeN(1))->GetPos_dtdt());
+        node_aero.rot_acceleration =
+            ((1.0 - eta_scaled) *
+                 std::dynamic_pointer_cast<chrono::fea::ChNodeFEAxyzrot>(element_elasto->GetNodeN(0))->GetWacc_par() +
+             eta_scaled *
+                 std::dynamic_pointer_cast<chrono::fea::ChNodeFEAxyzrot>(element_elasto->GetNodeN(1))->GetWacc_par());
     }
 
     // update pitch of blade for aero


### PR DESCRIPTION
- Finish the task 1 of issue38: get info from `BladeNodeAero` (introduced in #28 directly rather than elasto nodes (that could be discretized differently) and pass it to AeroDyn
- Reshape the function `compute_wind_loads_aerodyn` to pass aerodyn loads through node, to be consistent with the function `compute_wind_loads_bemt`