### PR TITLE
Fix node to blade tip distances + add tol in rotor

### DIFF
--- a/src/aero/blade_aero.cpp
+++ b/src/aero/blade_aero.cpp
@@ -104,7 +104,7 @@ void BladeAero::build() {
 
 void BladeAero::compute_distances_from_tip() {
     // this is the position of the element at the tip
-    auto& tip_position = discretized_points.back().coordinates;
+    auto tip_position = nodes.back().get_position();
     for (auto& node : nodes) {
         node.distance_from_tip = (node.get_position() - tip_position).norm();
     }

--- a/src/aero/rotor_aero.cpp
+++ b/src/aero/rotor_aero.cpp
@@ -111,7 +111,9 @@ void RotorAero::compute_wind_loads_bemt(WindModel& wind_model,
             double local_velocity_tangent = global_velocity.dot(global_direction_tangent);
             auto local_velocity0 = Vector2d(local_velocity_tangent, local_velocity_normal);
 
-            if (local_velocity0.norm() == 0.0) {
+            double tol = 1e-6;
+            if (local_velocity0.norm() < tol || (node.distance_from_tip < tol && tip_loss) ||
+                (node.distance_from_hub < tol && hub_loss)) {
                 node.load = Vector3d(0.0, 0.0, 0.0);
             } else {
                 // get induced velocity (2D) from blade node


### PR DESCRIPTION
Fixes problem of calculation of blade node distance to blade tip in `BladeAero` and adds tolerance to tip and hub distances in `RotorAero`. This was uncovered during checks for PR [#65](https://github.com/Total-RD/seahowl/pull/65).

Current test suite could not catch that problem (they all pass), but a local test from @wenchaoyu helped uncover the issue, so adding a test that could reveal this kind of bug should probably be introduced.

Note: distance of a blade node from the tip is calculated as the distance from the tip node of the blade (this means that it can be slightly off the rotor disc (prebend/bending taken into account in the distance here). As of now, this is only calculated once at the initialization step of the simulation.