### PR TITLE
Establish strategies for selecting models/fidelity levels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,12 +153,14 @@ set(SEAHOWL_ELASTO_SOURCES
 set(SEAHOWL_ELASTO_HEADERS
     include/seahowl/elasto/blade_elasto.h
     include/seahowl/elasto/entities_elasto.h
+    include/seahowl/elasto/strategy_elasto.h
     include/seahowl/elasto/component_elasto.h
     include/seahowl/elasto/reference_point_elasto.h
     include/seahowl/elasto/rotor_elasto.h
     include/seahowl/elasto/tower_elasto.h
     include/seahowl/elasto/mooring_elasto.h
     include/seahowl/elasto/chrono_adapters.h
+    include/seahowl/elasto/chrono_strategy.h
 )
 source_group(elasto FILES ${SEAHOWL_ELASTO_SOURCES} ${SEAHOWL_ELASTO_HEADERS})
 

--- a/include/seahowl/elasto/blade_elasto.h
+++ b/include/seahowl/elasto/blade_elasto.h
@@ -49,14 +49,12 @@ class BladeElasto : public ComponentElastoFEA {
 
   private:
     /**
-     * @brief Builds the blade with simple Timoshenko elements (lineic density, flap stiffness, edge stiffness).
+     * @brief Builds the blade with finite elements.
+     *
+     * Depending on strategy: simple Timoshenko (lineic density, flap stiffness, edge stiffness) or FPM Timoshenko
+     * elements (6x6 mass and stiffness matrices).
      */
-    void build_elements_tapered_timoshenko();
-
-    /**
-     * @brief Builds the blade with FPM Timoshenko elements (6x6 mass and stiffness matrices).
-     */
-    void build_elements_tapered_timoshenko_fpm();
+    void build_elements();
 };
 
 }  // namespace elasto

--- a/include/seahowl/elasto/chrono_strategy.h
+++ b/include/seahowl/elasto/chrono_strategy.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <seahowl/elasto/strategy_elasto.h>
+#include <seahowl/elasto/chrono_adapters.h>
+
+#include <memory.h>
+
+namespace seahowl {
+namespace elasto {
+
+class StrategyElastoChrono : public StrategyElasto {
+  public:
+    bool fpm_mode = false;
+    StrategyElastoChrono(){};
+    virtual std::shared_ptr<NodeElasto> make_node(Vector3d position, Quaternion rotation) const override {
+        return std::make_shared<NodeElastoChrono>(position, rotation);
+    };
+    virtual std::shared_ptr<ElementElasto> make_element_blade() const override {
+        if (fpm_mode == false) {
+            return std::make_shared<ElementBladeElastoChrono>();
+        } else {
+            return std::make_shared<ElementBladeElastoChronoFPM>();
+        }
+    };
+    virtual std::shared_ptr<ElementElasto> make_element_tower() const override {
+        return std::make_shared<ElementBladeElastoChrono>();
+    };
+    virtual std::shared_ptr<ElementElasto> make_element_mooring() const override {
+        return std::make_shared<ElementMooringElastoChrono>();
+    };
+    virtual std::shared_ptr<BodyElasto> make_body() const override { return std::make_shared<BodyElastoChrono>(); };
+    virtual std::shared_ptr<Link> make_link() const override { return std::make_shared<LinkChrono>(); };
+};
+
+}  // namespace elasto
+}  // namespace seahowl

--- a/include/seahowl/elasto/component_elasto.h
+++ b/include/seahowl/elasto/component_elasto.h
@@ -5,6 +5,7 @@
 
 #include <seahowl/commons.h>
 #include <seahowl/elasto/entities_elasto.h>
+#include <seahowl/elasto/strategy_elasto.h>
 #include <seahowl/elasto/reference_point_elasto.h>
 
 namespace seahowl {
@@ -18,6 +19,9 @@ namespace elasto {
  */
 class ComponentElasto {
   public:
+    /** @brief Elasto strategy to use on component. */
+    std::shared_ptr<StrategyElasto> strategy_elasto;
+
     /**
      * @brief Rotates the component.
      *

--- a/include/seahowl/elasto/strategy_elasto.h
+++ b/include/seahowl/elasto/strategy_elasto.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <seahowl/elasto/entities_elasto.h>
+#include <memory>
+
+namespace seahowl {
+namespace elasto {
+
+class StrategyElasto {
+  public:
+    virtual std::shared_ptr<NodeElasto> make_node(Vector3d position, Quaternion rotation) const = 0;
+    virtual std::shared_ptr<ElementElasto> make_element_blade() const = 0;
+    virtual std::shared_ptr<ElementElasto> make_element_tower() const = 0;
+    virtual std::shared_ptr<ElementElasto> make_element_mooring() const = 0;
+    virtual std::shared_ptr<BodyElasto> make_body() const = 0;
+    virtual std::shared_ptr<Link> make_link() const = 0;
+};
+
+}  // namespace elasto
+}  // namespace seahowl

--- a/include/seahowl/elasto/tower_elasto.h
+++ b/include/seahowl/elasto/tower_elasto.h
@@ -36,7 +36,7 @@ class TowerElasto : public ComponentElastoFEA {
     /**
      * @brief Builds the blade with Timoshenko elements (lineic density, foreaft stiffness, sideside stiffness).
      */
-    void build_elements_tapered_timoshenko();
+    void build_elements();
 };
 
 }  // namespace elasto

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -1,8 +1,8 @@
 #include <seahowl/elasto/blade_elasto.h>
 
-#include <seahowl/elasto/chrono_adapters.h>
 #include <seahowl/core/utils.h>  // For DiscretizationPoint
 #include <seahowl/elasto/reference_point_elasto.h>
+#include <seahowl/elasto/chrono_adapters.h>
 
 #include <numeric>
 
@@ -14,6 +14,10 @@ void BladeElasto::build() {
     // check that enough reference points were defined to create elements (at least 2)
     if (reference_points.size() <= 2) {
         throw std::runtime_error("Not enough elasto reference points defined for blade.");
+    }
+    // check that a pointer to a strategy was initialized
+    if (!strategy_elasto) {
+        throw std::runtime_error("Must define elasto strategy for blade.");
     }
 
     // check that discretization_fractions was defined, otherwise take reference point fractions
@@ -56,16 +60,10 @@ void BladeElasto::build() {
         nodes[ii]->set_rotation(Quaternion(rotation_matrix));
     }
 
-    if (fpm_mode) {
-        build_elements_tapered_timoshenko_fpm();
-    } else {
-        build_elements_tapered_timoshenko();
-    }
-    // commented out since loads are applied to nodes;
-    // build_loads(system);
+    build_elements();
 };
 
-void BladeElasto::build_elements_tapered_timoshenko() {
+void BladeElasto::build_elements() {
     elements.clear();
     const auto nelements = nodes.size() - 1;
 
@@ -75,7 +73,7 @@ void BladeElasto::build_elements_tapered_timoshenko() {
 
     for (size_t ii = 1; ii < nelements + 1; ii++) {
         // create element
-        auto element = std::make_shared<ElementBladeElastoChrono>();
+        auto element = strategy_elasto->make_element_blade();
         // add element to blade elements vector
         elements.push_back(element);
         // set element nodes
@@ -86,46 +84,9 @@ void BladeElasto::build_elements_tapered_timoshenko() {
         // switch from IEC standard (Z along blade) to chrono element coordinate system (X along element)
         rotation_relative =
             Quaternion(rotation_relative.w(), rotation_relative.z(), rotation_relative.y(), rotation_relative.x());
-        element->set_prebend(rotation_relative);
+        std::dynamic_pointer_cast<ElementBladeElasto>(element)->set_prebend(rotation_relative);
     }
 }
-
-void BladeElasto::build_elements_tapered_timoshenko_fpm() {
-    elements.clear();
-    const auto nelements = nodes.size() - 1;
-
-    if (nelements <= 0) {
-        throw std::runtime_error("Trying to build blade with no element.");
-    }
-
-    for (size_t ii = 1; ii < nelements + 1; ii++) {
-        // create element
-        auto element = std::make_shared<ElementBladeElastoChronoFPM>();
-        // add element to blade elements vector
-        elements.push_back(element);
-        // set element nodes
-        element->set_nodes(nodes[ii - 1], nodes[ii]);
-
-        // apply prebend and structural twist
-        auto rotation_relative = (nodes[ii]->get_rotation() * nodes[ii - 1]->get_rotation().inverse()).normalized();
-        // switch from IEC standard (Z along blade) to chrono element coordinate system (X along element)
-        rotation_relative =
-            Quaternion(rotation_relative.w(), rotation_relative.z(), rotation_relative.y(), rotation_relative.x());
-        element->set_prebend(rotation_relative);
-    }
-}
-
-// void BladeElasto::build_loads(chrono::ChSystemSMC& system) {
-//    auto loadcontainer = chrono_types::make_shared<chrono::ChLoadContainer>();
-//    system.Add(loadcontainer);
-//
-//    for (auto element : elements) {
-//        std::shared_ptr<chrono::ChLoad<ChLoaderWeighted>> loader_weighted(
-//            new chrono::ChLoad<ChLoaderWeighted>(element));
-//        loaders_aero.push_back(loader_weighted);
-//        loadcontainer->Add(loader_weighted);
-//    }
-//}
 
 void BladeElasto::evaluate_position_rotation(Vector3d& position,
                                              Quaternion& rotation,

--- a/src/elasto/mooring_elasto.cpp
+++ b/src/elasto/mooring_elasto.cpp
@@ -1,15 +1,15 @@
 #include <seahowl/elasto/mooring_elasto.h>
 #include <seahowl/core/utils.h>
-#include <seahowl/elasto/chrono_adapters.h>
-
-#include <chrono/fea/ChContactSurfaceNodeCloud.h>
-#include <chrono/physics/ChMaterialSurfaceSMC.h>
 
 using namespace seahowl::elasto;
 
 MooringElasto::MooringElasto() {}
 
 void MooringElasto::build() {
+    // check that a pointer to a strategy was initialized
+    if (!strategy_elasto) {
+        throw std::runtime_error("Must define elasto strategy for mooring.");
+    }
     // make reference points between fairlead and anchor
     std::vector<ReferencePointElasto> points;
     for (auto& fraction : discretization_fractions) {
@@ -33,12 +33,12 @@ void MooringElasto::build_elements_euler() {
 
     for (size_t ii = 1; ii < nelements + 1; ii++) {
         // create element
-        auto element = std::make_shared<ElementMooringElastoChrono>();
+        auto element = strategy_elasto->make_element_mooring();
         // add element to elements vector
         elements.push_back(element);
         // set element nodes
         element->set_nodes(nodes[ii - 1], nodes[ii]);
         // set section
-        element->set_properties(density, diameter, stiffness_axial);
+        std::dynamic_pointer_cast<ElementMooringElasto>(element)->set_properties(density, diameter, stiffness_axial);
     }
 }

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -2,7 +2,7 @@
 
 #include <seahowl/elasto/blade_elasto.h>
 #include <seahowl/elasto/tower_elasto.h>
-#include <seahowl/elasto/chrono_adapters.h>
+#include <seahowl/elasto/entities_elasto.h>
 
 using seahowl::elasto::BladeElasto;
 using seahowl::elasto::RotorElasto;
@@ -24,12 +24,17 @@ void RotorElasto::assemble(std::shared_ptr<SystemElasto> system) {
 }
 
 void RotorElasto::build(std::vector<std::shared_ptr<BladeElasto>> blades) {
+    // check that a pointer to a strategy was initialized
+    if (!strategy_elasto) {
+        throw std::runtime_error("Must define elasto strategy for RNA.");
+    }
+
     this->blades = blades;
 
     auto rotation0 = Quaternion(1.0, 0.0, 0.0, 0.0);
 
     // hub
-    body_hub = std::make_shared<BodyElastoChrono>();
+    body_hub = strategy_elasto->make_body();
     // move hub along X for overhang and COG offset, and along Z for distance from towertop
     body_hub->set_position(Vector3d(hub.overhang + hub.center_of_mass, 0.0, 0.0));
     // local Z axis along global X axis + shaft tilt along global Y axis
@@ -41,7 +46,7 @@ void RotorElasto::build(std::vector<std::shared_ptr<BladeElasto>> blades) {
     body_hub->set_inertia_diagonal(Vector3d(0., 0., hub.inertia));
 
     // shaft
-    body_shaft = std::make_shared<BodyElastoChrono>();
+    body_shaft = strategy_elasto->make_body();
     // move end of shaft at yaw axis of nacelle
     body_shaft->set_position(Vector3d(0.0, 0.0, shaft.distance_from_towertop));
     // align rotation
@@ -49,12 +54,12 @@ void RotorElasto::build(std::vector<std::shared_ptr<BladeElasto>> blades) {
     // massless body
     body_shaft->set_mass(0.0);
     // link hub to shaft
-    link_shaft_hub = std::make_shared<LinkChrono>();
+    link_shaft_hub = strategy_elasto->make_link();
     link_shaft_hub->initialize(body_hub, body_shaft);
     link_shaft_hub->set_constraints(true, true, true, false, true, true);
 
     // nacelle
-    body_nacelle = std::make_shared<BodyElastoChrono>();
+    body_nacelle = strategy_elasto->make_body();
     body_nacelle->set_position(nacelle.center_of_mass);
     body_nacelle->set_rotation(rotation0);
     // mass and inertia
@@ -62,17 +67,17 @@ void RotorElasto::build(std::vector<std::shared_ptr<BladeElasto>> blades) {
     ///@todo  change to full 3x3 inertia matrix
     body_nacelle->set_inertia_diagonal(Vector3d(0.0, 0.0, nacelle.inertia));
     // link nacelle body to shaft body
-    link_shaft_nacelle = std::make_shared<LinkChrono>();
+    link_shaft_nacelle = strategy_elasto->make_link();
     link_shaft_nacelle->initialize(body_nacelle, body_shaft);
     link_shaft_nacelle->set_constraints(true, true, true, true, true, true);
 
     // yaw bearing
-    body_yaw_bearing = std::make_shared<BodyElastoChrono>();
+    body_yaw_bearing = strategy_elasto->make_body();
     body_yaw_bearing->set_position(Vector3d(0.0, 0.0, 0.0));
     body_yaw_bearing->set_rotation(rotation0);
     body_yaw_bearing->set_mass(nacelle.yaw_bearing_mass);
     // link yaw bearing body to shaft body
-    link_shaft_yaw_bearing = std::make_shared<LinkChrono>();
+    link_shaft_yaw_bearing = strategy_elasto->make_link();
     link_shaft_yaw_bearing->initialize(body_shaft, body_yaw_bearing);
     link_shaft_yaw_bearing->set_constraints(true, true, true, true, true, true);
 
@@ -102,7 +107,7 @@ void RotorElasto::build(std::vector<std::shared_ptr<BladeElasto>> blades) {
         blade->translate(Vector3d(0.0, 0.0, shaft.distance_from_towertop));
 
         // link root node of blade to rotor center
-        auto link_hub_blade = std::make_shared<LinkChrono>();
+        auto link_hub_blade = strategy_elasto->make_link();
         link_hub_blade->initialize(blade->nodes[0], body_hub);
         link_hub_blade->set_constraints(true, true, true, true, true, true);
         links_blades.push_back(link_hub_blade);
@@ -114,7 +119,7 @@ void RotorElasto::link_tower(const TowerElasto& tower, std::shared_ptr<seahowl::
     // translate RNA center of origin to towertop
     this->translate(towertop_node->get_position() - this->body_yaw_bearing->get_position());
     // link yaw bearing body to towertop
-    link_towertop_yaw_bearing = std::make_shared<LinkChrono>();
+    link_towertop_yaw_bearing = strategy_elasto->make_link();
     system->add(link_towertop_yaw_bearing);
     link_towertop_yaw_bearing->initialize(towertop_node, body_yaw_bearing);
     link_towertop_yaw_bearing->set_constraints(true, true, true, true, true, true);

--- a/src/elasto/tower_elasto.cpp
+++ b/src/elasto/tower_elasto.cpp
@@ -1,6 +1,6 @@
 #include <seahowl/elasto/tower_elasto.h>
-#include <seahowl/core/utils.h>
 #include <seahowl/elasto/chrono_adapters.h>
+#include <seahowl/core/utils.h>
 
 #include <memory>
 #include <vector>
@@ -13,7 +13,11 @@ TowerElasto::TowerElasto() {}
 void TowerElasto::build() {
     // check that enough reference points were defined to create elements (at least 2)
     if (reference_points.size() <= 2) {
-        throw std::runtime_error("Not enough elasto reference points defined for blade.");
+        throw std::runtime_error("Not enough elasto reference points defined for tower.");
+    }
+    // check that a pointer to a strategy was initialized
+    if (!strategy_elasto) {
+        throw std::runtime_error("Must define elasto strategy for tower.");
     }
 
     // check that discretization_fractions was defined, otherwise take reference point fractions
@@ -47,10 +51,10 @@ void TowerElasto::build() {
         std::dynamic_pointer_cast<NodeElastoChrono>(nodes[ii])->set_properties(discretized_points[ii]);
     }
 
-    build_elements_tapered_timoshenko();
+    build_elements();
 };
 
-void TowerElasto::build_elements_tapered_timoshenko() {
+void TowerElasto::build_elements() {
     elements.clear();
     const auto nelements = nodes.size() - 1;
 
@@ -60,7 +64,7 @@ void TowerElasto::build_elements_tapered_timoshenko() {
 
     for (size_t ii = 1; ii < nelements + 1; ii++) {
         // create element
-        auto element = std::make_shared<ElementBladeElastoChrono>();
+        auto element = strategy_elasto->make_element_tower();
         // add element to blade elements vector
         elements.push_back(element);
         // set element nodes

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -7,6 +7,7 @@
 #include <seahowl/elasto/tower_elasto.h>
 #include <seahowl/core/turbine.h>
 #include <seahowl/elasto/blade_elasto.h>
+#include <seahowl/elasto/chrono_strategy.h>
 #include <seahowl/servo/controller_discon.h>
 #include <seahowl/core/system.h>
 #include <seahowl/commons.h>
@@ -334,6 +335,7 @@ seahowl::core::Turbine get_turbine_from_json(std::string filepath_turbine) {
     for (auto& blade_json : blades_json2) {
         auto filepath_blade = (DATADIR / blade_json.at("file").get<std::string>()).generic_string();
         auto blade = std::make_shared<seahowl::core::Blade>(get_blade_from_json(filepath_blade));
+        blade->elasto->strategy_elasto = std::make_shared<seahowl::elasto::StrategyElastoChrono>();
         blades_json.at("discretization").at("elasto").get_to(blade->elasto->discretization_fractions);
         blades_json.at("discretization").at("aero").get_to(blade->aero->discretization_fractions);
         blades_json.at("fpm").get_to(blade->elasto->fpm_mode);
@@ -344,11 +346,13 @@ seahowl::core::Turbine get_turbine_from_json(std::string filepath_turbine) {
     // RNA
     auto filepath_rotor = (DATADIR / rna_json.at("file").get<std::string>()).generic_string();
     auto rotor = get_rotor_from_json(filepath_rotor);
+    rotor.elasto.strategy_elasto = std::make_shared<seahowl::elasto::StrategyElastoChrono>();
     rna_json.at("initial_pitch_collective").get_to(rotor.elasto.pitch_collective);
 
     // tower
     auto filepath_tower = (DATADIR / tower_json.at("file").get<std::string>()).generic_string();
     auto tower = get_tower_from_json(filepath_tower);
+    tower.elasto.strategy_elasto = std::make_shared<seahowl::elasto::StrategyElastoChrono>();
     tower_json.at("discretization").at("elasto").get_to(tower.elasto.discretization_fractions);
     tower_json.at("discretization").at("aero").get_to(tower.aero.discretization_fractions);
 

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -18,6 +18,7 @@
 #include <seahowl/core/turbine.h>
 #include <seahowl/core/system.h>
 #include <seahowl/elasto/chrono_adapters.h>
+#include <seahowl/elasto/chrono_strategy.h>
 #include <seahowl/commons.h>
 
 #include <seahowl/io/read_json.h>
@@ -67,6 +68,7 @@ TEST(test_blade, mass_deflection) {
     system_elasto->add(blades_mesh);
     // blade
     auto blade_core = get_blade_from_json((DATADIR / "blade.json").generic_string());
+    blade_core.elasto->strategy_elasto = std::make_shared<StrategyElastoChrono>();
     // make 50 elements
     blade_core.elasto->discretization_fractions.clear();
     for (int ii = 0; ii < 51; ii++) {
@@ -120,6 +122,7 @@ TEST(test_rotor, mass) {
     }
 
     auto rotor = get_rotor_from_json((DATADIR / "rna.json").generic_string());
+    rotor.elasto.strategy_elasto = std::make_shared<StrategyElastoChrono>();
     rotor.build(blades);
     rotor.assemble(system_elasto);
     rotor.elasto.body_yaw_bearing->set_fixed(true);
@@ -141,6 +144,7 @@ TEST(test_tower, mass) {
     system_elasto->add(tower_mesh);
     // tower
     auto tower = get_tower_from_json((DATADIR / "tower.json").generic_string());
+    tower.elasto.strategy_elasto = std::make_shared<StrategyElastoChrono>();
     tower.build();
     tower.assemble(tower_mesh);
 
@@ -162,6 +166,7 @@ TEST(test_blade, natural_period_dynamic_edge) {
     system_elasto->add(blades_mesh);
     // blade
     auto blade_core = get_blade_from_json((DATADIR / "blade.json").generic_string());
+    blade_core.elasto->strategy_elasto = std::make_shared<StrategyElastoChrono>();
     // make 50 elements
     blade_core.elasto->discretization_fractions.clear();
     for (int ii = 0; ii < 51; ii++) {
@@ -221,6 +226,7 @@ TEST(test_blade, natural_period_dynamic_flap) {
     system_elasto->add(blades_mesh);
     // blade
     auto blade_core = get_blade_from_json((DATADIR / "blade.json").generic_string());
+    blade_core.elasto->strategy_elasto = std::make_shared<StrategyElastoChrono>();
     // make 50 elements
     blade_core.elasto->discretization_fractions.clear();
     for (int ii = 0; ii < 51; ii++) {


### PR DESCRIPTION
This PR is for developing a workflow for selecting different "strategies" (i.e. models, level of fidelities) for the different physical aspects (elasto, aero, etc). The main idea (to be discussed) is to develop abstract factories for each physics aspect (elasto, aero, etc), and concrete factory implementations for the selected strategy (e.g. FEM or model for elasto, in-house BEMT or AeroDyn for aero, etc). Each strategy can be or communicate with an adapter to other codes (e.g. Chrono for elasto, or AeroDyn for aero).

Taking elasto as an example, an abstract factory is used as a builder for elasto entities (nodes, elements, bodies, links). Concrete factory implementations (called "strategy" here) are then used to actually return the relevant types by calling adapters. For elasto, the concrete Chrono strategy can be used for that purpose for example.