### PR TITLE
Fix BEMT issues + tangential induction

### DIFF
--- a/src/aero/airfoil.cpp
+++ b/src/aero/airfoil.cpp
@@ -2,6 +2,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <iostream>
 
 using seahowl::aero::AirfoilCoefficients;
 using seahowl::aero::AirfoilProperties;
@@ -46,7 +47,7 @@ AirfoilProperties AirfoilProperties::operator+(const AirfoilProperties& other) c
     int idx1 = 0;
     int idx2 = 0;
     new_point.coefficients_list.clear();
-    while (idx1 + idx2 < this->coefficients_list.size() - 1 + other.coefficients_list.size() - 1) {
+    while (idx1 + idx2 < this->coefficients_list.size() + other.coefficients_list.size()) {
         auto& coeffs1 = this->coefficients_list[idx1];
         auto& coeffs2 = other.coefficients_list[idx2];
         if (abs(coeffs1.alpha - coeffs2.alpha) < 1e-6) {
@@ -57,6 +58,11 @@ AirfoilProperties AirfoilProperties::operator+(const AirfoilProperties& other) c
                 } else if (this->coefficients_list[idx1 + 1].alpha < other.coefficients_list[idx2 + 1].alpha) {
                     idx1 += 1;
                 } else {
+                    idx1 += 1;
+                    idx2 += 1;
+                }
+            } else {
+                if (idx1 + 1 >= this->coefficients_list.size() && idx2 + 1 >= other.coefficients_list.size()) {
                     idx1 += 1;
                     idx2 += 1;
                 }

--- a/src/aero/bemt.cpp
+++ b/src/aero/bemt.cpp
@@ -215,11 +215,13 @@ void seahowl::aero::apply_tower_shadow_effect_on_wind(Vector3d& wind_velocity,
         auto tower_length =
             (tower_aero.reference_points.back().coordinates - tower_aero.reference_points.front().coordinates).norm();
         if (coordinates_projected.x() > 0) {
-            std::vector<double> fractions{1.0 - (tower_length - coordinates_projected.x()) / tower_length};
+            std::vector<double> fractions{(tower_length - coordinates_projected.x()) / tower_length};
             auto tower_radius =
                 seahowl::get_discretized_points(fractions, tower_aero.reference_points)[0].diameter / 2.0;
+            // front distance of point from tower
             auto xx = coordinates_projected.z();
             auto xx2 = pow(xx, 2);
+            // side distance from tower of point
             auto yy = coordinates_projected.y();
             auto yy2 = pow(yy, 2);
             wind_velocity_tower =

--- a/src/aero/bemt.cpp
+++ b/src/aero/bemt.cpp
@@ -58,9 +58,16 @@ Vector2d seahowl::aero::get_induced_velocity(seahowl::aero::BladeNodeAero& node,
     auto ap = node.induction_factor_tangential;
     // limits
     double aa_max = 1.0;
-    double aa_min = -1.0;
+    double aa_min = 0.0;
     double ap_max = 1.5;
     double ap_min = -1.0;
+    // reset induction factors if they were max or min
+    if (aa >= aa_max || aa <= aa_min) {
+        aa = 0.0;
+    }
+    if (ap >= ap_max || ap <= ap_min) {
+        ap = 0.0;
+    }
     for (int ii = 1; ii <= max_iter; ii++) {
         // store previous alpha
         alpha_previous = alpha;
@@ -85,14 +92,18 @@ Vector2d seahowl::aero::get_induced_velocity(seahowl::aero::BladeNodeAero& node,
         double cn = cl * cos_phi + cd * sin_phi;
         double ct = cl * sin_phi - cd * cos_phi;
 
+        double tol_induction = 1e-6;  // tolerance for induction variables to avoid singularities
+
         // losses
         double loss_factor = 1.0;
-        if (tip_loss) {
+        // tip loss (with check that no division by zero will happen => y component of velocity > 0)
+        if (tip_loss && fabs(sin_phi) > tol_induction) {
             // Prandtl's approximation for tip-loss factor=
             loss_factor *=
                 (2.0 / PI) * acos(exp(nblades * (-node.distance_from_tip) / (2.0 * node.radius * fabs(sin_phi))));
         }
-        if (hub_loss) {
+        // hub loss (with check that no division by zero will happen => y component of velocity > 0)
+        if (hub_loss && fabs(sin_phi) > tol_induction) {
             // hub loss
             double hub_radius = (node.radius - node.distance_from_hub);
             loss_factor *=
@@ -101,30 +112,35 @@ Vector2d seahowl::aero::get_induced_velocity(seahowl::aero::BladeNodeAero& node,
 
         // update induction factors
 
-        double tol_induction = 1e-6;  // tolerance for induction variables to avoid singularities
-        // axial induction, based on AeroDyn v15 implementation
-        double kk = node.chord_solidity * cn / (4.0 * loss_factor * pow(sin_phi, 2));
-        if (kk <= 2.0 / 3.0) {
-            if (fabs(kk + 1.0) < tol_induction) {
-                aa = copysign(aa_max, -(1.0 + kk));
+        // axial induction, based on and adapted from AeroDyn v15 implementation
+        // first check if no division by zero (y component of velocity > 0)
+        if (fabs(sin_phi) > tol_induction) {
+            double kk = node.chord_solidity * cn / (4.0 * loss_factor * pow(sin_phi, 2));
+            if (kk <= 2.0 / 3.0) {
+                if (fabs(kk + 1.0) < tol_induction) {
+                    aa = copysign(aa_max, -(1.0 + kk));
+                } else {
+                    aa = kk / (1.0 + kk);
+                }
+                if (kk < -1.0) {
+                    // equivalent to aa > 1.0, not possible here => cap it
+                    aa = aa_max;
+                }
             } else {
-                aa = kk / (1.0 + kk);
-            }
-            if (kk < -1.0) {
-                throw std::runtime_error("Not valid BEMT solution for axial induction.");
+                double ff = loss_factor;
+                double temp = 2.0 * ff * kk;
+                double g1 = temp - (10.0 / 9.0 - ff);
+                double g2 = temp - (4.0 / 3.0 - ff) * ff;
+                double g3 = temp - (25.0 / 9.0 - 2.0 * ff);
+
+                if (fabs(g3) < tol_induction) {
+                    aa = 1.0 - 0.5 / sqrt(g2);
+                } else {
+                    aa = (g1 - sqrt(fabs(g2))) / g3;
+                }
             }
         } else {
-            double ff = loss_factor;
-            double temp = 2.0 * ff * kk;
-            double g1 = temp - (10.0 / 9.0 - ff);
-            double g2 = temp - (4.0 / 3.0 - ff) * ff;
-            double g3 = temp - (25.0 / 9.0 - 2.0 * ff);
-
-            if (fabs(g3) < tol_induction) {
-                aa = 1.0 - 0.5 / sqrt(g2);
-            } else {
-                aa = (g1 - sqrt(fabs(g2))) / g3;
-            }
+            aa = aa_max;
         }
 
         // @todo fix tangential induction factor calculation (convergence)

--- a/src/aero/bemt.cpp
+++ b/src/aero/bemt.cpp
@@ -59,7 +59,7 @@ Vector2d seahowl::aero::get_induced_velocity(seahowl::aero::BladeNodeAero& node,
     // limits
     double aa_max = 1.0;
     double aa_min = 0.0;
-    double ap_max = 1.5;
+    double ap_max = 1.0;
     double ap_min = -1.0;
     // reset induction factors if they were max or min
     if (aa >= aa_max || aa <= aa_min) {
@@ -143,22 +143,22 @@ Vector2d seahowl::aero::get_induced_velocity(seahowl::aero::BladeNodeAero& node,
             aa = aa_max;
         }
 
-        // @todo fix tangential induction factor calculation (convergence)
         //// tangential induction
-        // if (fabs(cos_phi) < tol_induction) {
-        //     ap = -1.0;
-        // } else {
-        //     double kp = element.chord_solidity * ct / (4.0 * loss_factor * sin_phi * cos_phi);
-        //     if (local_velocity_rotor.y() < 0.0) {
-        //         kp = -kp;
-        //     }
-        //     if (fabs(kp - 1.0) < tol_induction) {
-        //         ap = copysign(ap_max, 1.0 - kp);
-        //     } else {
-        //         ap = kp / (1.0 - kp);
-        //     }
-        // }
-        ap = 0.0;  // deactivate tangential induction
+        if (fabs(cos_phi) < tol_induction) {
+            ap = ap_min;
+        } else if (fabs(sin_phi) < tol_induction) {
+            ap = ap_max;
+        } else {
+            double kp = node.chord_solidity * ct / (4.0 * loss_factor * sin_phi * cos_phi);
+            if (local_velocity_rotor.y() < 0.0) {
+                kp = -kp;
+            }
+            if (fabs(kp - 1.0) < tol_induction) {
+                ap = copysign(ap_max, 1.0 - kp);
+            } else {
+                ap = kp / (1.0 - kp);
+            }
+        }
 
         // apply limits on induction factors
         if (aa > aa_max) {

--- a/src/core/rotor.cpp
+++ b/src/core/rotor.cpp
@@ -33,7 +33,6 @@ void Rotor::poststep(double time, double dt) {
         blade->poststep(time, dt);
     }
     update_positions_aero();
-    aero.compute_chords_solidity();
 }
 
 void Rotor::update_positions_aero() {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -485,11 +485,21 @@ double SystemElastoChrono::get_time() const {
 }
 
 void SystemElastoChrono::do_statics(bool linear, int nonlinear_steps) {
+    // constrain rotor
+    for (auto& turbine : turbines) {
+        turbine.rotor.link_shaft_hub->set_constraints(true, true, true, true, true, true);
+    }
+    // linear statics
     if (linear) {
         chobj->DoStaticLinear();
     }
+    // nonlinear statics
     if (nonlinear_steps > 0) {
         chobj->DoStaticNonlinear(nonlinear_steps, true);
+    }
+    // unconstrain rotor
+    for (auto& turbine : turbines) {
+        turbine.rotor.link_shaft_hub->set_constraints(true, true, true, false, true, true);
     }
 };
 

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -197,11 +197,11 @@ double RotorElasto::get_rpm() const {
 double RotorElasto::get_azimuth() const {
     // get angle between quaternions
     auto qq = (body_shaft->get_rotation().conjugate() * body_hub->get_rotation()).normalized();
-    double angle0 = std::atan2(qq.vec().x(), qq.w());
+    double angle0 = 2 * std::atan2(qq.vec().x(), qq.w());
     // get angle between 0 and 2pi
     double angle1 = fmod(angle0, 2 * PI);
-    // get angle between -pi and +pi
-    double angle2 = fmod(angle1 + PI, 2 * PI) - PI;
+    // get strictly positive angle
+    double angle2 = fmod(angle1 + 2 * PI, 2 * PI);
     return angle2;
 }
 

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -297,7 +297,9 @@ TEST(test_turbine, rpm_initial_pitch) {
 
     // statics
     if (statics_prestep) {
+        turbine.rotor.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
         system_elasto.do_statics(true, 10);
+        turbine.rotor.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
     }
 
     double time = 0.0;
@@ -318,7 +320,7 @@ TEST(test_turbine, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rotor.elasto.get_rpm(), 2.809, 0.02);
+    ASSERT_NEAR(turbine.rotor.elasto.get_rpm(), 2.829, 0.02);
 }
 
 #ifdef HAVE_AERODYN
@@ -362,7 +364,9 @@ TEST(test_aerodyn, rpm_initial_pitch) {
 
     // statics
     if (statics_prestep) {
+        turbine.rotor.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
         system_elasto.do_statics(true, 10);
+        turbine.rotor.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
     }
 
     double time = 0.0;
@@ -458,7 +462,7 @@ TEST(test_turbine, multiturbines) {
     }
 
     for (auto& turbine : system_core.turbines) {
-        ASSERT_NEAR(turbine.rotor.elasto.get_rpm(), 2.809, 0.02);
+        ASSERT_NEAR(turbine.rotor.elasto.get_rpm(), 2.829, 0.02);
     }
 }
 
@@ -503,7 +507,9 @@ TEST(test_inflowwind, rpm_initial_pitch) {
 
     // statics
     if (statics_prestep) {
+        turbine.rotor.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
         system_elasto.do_statics(true, 10);
+        turbine.rotor.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
     }
 
     double time = 0.0;
@@ -524,6 +530,6 @@ TEST(test_inflowwind, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rotor.elasto.get_rpm(), 2.809, 0.02);
+    ASSERT_NEAR(turbine.rotor.elasto.get_rpm(), 2.829, 0.02);
 }
 #endif


### PR DESCRIPTION
This PR changes the following mainly for the BEMT:
- fix for airfoil interpolation (last coefficients in list were not included previously)
- axial induction lower bound at 0.0 (was -1.0 previously)
- tangential induction reactivated (resolves #67)
- tangential induction upper bound at 1.0 (was 1.5 previously)
- several checks for avoiding divisions by zero
- fix tower shadow diameter lookup (inverse fraction)

Other changes:
- rotor only calculates chord solidity at initialization (was at each time step previously)
- constrain rotor in statics step
- fix rotor azimuth calculation (used in tower shadow calculation)