### PR TITLE
Interpolation and aero initialization bug fixes

### DIFF
--- a/src/aero/aerodyn_adapter.cpp
+++ b/src/aero/aerodyn_adapter.cpp
@@ -184,7 +184,7 @@ void seahowl::aero::AeroDynAdapter::setMotionRoot(seahowl::core::Turbine& turbin
 
 void seahowl::aero::AeroDynAdapter::setMotionMesh(seahowl::core::Turbine& turbine) {
     auto nblades = turbine.blades.size();
-    auto nMeshPerBlade = turbine.rotor.blades[0]->elasto->nodes.size();
+    auto nMeshPerBlade = turbine.rotor.blades[0]->aero->nodes.size();
     auto nMesh = nMeshPerBlade * nblades;
     float* meshPos_C = new float[3 * nMesh];
     double* meshOri_C = new double[9 * nMesh];

--- a/src/elasto/elasto.cpp
+++ b/src/elasto/elasto.cpp
@@ -109,7 +109,7 @@ void ComponentElastoFEA::accumulate_element_load(chrono::ChVector<double> load,
     node0->SetForce(node0->GetForce() + load0);
     node0->SetTorque(node0->GetTorque() + (position + offset - node0->GetPos()) % load0);
     // load on second node
-    double weight1 = 0.5 * abs(eta - 1);
+    double weight1 = 0.5 * abs(eta + 1);
     auto load1 = load * weight1;
     auto node1 = std::dynamic_pointer_cast<chrono::fea::ChNodeFEAxyzrot>(element->GetNodeN(1));
     node1->SetForce(node1->GetForce() + load1);


### PR DESCRIPTION
Two bug fixes related to aero/elasto communication:
- Fixed weights for applying aero loads from aero elements to elasto nodes. The issue appeared when discretization aero was different from discretization elasto (which is not the case by default for IEA15MW example). With the same aero and elasto discretizations, weights were already 0.5 for both nodes (as it should be), so it worked as intended.
- Fixed initialization of blade mesh by AeroDynAdapter to use aero info rather than elasto info to pass to AeroDyn.