### PR TITLE
Create adapter for MoorDyn v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ option(SEAHOWL_ENABLE_VTK "Enable VTK Library for output" OFF)
 option(SEAHOWL_ENABLE_AERODYN "Enable AeroDyn module" OFF)
 option(SEAHOWL_ENABLE_INFLOWWIND "Enable InflowWind module" OFF)
 option(SEAHOWL_ENABLE_HYDROCHRONO "Enable HydroChrono library" OFF)
+option(SEAHOWL_ENABLE_MOORDYN "Enable MoorDyn module" OFF)
 
 # =======================
 # External libraries
@@ -80,6 +81,13 @@ if(SEAHOWL_ENABLE_INFLOWWIND)
     add_compile_definitions(SEAHOWL_HAVE_INFLOWWIND=1)
     add_definitions("-DHAVE_INFLOWWIND=1")
 endif(SEAHOWL_ENABLE_INFLOWWIND)
+
+# MoorDyn module
+if(SEAHOWL_ENABLE_MOORDYN)
+    find_package(MoorDyn REQUIRED)
+    add_compile_definitions(SEAHOWL_HAVE_MOORDYN=1)
+    add_definitions("-DHAVE_MOORDYN=1")
+endif(SEAHOWL_ENABLE_MOORDYN)
 
 if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
 	message(FATAL_ERROR "ONLY 64 BITS SUPPORTED")
@@ -205,6 +213,10 @@ set(SEAHOWL_ELASTO_HEADERS
     include/seahowl/elasto/turbine_floating_elasto.h
     include/seahowl/elasto/chrono_adapters.h
 )
+if (SEAHOWL_ENABLE_MOORDYN)
+    list(APPEND SEAHOWL_ELASTO_SOURCES src/elasto/moordyn_adapter.cpp)
+    list(APPEND SEAHOWL_ELASTO_HEADERS include/seahowl/elasto/moordyn_adapter.h)
+endif(SEAHOWL_ENABLE_MOORDYN)
 source_group(elasto FILES ${SEAHOWL_ELASTO_SOURCES} ${SEAHOWL_ELASTO_HEADERS})
 
 # aero
@@ -308,7 +320,7 @@ set_target_properties(
 target_include_directories(
     seahowl_core
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ ${CMAKE_CURRENT_SOURCE_DIR}/include ${CHRONO_INCLUDE_DIRS}
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ ${CMAKE_CURRENT_SOURCE_DIR}/include ${CHRONO_INCLUDE_DIRS} ${MoorDyn_DIR}/../../include/moordyn
 )
 
 target_compile_features(
@@ -352,6 +364,9 @@ if (SEAHOWL_ENABLE_INFLOWWIND)
     target_link_libraries(seahowl_core PRIVATE INFLOWWIND::INFLOWWIND)
 endif (SEAHOWL_ENABLE_INFLOWWIND)
 
+if (SEAHOWL_ENABLE_MOORDYN)
+    target_link_libraries(seahowl_core PRIVATE MoorDyn::moordyn)
+endif (SEAHOWL_ENABLE_MOORDYN)
 
 # =============
 # DRIVER
@@ -365,7 +380,7 @@ target_sources(
 target_include_directories(
     seahowl_driver
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ ${CMAKE_CURRENT_SOURCE_DIR}/include ${CHRONO_INCLUDE_DIRS}
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ ${CMAKE_CURRENT_SOURCE_DIR}/include ${CHRONO_INCLUDE_DIRS} ${MoorDyn_DIR}/../../include/moordyn
 )
 
 target_compile_features(seahowl_driver PRIVATE cxx_std_17)

--- a/data/IEA15MW/main.json
+++ b/data/IEA15MW/main.json
@@ -32,7 +32,9 @@
       "rotation": 0,
       "file": "./turbine.json",
       "use_aerodyn": false,
-      "file_aerodyn": "./aerodyn/IEA-15-240-RWT_AeroDyn15.dat"
+      "file_aerodyn": "./aerodyn/IEA-15-240-RWT_AeroDyn15.dat",
+      "use_moordyn": false,
+      "file_moordyn": "./moordyn/lines.txt"
     }
   ]
 }

--- a/data/IEA15MW/moordyn/lines.txt
+++ b/data/IEA15MW/moordyn/lines.txt
@@ -1,0 +1,33 @@
+--------------------- MoorDyn Input File ------------------------------------
+MoorDyn input file of the mooring system for OC3-Hywind
+----------------------- LINE TYPES ------------------------------------------
+TypeName   Diam    Mass/m     EA         BA/-zeta    EI         Cd     Ca     CdAx    CaAx
+(name)     (m)     (kg/m)     (N)        (N-s/-)     (N-m^2)    (-)    (-)    (-)     (-)
+main       0.09    77.7066    384.243E6  -0.8        0          1.6    1.0    0.1     0.0
+---------------------- CONNECTION PROPERTIES --------------------------------
+ID    Type      X       Y       Z       Mass   Volume  CdA    Ca
+(#)   (-)       (m)     (m)     (m)     (kg)   (mˆ3)   (m^2)  (-)
+1     Fixed     320.0  0       -320.0  0      0       0      0
+2     Fixed    -160.0  277.13  -320.0  0      0       0      0
+3     Fixed    -160.0 -277.13  -320.0  0      0       0      0
+4     Vessel    0.0    0.0      0.0    0      0       0      0
+5     Vessel    0.0    0.0      0.0    0      0       0      0
+6     Vessel    0.0    0.0      0.0    0      0       0      0
+---------------------- LINES ----------------------------------------
+ID   LineType   AttachA  AttachB  UnstrLen  NumSegs  LineOutputs
+(#)   (name)     (#)      (#)       (m)       (-)     (-)
+1     main       1        4         500.0     20      -
+2     main       2        5         500.0     20      -
+3     main       3        6         500.0     20      -
+---------------------- OPTIONS -----------------------------------------
+2             writeLog      Write a log file
+0.002         dtM           time step to use in mooring integration (s)
+3.0e6         kBot          bottom stiffness (Pa/m)
+3.0e5         cBot          bottom damping (Pa-s/m)
+1025.0        WtrDnsty      water density (kg/m^3)
+320           WtrDpth       water depth (m)
+1.0           dtIC          time interval for analyzing convergence during IC gen (s)
+100.0         TmaxIC        max time for ic gen (s)
+4.0           CdScaleIC     factor by which to scale drag coefficients during dynamic relaxation (-)
+0.001         threshIC      threshold for IC convergence (-)
+------------------------- need this line --------------------------------------

--- a/include/seahowl/elasto/moordyn_adapter.h
+++ b/include/seahowl/elasto/moordyn_adapter.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <seahowl/commons/numerics.h>
+
+#include <MoorDyn2.h>
+
+namespace seahowl {
+namespace elasto {
+class TurbineElasto;
+}  // namespace elasto
+}  // namespace seahowl
+
+namespace seahowl {
+namespace elasto {
+
+class MoorDynAdapter {
+  public:
+    Eigen::VectorXd fairlead_position;
+    Eigen::VectorXd fairlead_velocity;
+    Eigen::VectorXd fairlead_load;
+
+    MoorDynAdapter(std::string MoordynInfile);
+    ~MoorDynAdapter();
+
+    void initialize(seahowl::elasto::TurbineElasto& turbine);  // to be changed to floater entity
+    void step(double time, double dt, seahowl::elasto::TurbineElasto& turbine);
+    void end();
+    void saveVTK(std::string filename);
+
+  private:
+    MoorDyn moordynobj;
+    int ErrStat = MOORDYN_SUCCESS;
+};
+
+}  // namespace elasto
+}  // namespace seahowl

--- a/include/seahowl/elasto/turbine_elasto.h
+++ b/include/seahowl/elasto/turbine_elasto.h
@@ -8,6 +8,9 @@
 namespace seahowl {
 namespace elasto {
 class SystemElasto;
+#ifdef HAVE_MOORDYN
+class MoorDynAdapter;
+#endif
 }  // namespace elasto
 }  // namespace seahowl
 
@@ -30,6 +33,13 @@ class TurbineElasto : public ComponentElasto {
     seahowl::elasto::RotorNacelleAssemblyElasto rna;
     /** @brief Tower of the turbine. */
     seahowl::elasto::TowerElasto tower;
+
+    /** @brief Whether to use MoorDyn or not. */
+    bool use_moordyn = false;
+#ifdef HAVE_MOORDYN
+    /** @brief MoorDyn adapter (only used if MoorDyn is enabled). */
+    std::shared_ptr<seahowl::elasto::MoorDynAdapter> moordyn;
+#endif
 
     /**
      * @brief Constructor.
@@ -82,6 +92,14 @@ class TurbineElasto : public ComponentElasto {
      * @brief Returns the mass of the turbine.
      */
     virtual double get_mass() const override;
+
+    /**
+     * @brief Initializes moordyn.
+     *
+     * @param[in] time Time of the simulation (usually 0 at init).
+     * @param[in] dt Time step length.
+     */
+    void initialize(double time, double dt);
 };
 
 }  // namespace elasto

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -23,6 +23,7 @@ void Turbine::initialize(double time, double dt) {
     controller->initialize(time, dt, *this);
 
     aero.initialize(time, dt);
+    elasto.initialize(time, dt);
 
     spdlog::info("Initialized turbine of total mass {:.4}kg.", elasto.get_mass());
 }

--- a/src/elasto/moordyn_adapter.cpp
+++ b/src/elasto/moordyn_adapter.cpp
@@ -1,0 +1,74 @@
+#include "seahowl/elasto/moordyn_adapter.h"
+#include <seahowl/elasto/turbine_elasto.h>
+#include <iostream>
+
+seahowl::elasto::MoorDynAdapter::MoorDynAdapter(std::string MoordynInfile) {
+    std::cout << "Using MoorDyn in SEAHOWL" << std::endl;
+    const char* infile = MoordynInfile.c_str();
+    moordynobj = MoorDyn_Create(infile);
+}
+
+seahowl::elasto::MoorDynAdapter::~MoorDynAdapter() {}
+
+void seahowl::elasto::MoorDynAdapter::initialize(seahowl::elasto::TurbineElasto& turbine) {
+    unsigned int nMooringLine;
+    ErrStat = MoorDyn_GetNumberLines(moordynobj, &nMooringLine);
+    if (ErrStat != MOORDYN_SUCCESS) {
+        throw std::runtime_error("Failed to get the number of lines.");
+    }
+
+    unsigned int nCoupledDof;
+    ErrStat = MoorDyn_NCoupledDOF(moordynobj, &nCoupledDof);
+    if (ErrStat != MOORDYN_SUCCESS) {
+        throw std::runtime_error("Failed to get the number of coupled DOF.");
+    }
+
+    fairlead_position = Eigen::VectorXd::Zero(nCoupledDof);
+    fairlead_velocity = Eigen::VectorXd::Zero(nCoupledDof);
+    fairlead_load = Eigen::VectorXd::Zero(nCoupledDof);
+
+    auto nMeshTower = turbine.tower.nodes.size();
+    auto position = turbine.tower.nodes[0]->get_position();
+    auto velocity = turbine.tower.nodes[0]->get_velocity();
+    fairlead_position << position, position, position;
+    fairlead_velocity << velocity, velocity, velocity;
+    MoorDyn_Init(moordynobj, &fairlead_position[0], &fairlead_velocity[0]);
+}
+
+void seahowl::elasto::MoorDynAdapter::step(double time, double dt, seahowl::elasto::TurbineElasto& turbine) {
+    auto nMeshTower = turbine.tower.nodes.size();
+    auto position = turbine.tower.nodes[0]->get_position();
+    auto velocity = turbine.tower.nodes[0]->get_velocity();
+    fairlead_position << position, position, position;
+    fairlead_velocity << velocity, velocity, velocity;
+
+    ErrStat = MoorDyn_Step(moordynobj, &fairlead_position[0], &fairlead_velocity[0], &fairlead_load[0], &time, &dt);
+    if (ErrStat != MOORDYN_SUCCESS) {
+        throw std::runtime_error("Failed to compute the loads on the mooring lines.");
+    }
+}
+
+// void seahowl::elasto::MoorDynAdapter::step(double time, double dt, seahowl::EntityDynamic& entity) {
+
+//     auto position = entity.get_position();
+//     auto velocity = entity.get_velocity();
+//     fairlead_position << position,position,position;
+//     fairlead_velocity << velocity,velocity,velocity;
+
+//     ErrStat = MoorDyn_Step(moordynobj,&fairlead_position[0],&fairlead_velocity[0],&fairlead_load[0],&time,&dt);
+//     if (ErrStat != MOORDYN_SUCCESS) {
+//         throw std::runtime_error("Failed to compute the loads on the mooring lines.");
+//     }
+// }
+
+void seahowl::elasto::MoorDynAdapter::end() {
+    ErrStat = MoorDyn_Close(moordynobj);
+    if (ErrStat != MOORDYN_SUCCESS) {
+        throw std::runtime_error("Failed to release MoorDyn allocated resources.");
+    }
+}
+
+void seahowl::elasto::MoorDynAdapter::saveVTK(std::string filename) {
+    const char* infile = filename.c_str();
+    MoorDyn_SaveVTK(moordynobj, infile);
+}

--- a/src/elasto/turbine_elasto.cpp
+++ b/src/elasto/turbine_elasto.cpp
@@ -3,6 +3,10 @@
 #include "seahowl/elasto/system_elasto.h"
 #include "seahowl/elasto/chrono_adapters.h"
 
+#ifdef HAVE_MOORDYN
+    #include "seahowl/elasto/moordyn_adapter.h"
+#endif
+
 using namespace seahowl::elasto;
 
 TurbineElasto::TurbineElasto() {
@@ -51,4 +55,14 @@ double TurbineElasto::get_mass() const {
     // tower
     total_mass += tower.get_mass();
     return total_mass;
+}
+
+void TurbineElasto::initialize(double time, double dt) {
+#ifdef HAVE_MOORDYN
+    if (use_moordyn) {
+        moordyn->initialize(*this);
+        moordyn->saveVTK("./output/mooring_lines");  // test vtk save here, will be relocated in order to be
+                                                     // consistent with seahowl vtk save
+    }
+#endif
 }

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -25,6 +25,9 @@
     #include "seahowl/hydro/hydrochrono_adapter.h"
     #include "seahowl/elasto/chrono_adapters.h"
 #endif
+#ifdef HAVE_MOORDYN
+    #include <seahowl/elasto/moordyn_adapter.h>
+#endif
 
 #include <string>
 #include <memory>
@@ -663,6 +666,20 @@ void populate_system_from_json(std::string filepath, seahowl::core::System& syst
             }
             turbine.aero.aerodyn =
                 std::make_shared<seahowl::aero::AeroDynAdapter>(aerodyn_filepath, inflowwind_filepath);
+        }
+#endif
+
+        // moordyn option
+#ifdef HAVE_MOORDYN
+        turbine.elasto.use_moordyn = turbine_json.at("use_moordyn").get<bool>();
+        if (turbine.elasto.use_moordyn) {
+            std::string moordyn_filepath;
+            if (turbine_json.contains("file_moordyn")) {
+                moordyn_filepath = (DATADIR / turbine_json.at("file_moordyn")).generic_string();
+            } else {
+                throw std::runtime_error("Turbine set to use moordyn but MoorDyn file path not defined.");
+            }
+            turbine.elasto.moordyn = std::make_shared<seahowl::elasto::MoorDynAdapter>(moordyn_filepath);
         }
 #endif
 


### PR DESCRIPTION
This PR is NOT ready for merging (see list below).

**Feature description**
This adapter can allow `seahowl` to couple with `MoorDyn` module

**Task list to complete**
- [ ] create `MoorDyn` adaptor in `Seahowl`
- [ ] clean the implementation (mooring vtk files and log files)
- [ ] update README
- [ ] create test case

**Additional supporting information**
Latest main version of [MoorDyn v2](https://github.com/FloatingArrayDesign/MoorDyn/tree/v2) is needed.

**Related issue, if one exists**
None

**Optional updates that might be nice someday**
- [ ] create general input file in json for mooring lines
- [ ] set up a multi-turbines case with shared mooring lines