### PR TITLE
Overhaul of moorings with Chrono

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -62,6 +62,11 @@ target_include_directories(ex_mooring
 	${CHRONO_INCLUDE_DIRS}
 )
 
+target_compile_features(ex_mooring
+    PRIVATE
+    cxx_std_17
+)
+
 target_link_libraries(ex_mooring
     PRIVATE
 	seahowl_core

--- a/examples/ex_mooring.cpp
+++ b/examples/ex_mooring.cpp
@@ -11,6 +11,14 @@
 #include <chrono/fea/ChElementCableANCF.h>
 #include <chrono/fea/ChLinkPointFrame.h>
 
+#include <filesystem>  // C++17
+
+using std::filesystem::create_directory;
+
+#ifdef HAVE_VTK
+    #include <seahowl/io/write_vtk.h>
+#endif
+
 #ifdef HAVE_IRRLICHT
     #include <chrono_irrlicht/ChVisualSystemIrrlicht.h>
     #include <seahowl/io/viz_insitu.h>
@@ -19,6 +27,27 @@
 using namespace seahowl;
 using namespace seahowl::elasto;
 using namespace chrono;
+
+void seabed_interaction(seahowl::elasto::SystemElasto& system, seahowl::elasto::MooringElasto& mooring) {
+    auto seabed_depth = 0.0;
+    auto seabed_stiffness = 1e6;
+    Vector3d gravity_direction =
+        system.get_gravitational_acceleration() / system.get_gravitational_acceleration().norm();
+    auto seabed_position = (-gravity_direction) * seabed_depth;
+    for (auto& element : mooring.elements) {
+        auto element_length = dynamic_cast<seahowl::elasto::ElementMooringElasto&>(*element).get_rest_length();
+        for (auto& node : element->nodes) {
+            auto node_position = node->get_position();
+            Vector3d node_z_vector = node_position.cwiseProduct(-gravity_direction);
+            double penetration_depth = (node_z_vector - seabed_position).dot(-gravity_direction);
+            if (penetration_depth < 0) {
+                auto load_up = gravity_direction * seabed_stiffness * penetration_depth * mooring.diameter;
+                auto load_half_element = load_up * 0.5 * element_length;
+                node->set_force(node->get_force() + load_up);
+            }
+        }
+    }
+}
 
 void setup_cables(seahowl::elasto::SystemElasto& system,
                   seahowl::elasto::MooringElasto& mooring,
@@ -49,6 +78,8 @@ void setup_cables(seahowl::elasto::SystemElasto& system,
             auto& element = dynamic_cast<seahowl::elasto::ElementMooringElasto&>(*mooring.elements[idx_el]);
             element.set_rest_length(lengths_initial[idx_el] + lengths_delta[idx_el] * step);
         }
+        mooring.compute_hydro_loads();
+        seabed_interaction(system, mooring);
         system.step(dt);
     }
 }
@@ -75,13 +106,17 @@ int main(int argc, char* argv[]) {
 
     // mooring line
     auto mooring = seahowl::elasto::MooringElasto();
-    mooring.fairlead_position = Vector3d(0.0, 200.0, 200.0);
+    mooring.fairlead_position = Vector3d(0.0, 837.60 - 40.868, 200.0 - 14.0);
     mooring.anchor_position = Vector3d(0.0, 0.0, 0.0);
-    mooring.length = 350.0;
+    mooring.length = 835.5;
     mooring.diameter = 0.13376;
     mooring.stiffness_axial = 753.6e6;
     mooring.density = 116.6 / (PI * pow(mooring.diameter, 2) / 4.0);
-    mooring.discretization_fractions = {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+    mooring.discretization_fractions = {};
+    int nelements = 40;
+    for (int ii = 0; ii < nelements + 1; ii++) {
+        mooring.discretization_fractions.push_back(1.0 / nelements * ii);
+    }
     //
     mooring.build();
     mooring.assemble(system_elasto);
@@ -140,6 +175,16 @@ int main(int argc, char* argv[]) {
     double time = 0;
     double step = 0;
 
+#ifdef HAVE_VTK
+    auto output_vtk = false;
+    std::vector<OutputMeshVTK> vtk_outputs;
+    if (output_vtk) {
+        create_directory("./output");
+        auto& post_mooring = vtk_outputs.emplace_back(mooring);
+        post_mooring.initialize("./output/mooring");
+    }
+#endif
+
 #ifdef HAVE_IRRLICHT
     auto application = chrono_types::make_shared<chrono::irrlicht::ChVisualSystemIrrlicht>();
     application->SetWindowTitle("SEAHOWL");
@@ -153,14 +198,22 @@ int main(int argc, char* argv[]) {
     // system_chrono->DoStaticRelaxing();
     // system_chrono->DoStaticLinear();
     mooring.drag_coefficient = 0;
-    setup_cables(system_elasto, mooring, 0.01, 1000);
+    setup_cables(system_elasto, mooring, dt, 1000);
     mooring.drag_coefficient = 0.5;
     while (true) {
         time += system_chrono->GetStep();
         mooring.compute_hydro_loads();
+        seabed_interaction(system_elasto, mooring);
         system_chrono->DoStepDynamics(dt);
         step += 1;
         std::cout << "time: " << time << std::endl;
+#ifdef HAVE_VTK
+        if (output_vtk) {
+            for (auto const& vtk_output : vtk_outputs) {
+                vtk_output.write(system_elasto.get_time(), step);
+            }
+        }
+#endif
 #ifdef HAVE_IRRLICHT
         application->GetDevice()->run();
         draw_system(system_chrono, application);

--- a/examples/ex_mooring.cpp
+++ b/examples/ex_mooring.cpp
@@ -22,6 +22,7 @@ using namespace seahowl::elasto;
 void seabed_interaction(seahowl::elasto::SystemElasto& system, seahowl::elasto::MooringElasto& mooring) {
     auto seabed_depth = 0.0;
     auto seabed_stiffness = 1e6;
+    auto seabed_stiffness_shear = 0;
     Vector3d gravity_direction =
         system.get_gravitational_acceleration() / system.get_gravitational_acceleration().norm();
     auto seabed_position = (-gravity_direction) * seabed_depth;
@@ -32,27 +33,35 @@ void seabed_interaction(seahowl::elasto::SystemElasto& system, seahowl::elasto::
             // assuming a flat seabed normal to gravitational acceleration direction
             auto seabed_normal = -gravity_direction;
 
-            // stiffness force
             auto node_position = node->get_position();
             Vector3d node_z_vector = node_position.cwiseProduct(seabed_normal);
-            double penetration_depth = (node_z_vector - seabed_position).dot(seabed_normal);
-            if (penetration_depth <= 0) {
-                auto load_stiffness_linear =
-                    gravity_direction * seabed_stiffness * penetration_depth * mooring.diameter;
+            double penetration_depth = (seabed_position - node_z_vector).dot(seabed_normal);
+            if (penetration_depth >= 0) {
+                // stiffness force
+                auto load_stiffness_linear = seabed_stiffness * penetration_depth * mooring.diameter * seabed_normal;
                 // apply on node for half an element length
                 node->set_force(node->get_force() + 0.5 * element_length * (load_stiffness_linear));
-            }
 
-            // damping force
-            auto node_velocity = node->get_velocity();
-            double penetration_velocity = (node_velocity).dot(-seabed_normal);
-            if (penetration_depth <= 0 && penetration_velocity > 0) {
+                // damping force
                 auto lambda = 0.5;  // fraction of critical damping
-                auto load_damping =
-                    2.0 * lambda *
-                    std::sqrt(seabed_stiffness * element_mass * mooring.diameter * (0.5 * element_length)) *
-                    penetration_velocity * seabed_normal;
-                node->set_force(node->get_force() + load_damping);
+                auto node_velocity = node->get_velocity();
+                double penetration_velocity = (node_velocity).dot(-seabed_normal);
+                if (penetration_depth >= 0 && penetration_velocity > 0) {
+                    auto load_damping_normal =
+                        2.0 * lambda *
+                        std::sqrt(seabed_stiffness * element_mass * mooring.diameter * (0.5 * element_length)) *
+                        penetration_velocity * seabed_normal;
+                    node->set_force(node->get_force() + load_damping_normal);
+                }
+
+                Vector3d tangential_velocity = node_velocity + penetration_velocity * seabed_normal;
+                if (penetration_depth >= 0 && tangential_velocity.norm() > 0) {
+                    auto load_damping_tangential =
+                        -2.0 * lambda *
+                        std::sqrt(seabed_stiffness_shear * element_mass * mooring.diameter * (0.5 * element_length)) *
+                        tangential_velocity;
+                    node->set_force(node->get_force() + load_damping_tangential);
+                }
             }
         }
     }

--- a/examples/ex_mooring.cpp
+++ b/examples/ex_mooring.cpp
@@ -89,9 +89,14 @@ int main(int argc, char* argv[]) {
     mooring.fairlead_position = Vector3d(0.0, 837.60 - 58, 200.0 - 14.0);
     mooring.anchor_position = Vector3d(0.0, 0.0, 0.0);
     mooring.length = 850.0;
-    mooring.diameter = 0.33;
+    mooring.diameter = 0.185;
     mooring.stiffness_axial = 3270e6;
     mooring.density_linear = 685.0;
+    mooring.drag_coefficient_normal = 2.0;
+    mooring.drag_coefficient_tangential = 1.15;
+    mooring.added_mass_coefficient_normal = 1.0;
+    mooring.added_mass_coefficient_tangential = 1.0;
+    mooring.diameter = 0.33;
     mooring.discretization_fractions = {};
     int nelements = 40;
     for (int ii = 0; ii < nelements + 1; ii++) {
@@ -149,9 +154,7 @@ int main(int argc, char* argv[]) {
     draw_system_init(system_elasto.chobj, application);
 #endif
 
-    mooring.drag_coefficient = 0;
     setup_cables(system_elasto, mooring, dt, 1000, fluid_density);
-    mooring.drag_coefficient = 0.5;
     while (true) {
         time += system_elasto.get_time();
         mooring.compute_hydro_loads(system_elasto.get_gravitational_acceleration(), fluid_density);

--- a/examples/ex_mooring.cpp
+++ b/examples/ex_mooring.cpp
@@ -121,6 +121,11 @@ int main(int argc, char* argv[]) {
     mooring.build();
     mooring.assemble(system_elasto);
 
+    // set bending stiffness to zero
+    for (auto& element : mooring.elements) {
+        dynamic_cast<ElementMooringElastoChrono&>(*element).set_bending_inertia(0);
+    }
+
     // make fairlead
     auto fairlead = chrono_types::make_shared<ChBody>();
     fairlead->SetBodyFixed(true);

--- a/examples/ex_mooring.cpp
+++ b/examples/ex_mooring.cpp
@@ -2,16 +2,8 @@
 #include <seahowl/elasto/chrono_adapters.h>
 #include <seahowl/commons/numerics.h>
 
-#include <chrono/physics/ChSystemSMC.h>
-#include <chrono/solver/ChDirectSolverLS.h>
-#include <chrono/physics/ChLinkMate.h>
-#include <chrono/fea/ChNodeFEAxyzrot.h>
-#include <chrono/fea/ChContactSurfaceNodeCloud.h>
-#include <chrono/physics/ChBodyEasy.h>
-#include <chrono/fea/ChElementCableANCF.h>
-#include <chrono/fea/ChLinkPointFrame.h>
-
 #include <filesystem>  // C++17
+#include <iostream>
 
 using std::filesystem::create_directory;
 
@@ -26,7 +18,6 @@ using std::filesystem::create_directory;
 
 using namespace seahowl;
 using namespace seahowl::elasto;
-using namespace chrono;
 
 void seabed_interaction(seahowl::elasto::SystemElasto& system, seahowl::elasto::MooringElasto& mooring) {
     auto seabed_depth = 0.0;
@@ -52,7 +43,8 @@ void seabed_interaction(seahowl::elasto::SystemElasto& system, seahowl::elasto::
 void setup_cables(seahowl::elasto::SystemElasto& system,
                   seahowl::elasto::MooringElasto& mooring,
                   double dt = 0.01,
-                  int nsteps = 1000) {
+                  int nsteps = 1000,
+                  double fluid_density = 1000.0) {
     // check that mooring was built properly
     int nb_elements = mooring.elements.size();
     if (nb_elements != mooring.discretization_fractions.size() - 1) {
@@ -64,7 +56,7 @@ void setup_cables(seahowl::elasto::SystemElasto& system,
     std::vector<double> lengths_initial(nb_elements);
     std::vector<double> lengths_final(nb_elements);
     std::vector<double> lengths_delta(nb_elements);
-    for (int idx_el = 0; idx_el < nb_elements; idx_el++) {
+    for (size_t idx_el = 0; idx_el < nb_elements; idx_el++) {
         auto& element = dynamic_cast<seahowl::elasto::ElementMooringElasto&>(*mooring.elements[idx_el]);
         lengths_final[idx_el] =
             mooring.length * (mooring.discretization_fractions[idx_el + 1] - mooring.discretization_fractions[idx_el]);
@@ -78,7 +70,7 @@ void setup_cables(seahowl::elasto::SystemElasto& system,
             auto& element = dynamic_cast<seahowl::elasto::ElementMooringElasto&>(*mooring.elements[idx_el]);
             element.set_rest_length(lengths_initial[idx_el] + lengths_delta[idx_el] * step);
         }
-        mooring.compute_hydro_loads();
+        mooring.compute_hydro_loads(system.get_gravitational_acceleration(), fluid_density);
         seabed_interaction(system, mooring);
         system.step(dt);
     }
@@ -90,28 +82,16 @@ int main(int argc, char* argv[]) {
     // system
     auto system_elasto = SystemElastoChrono();
     system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
-    auto system_chrono = system_elasto.chobj;
-
-    auto solver = chrono_types::make_shared<ChSolverSparseLU>();
-    system_chrono->SetSolver(solver);
-    solver->UseSparsityPatternLearner(true);
-    solver->LockSparsityPattern(true);
-    solver->SetVerbose(false);
-
-    system_chrono->SetTimestepperType(ChTimestepper::Type::HHT);
-    if (auto mystepper = std::dynamic_pointer_cast<ChTimestepperHHT>(system_chrono->GetTimestepper())) {
-        mystepper->SetStepControl(false);
-        mystepper->SetModifiedNewton(false);
-    }
+    double fluid_density = 1000.0;
 
     // mooring line
     auto mooring = seahowl::elasto::MooringElasto();
-    mooring.fairlead_position = Vector3d(0.0, 837.60 - 40.868, 200.0 - 14.0);
+    mooring.fairlead_position = Vector3d(0.0, 837.60 - 58, 200.0 - 14.0);
     mooring.anchor_position = Vector3d(0.0, 0.0, 0.0);
-    mooring.length = 835.5;
-    mooring.diameter = 0.13376;
-    mooring.stiffness_axial = 753.6e6;
-    mooring.density = 116.6 / (PI * pow(mooring.diameter, 2) / 4.0);
+    mooring.length = 850.0;
+    mooring.diameter = 0.33;
+    mooring.stiffness_axial = 3270e6;
+    mooring.density_linear = 685.0;
     mooring.discretization_fractions = {};
     int nelements = 40;
     for (int ii = 0; ii < nelements + 1; ii++) {
@@ -127,55 +107,26 @@ int main(int argc, char* argv[]) {
     }
 
     // make fairlead
-    auto fairlead = chrono_types::make_shared<ChBody>();
-    fairlead->SetBodyFixed(true);
-    system_chrono->Add(fairlead);
+    auto fairlead = seahowl::elasto::BodyElastoChrono();
+    fairlead.set_fixed(true);
+    system_elasto.add(fairlead);
     // attach to fairlead
-    auto fairlead_link = chrono_types::make_shared<chrono::fea::ChLinkPointFrame>();
-    fairlead_link->Initialize(std::dynamic_pointer_cast<NodeElastoChronoD>(mooring.nodes.front())->chobj, fairlead);
-    system_chrono->Add(fairlead_link);
-    // fairlead_link->SetConstrainedCoords(true, true, true,     // x, y, z
+    auto fairlead_link = seahowl::elasto::LinkChronoCable();
+    fairlead_link.initialize(*mooring.nodes.front(), fairlead);
+    system_elasto.add(fairlead_link);
+    // fairlead_link.set_constraints(true, true, true,     // x, y, z
     //                                     true, false, false);  // Rx, Ry, Rz
 
     // make anchor
-    auto anchor = chrono_types::make_shared<ChBody>();
-    anchor->SetBodyFixed(true);
-    system_chrono->Add(anchor);
+    auto anchor = seahowl::elasto::BodyElastoChrono();
+    anchor.set_fixed(true);
+    system_elasto.add(anchor);
     // attach to anchor
-    auto anchor_link = chrono_types::make_shared<chrono::fea::ChLinkPointFrame>();
-    anchor_link->Initialize(std::dynamic_pointer_cast<NodeElastoChronoD>(mooring.nodes.back())->chobj, anchor);
-    system_chrono->Add(anchor_link);
-    // anchor_link->SetConstrainedCoords(true, true, true,     // x, y, z
+    auto anchor_link = seahowl::elasto::LinkChronoCable();
+    anchor_link.initialize(*mooring.nodes.back(), anchor);
+    system_elasto.add(anchor_link);
+    // anchor_link.set_constraintss(true, true, true,     // x, y, z
     //                                   true, false, false);  // Rx, Ry, Rz
-
-    //// assemble contact node cloud
-    //// make contact material
-    // auto contact_material = chrono_types::make_shared<chrono::ChMaterialSurfaceSMC>();
-    // double area = chrono::CH_C_PI * pow(mooring.diameter, 2) / 4.0;
-    // contact_material->SetYoungModulus(mooring.stiffness_axial / area);
-    // contact_material->SetFriction(0.3f);
-    // contact_material->SetRestitution(0.2f);
-    // contact_material->SetAdhesion(0);
-    // auto contact_cloud = chrono_types::make_shared<chrono::fea::ChContactSurfaceNodeCloud>(
-    //     contact_material, std::dynamic_pointer_cast<MeshElastoChrono>(system_elasto.mesh)->chobj.get());
-    // for (auto& node : mooring.nodes) {
-    //     contact_cloud->AddNode(std::dynamic_pointer_cast<NodeElastoChronoD>(node)->chobj, mooring.diameter);
-    // }
-    // std::dynamic_pointer_cast<MeshElastoChrono>(system_elasto.mesh)->chobj->AddContactSurface(contact_cloud);
-    // std::cout << "here" << std::endl;
-
-    // // make floor
-    // // material
-    // auto floor_material = chrono_types::make_shared<ChMaterialSurfaceSMC>();
-    // floor_material->SetYoungModulus(6e4);
-    // floor_material->SetFriction(0.3);
-    // floor_material->SetRestitution(0.2);
-    // floor_material->SetAdhesion(0);
-    // // box
-    // auto floor = chrono_types::make_shared<ChBodyEasyBox>(2000, 2000, 5, 1000, true, true, floor_material);
-    // floor->SetPos(ChVector<double>(0.0, 0.0, -2.7));
-    // floor->SetBodyFixed(true);
-    // system_chrono->Add(floor);
 
     double time = 0;
     double step = 0;
@@ -195,23 +146,19 @@ int main(int argc, char* argv[]) {
     application->SetWindowTitle("SEAHOWL");
     application->Initialize();
     application->SetCameraVertical(chrono::CameraVerticalDir::Z);
-    draw_system_init(system_chrono, application);
+    draw_system_init(system_elasto.chobj, application);
 #endif
-    // anchor_link->SetConstrainedCoords(false, false, false,    // x, y, z
-    //                                    false, false, false);  // Rx, Ry, Rz
 
-    // system_chrono->DoStaticRelaxing();
-    // system_chrono->DoStaticLinear();
     mooring.drag_coefficient = 0;
-    setup_cables(system_elasto, mooring, dt, 1000);
+    setup_cables(system_elasto, mooring, dt, 1000, fluid_density);
     mooring.drag_coefficient = 0.5;
     while (true) {
-        time += system_chrono->GetStep();
-        mooring.compute_hydro_loads();
+        time += system_elasto.get_time();
+        mooring.compute_hydro_loads(system_elasto.get_gravitational_acceleration(), fluid_density);
         seabed_interaction(system_elasto, mooring);
-        system_chrono->DoStepDynamics(dt);
+        system_elasto.step(dt);
         step += 1;
-        std::cout << "time: " << time << std::endl;
+        std::cout << "time: " << time << ", tension: " << fairlead_link.get_reaction_force().norm() << std::endl;
 #ifdef HAVE_VTK
         if (output_vtk) {
             for (auto const& vtk_output : vtk_outputs) {
@@ -221,7 +168,7 @@ int main(int argc, char* argv[]) {
 #endif
 #ifdef HAVE_IRRLICHT
         application->GetDevice()->run();
-        draw_system(system_chrono, application);
+        draw_system(system_elasto.chobj, application);
         application->EndScene();
 #endif
     }

--- a/examples/ex_mooring.cpp
+++ b/examples/ex_mooring.cpp
@@ -118,12 +118,12 @@ int main(int argc, char* argv[]) {
     mooring.length = 850.0;
     mooring.diameter = 0.185;
     mooring.stiffness_axial = 3270e6;
+    mooring.stiffness_bending = 0.0;
     mooring.density_linear = 685.0;
     mooring.drag_coefficient_normal = 2.0;
     mooring.drag_coefficient_tangential = 1.15;
     mooring.added_mass_coefficient_normal = 1.0;
     mooring.added_mass_coefficient_tangential = 1.0;
-    mooring.diameter = 0.33;
     mooring.discretization_fractions = {};
     int nelements = 40;
     for (int ii = 0; ii < nelements + 1; ii++) {
@@ -132,11 +132,6 @@ int main(int argc, char* argv[]) {
     //
     mooring.build();
     mooring.assemble(system_elasto);
-
-    // set bending stiffness to zero
-    for (auto& element : mooring.elements) {
-        dynamic_cast<ElementMooringElastoChrono&>(*element).set_bending_inertia(0);
-    }
 
     // make fairlead
     auto fairlead = seahowl::elasto::BodyElastoChrono();

--- a/examples/ex_mooring.cpp
+++ b/examples/ex_mooring.cpp
@@ -20,6 +20,39 @@ using namespace seahowl;
 using namespace seahowl::elasto;
 using namespace chrono;
 
+void setup_cables(seahowl::elasto::SystemElasto& system,
+                  seahowl::elasto::MooringElasto& mooring,
+                  double dt = 0.01,
+                  int nsteps = 1000) {
+    // check that mooring was built properly
+    int nb_elements = mooring.elements.size();
+    if (nb_elements != mooring.discretization_fractions.size() - 1) {
+        throw std::runtime_error(
+            "Number of elements and discretization fractions on mooring do not match (build mooring first?).");
+    }
+
+    // get initial and final lengths of mooring, and length increment to apply
+    std::vector<double> lengths_initial(nb_elements);
+    std::vector<double> lengths_final(nb_elements);
+    std::vector<double> lengths_delta(nb_elements);
+    for (int idx_el = 0; idx_el < nb_elements; idx_el++) {
+        auto& element = dynamic_cast<seahowl::elasto::ElementMooringElasto&>(*mooring.elements[idx_el]);
+        lengths_final[idx_el] =
+            mooring.length * (mooring.discretization_fractions[idx_el + 1] - mooring.discretization_fractions[idx_el]);
+        lengths_initial[idx_el] = (element.nodes[1]->get_position() - element.nodes[0]->get_position()).norm();
+        lengths_delta[idx_el] = (lengths_final[idx_el] - lengths_initial[idx_el]) / nsteps;
+    }
+
+    // apply length increments dynamically
+    for (int step = 0; step <= nsteps; step++) {
+        for (int idx_el = 0; idx_el < nb_elements; idx_el++) {
+            auto& element = dynamic_cast<seahowl::elasto::ElementMooringElasto&>(*mooring.elements[idx_el]);
+            element.set_rest_length(lengths_initial[idx_el] + lengths_delta[idx_el] * step);
+        }
+        system.step(dt);
+    }
+}
+
 int main(int argc, char* argv[]) {
     double dt = 0.01;
 
@@ -44,7 +77,7 @@ int main(int argc, char* argv[]) {
     auto mooring = seahowl::elasto::MooringElasto();
     mooring.fairlead_position = Vector3d(0.0, 200.0, 200.0);
     mooring.anchor_position = Vector3d(0.0, 0.0, 0.0);
-    mooring.length = 284;
+    mooring.length = 350.0;
     mooring.diameter = 0.13376;
     mooring.stiffness_axial = 753.6e6;
     mooring.density = 116.6 / (PI * pow(mooring.diameter, 2) / 4.0);
@@ -120,18 +153,12 @@ int main(int argc, char* argv[]) {
     // system_chrono->DoStaticRelaxing();
     // system_chrono->DoStaticLinear();
     mooring.drag_coefficient = 0;
+    setup_cables(system_elasto, mooring, 0.01, 1000);
+    mooring.drag_coefficient = 0.5;
     while (true) {
         time += system_chrono->GetStep();
         mooring.compute_hydro_loads();
         system_chrono->DoStepDynamics(dt);
-        if (time < 10) {
-            for (auto& element : mooring.elements) {
-                auto& element_mooring = dynamic_cast<seahowl::elasto::ElementMooringElasto&>(*element);
-                element_mooring.set_rest_length(element_mooring.get_rest_length() * 1.0003);
-            }
-        } else if (time > 15) {
-            mooring.drag_coefficient = 0.5;
-        }
         step += 1;
         std::cout << "time: " << time << std::endl;
 #ifdef HAVE_IRRLICHT

--- a/examples/ex_mooring.cpp
+++ b/examples/ex_mooring.cpp
@@ -27,14 +27,32 @@ void seabed_interaction(seahowl::elasto::SystemElasto& system, seahowl::elasto::
     auto seabed_position = (-gravity_direction) * seabed_depth;
     for (auto& element : mooring.elements) {
         auto element_length = dynamic_cast<seahowl::elasto::ElementMooringElasto&>(*element).get_rest_length();
+        auto element_mass = dynamic_cast<seahowl::elasto::ElementMooringElasto&>(*element).get_mass();
         for (auto& node : element->nodes) {
+            // assuming a flat seabed normal to gravitational acceleration direction
+            auto seabed_normal = -gravity_direction;
+
+            // stiffness force
             auto node_position = node->get_position();
-            Vector3d node_z_vector = node_position.cwiseProduct(-gravity_direction);
-            double penetration_depth = (node_z_vector - seabed_position).dot(-gravity_direction);
-            if (penetration_depth < 0) {
-                auto load_up = gravity_direction * seabed_stiffness * penetration_depth * mooring.diameter;
-                auto load_half_element = load_up * 0.5 * element_length;
-                node->set_force(node->get_force() + load_up);
+            Vector3d node_z_vector = node_position.cwiseProduct(seabed_normal);
+            double penetration_depth = (node_z_vector - seabed_position).dot(seabed_normal);
+            if (penetration_depth <= 0) {
+                auto load_stiffness_linear =
+                    gravity_direction * seabed_stiffness * penetration_depth * mooring.diameter;
+                // apply on node for half an element length
+                node->set_force(node->get_force() + 0.5 * element_length * (load_stiffness_linear));
+            }
+
+            // damping force
+            auto node_velocity = node->get_velocity();
+            double penetration_velocity = (node_velocity).dot(-seabed_normal);
+            if (penetration_depth <= 0 && penetration_velocity > 0) {
+                auto lambda = 0.5;  // fraction of critical damping
+                auto load_damping =
+                    2.0 * lambda *
+                    std::sqrt(seabed_stiffness * element_mass * mooring.diameter * (0.5 * element_length)) *
+                    penetration_velocity * seabed_normal;
+                node->set_force(node->get_force() + load_damping);
             }
         }
     }

--- a/examples/ex_mooring.cpp
+++ b/examples/ex_mooring.cpp
@@ -8,6 +8,13 @@
 #include <chrono/fea/ChNodeFEAxyzrot.h>
 #include <chrono/fea/ChContactSurfaceNodeCloud.h>
 #include <chrono/physics/ChBodyEasy.h>
+#include <chrono/fea/ChElementCableANCF.h>
+#include <chrono/fea/ChLinkPointFrame.h>
+
+#ifdef HAVE_IRRLICHT
+    #include <chrono_irrlicht/ChVisualSystemIrrlicht.h>
+    #include <seahowl/io/viz_insitu.h>
+#endif
 
 using namespace seahowl;
 using namespace seahowl::elasto;
@@ -37,7 +44,7 @@ int main(int argc, char* argv[]) {
     auto mooring = seahowl::elasto::MooringElasto();
     mooring.fairlead_position = Vector3d(0.0, 200.0, 200.0);
     mooring.anchor_position = Vector3d(0.0, 0.0, 0.0);
-    mooring.length = 282.84;
+    mooring.length = 284;
     mooring.diameter = 0.13376;
     mooring.stiffness_axial = 753.6e6;
     mooring.density = 116.6 / (PI * pow(mooring.diameter, 2) / 4.0);
@@ -51,39 +58,38 @@ int main(int argc, char* argv[]) {
     fairlead->SetBodyFixed(true);
     system_chrono->Add(fairlead);
     // attach to fairlead
-    auto fairlead_link = chrono_types::make_shared<ChLinkMateGeneric>();
-    fairlead_link->Initialize(std::dynamic_pointer_cast<NodeElastoChrono>(mooring.nodes.front())->chobj, fairlead,
-                              false, std::dynamic_pointer_cast<NodeElastoChrono>(mooring.nodes.front())->chobj->Frame(),
-                              std::dynamic_pointer_cast<NodeElastoChrono>(mooring.nodes.front())->chobj->Frame());
+    auto fairlead_link = chrono_types::make_shared<chrono::fea::ChLinkPointFrame>();
+    fairlead_link->Initialize(std::dynamic_pointer_cast<NodeElastoChronoD>(mooring.nodes.front())->chobj, fairlead);
     system_chrono->Add(fairlead_link);
-    fairlead_link->SetConstrainedCoords(true, true, true,     // x, y, z
-                                        true, false, false);  // Rx, Ry, Rz
+    // fairlead_link->SetConstrainedCoords(true, true, true,     // x, y, z
+    //                                     true, false, false);  // Rx, Ry, Rz
 
     // make anchor
     auto anchor = chrono_types::make_shared<ChBody>();
     anchor->SetBodyFixed(true);
     system_chrono->Add(anchor);
     // attach to anchor
-    auto anchor_link = chrono_types::make_shared<ChLinkMateFix>();
-    anchor_link->Initialize(std::dynamic_pointer_cast<NodeElastoChrono>(mooring.nodes.back())->chobj, anchor);
+    auto anchor_link = chrono_types::make_shared<chrono::fea::ChLinkPointFrame>();
+    anchor_link->Initialize(std::dynamic_pointer_cast<NodeElastoChronoD>(mooring.nodes.back())->chobj, anchor);
     system_chrono->Add(anchor_link);
-    anchor_link->SetConstrainedCoords(true, true, true,     // x, y, z
-                                      true, false, false);  // Rx, Ry, Rz
+    // anchor_link->SetConstrainedCoords(true, true, true,     // x, y, z
+    //                                   true, false, false);  // Rx, Ry, Rz
 
-    // assemble contact node cloud
-    // make contact material
-    auto contact_material = chrono_types::make_shared<chrono::ChMaterialSurfaceSMC>();
-    double area = chrono::CH_C_PI * pow(mooring.diameter, 2) / 4.0;
-    contact_material->SetYoungModulus(mooring.stiffness_axial / area);
-    contact_material->SetFriction(0.3f);
-    contact_material->SetRestitution(0.2f);
-    contact_material->SetAdhesion(0);
-    auto contact_cloud = chrono_types::make_shared<chrono::fea::ChContactSurfaceNodeCloud>(
-        contact_material, std::dynamic_pointer_cast<MeshElastoChrono>(system_elasto.mesh)->chobj.get());
-    for (auto& node : mooring.nodes) {
-        contact_cloud->AddNode(std::dynamic_pointer_cast<NodeElastoChrono>(node)->chobj, mooring.diameter);
-    }
-    std::dynamic_pointer_cast<MeshElastoChrono>(system_elasto.mesh)->chobj->AddContactSurface(contact_cloud);
+    //// assemble contact node cloud
+    //// make contact material
+    // auto contact_material = chrono_types::make_shared<chrono::ChMaterialSurfaceSMC>();
+    // double area = chrono::CH_C_PI * pow(mooring.diameter, 2) / 4.0;
+    // contact_material->SetYoungModulus(mooring.stiffness_axial / area);
+    // contact_material->SetFriction(0.3f);
+    // contact_material->SetRestitution(0.2f);
+    // contact_material->SetAdhesion(0);
+    // auto contact_cloud = chrono_types::make_shared<chrono::fea::ChContactSurfaceNodeCloud>(
+    //     contact_material, std::dynamic_pointer_cast<MeshElastoChrono>(system_elasto.mesh)->chobj.get());
+    // for (auto& node : mooring.nodes) {
+    //     contact_cloud->AddNode(std::dynamic_pointer_cast<NodeElastoChronoD>(node)->chobj, mooring.diameter);
+    // }
+    // std::dynamic_pointer_cast<MeshElastoChrono>(system_elasto.mesh)->chobj->AddContactSurface(contact_cloud);
+    // std::cout << "here" << std::endl;
 
     // // make floor
     // // material
@@ -96,21 +102,43 @@ int main(int argc, char* argv[]) {
     // auto floor = chrono_types::make_shared<ChBodyEasyBox>(2000, 2000, 5, 1000, true, true, floor_material);
     // floor->SetPos(ChVector<double>(0.0, 0.0, -2.7));
     // floor->SetBodyFixed(true);
-    // system.Add(floor);
+    // system_chrono->Add(floor);
 
     double time = 0;
     double step = 0;
 
-    // release anchor
-    anchor_link->SetConstrainedCoords(false, false, false,   // x, y, z
-                                      false, false, false);  // Rx, Ry, Rz
+#ifdef HAVE_IRRLICHT
+    auto application = chrono_types::make_shared<chrono::irrlicht::ChVisualSystemIrrlicht>();
+    application->SetWindowTitle("SEAHOWL");
+    application->Initialize();
+    application->SetCameraVertical(chrono::CameraVerticalDir::Z);
+    draw_system_init(system_chrono, application);
+#endif
+    // anchor_link->SetConstrainedCoords(false, false, false,    // x, y, z
+    //                                    false, false, false);  // Rx, Ry, Rz
 
+    // system_chrono->DoStaticRelaxing();
+    // system_chrono->DoStaticLinear();
+    mooring.drag_coefficient = 0;
     while (true) {
-        system_chrono->DoStepDynamics(dt);
         time += system_chrono->GetStep();
+        mooring.compute_hydro_loads();
+        system_chrono->DoStepDynamics(dt);
+        if (time < 10) {
+            for (auto& element : mooring.elements) {
+                auto& element_mooring = dynamic_cast<seahowl::elasto::ElementMooringElasto&>(*element);
+                element_mooring.set_rest_length(element_mooring.get_rest_length() * 1.0003);
+            }
+        } else if (time > 15) {
+            mooring.drag_coefficient = 0.5;
+        }
         step += 1;
-        std::cout << time << std::endl;
-        chrono::GetLog() << mooring.nodes.back()->get_position();
+        std::cout << "time: " << time << std::endl;
+#ifdef HAVE_IRRLICHT
+        application->GetDevice()->run();
+        draw_system(system_chrono, application);
+        application->EndScene();
+#endif
     }
 
     return 0;

--- a/include/seahowl/elasto/chrono_adapters.h
+++ b/include/seahowl/elasto/chrono_adapters.h
@@ -26,12 +26,18 @@ class ChQuaternion;
 template <class Real>
 class ChFrameMoving;
 class ChBody;
+class ChLinkBase;
+class ChLinkPointPoint;
+class ChLinkPointFrame;
 class ChLinkMateGeneric;
 class ChSystem;
 namespace fea {
+class ChNodeFEAbase;
 class ChNodeFEAxyzrot;
+class ChNodeFEAxyzD;
 class ChElementBeam;
 class ChElementBeamEuler;
+class ChElementCableANCF;
 class ChElementBeamTaperedTimoshenko;
 class ChElementBeamTaperedTimoshenkoFPM;
 class ChBeamSectionTimoshenkoAdvancedGeneric;
@@ -90,10 +96,16 @@ class BodyElastoChrono : public BodyElasto, public EntityDynamicChrono {
     virtual double get_mass() override;
 };
 
+class NodeElastoChronoBase {
+  public:
+    /** @brief Pointer to underlying Chrono object. */
+    std::shared_ptr<chrono::fea::ChNodeFEAbase> chobj;
+};
+
 /**
  * @brief Chrono elasto node class.
  */
-class NodeElastoChrono : public NodeElasto, public EntityDynamicChrono {
+class NodeElastoChrono : public NodeElasto, public EntityDynamicChrono, public NodeElastoChronoBase {
   public:
     /** @brief Pointer to underlying Chrono object. */
     std::shared_ptr<chrono::fea::ChNodeFEAxyzrot> chobj;
@@ -113,6 +125,36 @@ class NodeElastoChrono : public NodeElasto, public EntityDynamicChrono {
     virtual void set_fixed(bool is_fixed) override;
     void set_properties(const BladeReferencePointElasto& ref, bool fpm = false);
     void set_properties(const TowerReferencePointElasto& ref);
+};
+
+class NodeElastoChronoD : public NodeElasto, public NodeElastoChronoBase {
+  public:
+    /** @brief Pointer to underlying Chrono object. */
+    std::shared_ptr<chrono::fea::ChNodeFEAxyzD> chobj;
+
+    NodeElastoChronoD(const Vector3d& position, const Vector3d& direction);
+    virtual void set_rotation(const Quaternion& rotation) override;
+    virtual Quaternion get_rotation() const override;
+    virtual Vector3d get_direction() const override;
+    virtual void reset_loads() override;
+    virtual Vector3d get_force(bool is_local = false) const override;
+    virtual Vector3d get_torque(bool is_local = true) const override;
+    virtual void set_force(const Vector3d& force, bool is_local = false) override;
+    virtual void set_torque(const Vector3d& torque, bool is_local = true) override;
+    virtual void accumulate_force(const Vector3d& force, bool is_local = false) override;
+    virtual void accumulate_torque(const Vector3d& torque, bool is_local = true) override;
+    virtual void set_fixed(bool is_fixed) override;
+
+    virtual void set_position(const Vector3d& position) override;
+    virtual Vector3d get_position() const override;
+    virtual void set_velocity(const Vector3d& velocity) override;
+    virtual Vector3d get_velocity() const override;
+    virtual void set_acceleration(const Vector3d& acceleration) override;
+    virtual Vector3d get_acceleration() const override;
+    virtual void set_rotational_velocity(const Vector3d& rotational_velocity, bool is_local = true) override;
+    virtual Vector3d get_rotational_velocity(bool is_local = true) const override;
+    virtual void set_rotational_acceleration(const Vector3d& rotational_acceleration, bool is_local = true) override;
+    virtual Vector3d get_rotational_acceleration(bool is_local = true) const override;
 };
 
 /**
@@ -159,22 +201,47 @@ class ElementBladeElastoChronoFPM : public ElementElastoChrono, public ElementBl
 class ElementMooringElastoChrono : public ElementElastoChrono, public ElementMooringElasto {
   public:
     /** @brief Pointer to underlying Chrono object. */
-    std::shared_ptr<chrono::fea::ChElementBeamEuler> chobj;
+    std::shared_ptr<chrono::fea::ChElementCableANCF> chobj;
 
     ElementMooringElastoChrono();
     virtual void set_nodes(std::shared_ptr<NodeElasto> node1, std::shared_ptr<NodeElasto> node2) override;
     virtual void set_properties(double density, double diameter, double stiffness_axial) override;
+    virtual void set_rest_length(double rest_length) override;
+    virtual double get_rest_length() override;
+};
+
+class LinkChronoBase {
+  public:
+    /** @brief Pointer to underlying Chrono object. */
+    std::shared_ptr<chrono::ChLinkBase> chobj;
 };
 
 /**
  * @brief Chrono link class.
  */
-class LinkChrono : public Link {
+class LinkChrono : public Link, public LinkChronoBase {
   public:
     /** @brief Pointer to underlying Chrono object. */
     std::shared_ptr<chrono::ChLinkMateGeneric> chobj;
 
     LinkChrono();
+    virtual void set_constraints(bool surge, bool sway, bool heave, bool roll, bool pitch, bool yaw) override;
+    virtual void initialize(const BodyElasto& body1, const BodyElasto& body2) override;
+    virtual void initialize(const NodeElasto& node1, const BodyElasto& body2) override;
+    virtual void initialize(const NodeElasto& node1, const NodeElasto& node2) override;
+    Vector3d get_reaction_force() const override;
+    Vector3d get_reaction_torque() const override;
+};
+
+/**
+ * @brief Chrono link class for cables.
+ */
+class LinkChronoCable : public Link, public LinkChronoBase {
+  public:
+    /** @brief Pointer to underlying Chrono object. */
+    std::shared_ptr<chrono::ChLinkBase> chobj;
+
+    LinkChronoCable();
     virtual void set_constraints(bool surge, bool sway, bool heave, bool roll, bool pitch, bool yaw) override;
     virtual void initialize(const BodyElasto& body1, const BodyElasto& body2) override;
     virtual void initialize(const NodeElasto& node1, const BodyElasto& body2) override;

--- a/include/seahowl/elasto/chrono_adapters.h
+++ b/include/seahowl/elasto/chrono_adapters.h
@@ -207,7 +207,9 @@ class ElementMooringElastoChrono : public ElementElastoChrono, public ElementMoo
     virtual void set_nodes(std::shared_ptr<NodeElasto> node1, std::shared_ptr<NodeElasto> node2) override;
     virtual void set_properties(double density, double diameter, double stiffness_axial) override;
     virtual void set_rest_length(double rest_length) override;
-    virtual double get_rest_length() override;
+    virtual double get_rest_length() const override;
+    virtual void set_bending_inertia(double bending_inertia) override;
+    virtual double get_bending_inertia() const override;
 };
 
 class LinkChronoBase {

--- a/include/seahowl/elasto/chrono_adapters.h
+++ b/include/seahowl/elasto/chrono_adapters.h
@@ -205,11 +205,12 @@ class ElementMooringElastoChrono : public ElementElastoChrono, public ElementMoo
 
     ElementMooringElastoChrono();
     virtual void set_nodes(std::shared_ptr<NodeElasto> node1, std::shared_ptr<NodeElasto> node2) override;
-    virtual void set_properties(double density, double diameter, double stiffness_axial) override;
+    virtual void set_properties(double density,
+                                double diameter,
+                                double stiffness_axial,
+                                double stiffness_bending) override;
     virtual void set_rest_length(double rest_length) override;
     virtual double get_rest_length() const override;
-    virtual void set_bending_inertia(double bending_inertia) override;
-    virtual double get_bending_inertia() const override;
 };
 
 class LinkChronoBase {

--- a/include/seahowl/elasto/entities_elasto.h
+++ b/include/seahowl/elasto/entities_elasto.h
@@ -217,8 +217,9 @@ class ElementMooringElasto : public virtual ElementElasto {
      * @param[in] density Density of element.
      * @param[in] diameter Diameter of element.
      * @param[in] stiffness_axial Axial stiffness of element.
+     * @param[in] stiffness_bending Bending stiffness of element.
      */
-    virtual void set_properties(double density, double diameter, double stiffness_axial) = 0;
+    virtual void set_properties(double density, double diameter, double stiffness_axial, double stiffness_bending) = 0;
 
     /**
      * @brief Sets rest length of mooring elasto element.
@@ -231,18 +232,6 @@ class ElementMooringElasto : public virtual ElementElasto {
      * @brief Returns rest length of mooring elasto element.
      */
     virtual double get_rest_length() const = 0;
-
-    /**
-     * @brief Sets bending moment of inertia of the element.
-     *
-     * @param[in] bending_inertia Bending moment of inertia of the element.
-     */
-    virtual void set_bending_inertia(double bending_inertia) = 0;
-
-    /**
-     * @brief Returns bending moment of inertia of the element.
-     */
-    virtual double get_bending_inertia() const = 0;
 };
 
 /**

--- a/include/seahowl/elasto/entities_elasto.h
+++ b/include/seahowl/elasto/entities_elasto.h
@@ -219,6 +219,18 @@ class ElementMooringElasto : public virtual ElementElasto {
      * @param[in] stiffness_axial Axial stiffness of element.
      */
     virtual void set_properties(double density, double diameter, double stiffness_axial) = 0;
+
+    /**
+     * @brief Sets rest length of mooring elasto element.
+     *
+     * @param[in] rest_length Rest length of element.
+     */
+    virtual void set_rest_length(double rest_length) = 0;
+
+    /**
+     * @brief Returns rest length of mooring elasto element.
+     */
+    virtual double get_rest_length() = 0;
 };
 
 /**

--- a/include/seahowl/elasto/entities_elasto.h
+++ b/include/seahowl/elasto/entities_elasto.h
@@ -230,7 +230,19 @@ class ElementMooringElasto : public virtual ElementElasto {
     /**
      * @brief Returns rest length of mooring elasto element.
      */
-    virtual double get_rest_length() = 0;
+    virtual double get_rest_length() const = 0;
+
+    /**
+     * @brief Sets bending moment of inertia of the element.
+     *
+     * @param[in] bending_inertia Bending moment of inertia of the element.
+     */
+    virtual void set_bending_inertia(double bending_inertia) = 0;
+
+    /**
+     * @brief Returns bending moment of inertia of the element.
+     */
+    virtual double get_bending_inertia() const = 0;
 };
 
 /**

--- a/include/seahowl/elasto/mooring_elasto.h
+++ b/include/seahowl/elasto/mooring_elasto.h
@@ -21,6 +21,8 @@ class MooringElasto : public ComponentElastoFEA {
     double diameter = 0.0;
     /** @brief Axial stiffness of the mooring line. */
     double stiffness_axial = 0.0;
+    /** @brief Bending stiffness of the mooring line. */
+    double stiffness_bending = 0.0;
     /** @brief Linear density of the mooring line. */
     double density_linear = 0.0;
     /** @brief Unstretched length of the mooring line. */

--- a/include/seahowl/elasto/mooring_elasto.h
+++ b/include/seahowl/elasto/mooring_elasto.h
@@ -51,7 +51,7 @@ class MooringElasto : public ComponentElastoFEA {
      * param[in] gravitational_acceleration Gravitational acceleration vector.
      * param[in] fluid_density Density of fluid.
      */
-    void compute_hydro_loads(Vector3d& gravitational_acceleration, double fluid_density);
+    void compute_hydro_loads(const Vector3d& gravitational_acceleration, double fluid_density);
 
   private:
     /**

--- a/include/seahowl/elasto/mooring_elasto.h
+++ b/include/seahowl/elasto/mooring_elasto.h
@@ -25,6 +25,10 @@ class MooringElasto : public ComponentElastoFEA {
     double density = 0.0;
     /** @brief Unstretched length of the mooring line. */
     double length = 0.0;
+    /** @brief Drag coefficient of the mooring line. */
+    double drag_coefficient = 0.5;
+    /** @brief Added mass coefficient of the mooring line. */
+    double added_mass_coefficient = 0.5;
 
     MooringElasto();
 
@@ -32,12 +36,14 @@ class MooringElasto : public ComponentElastoFEA {
      * @brief Builds the mooring (to call before assemble).
      */
     void build();
+    void build_nodes(const std::vector<ReferencePointElasto>& discretized_points);
+    void compute_hydro_loads();
 
   private:
     /**
-     * @brief Builds the mooring with Euler-Bernoulli elements.
+     * @brief Builds the mooring with ANCF cable elements.
      */
-    void build_elements_euler();
+    void build_elements();
 };
 
 }  // namespace elasto

--- a/include/seahowl/elasto/mooring_elasto.h
+++ b/include/seahowl/elasto/mooring_elasto.h
@@ -21,8 +21,8 @@ class MooringElasto : public ComponentElastoFEA {
     double diameter = 0.0;
     /** @brief Axial stiffness of the mooring line. */
     double stiffness_axial = 0.0;
-    /** @brief Lineic density of the mooring line. */
-    double density = 0.0;
+    /** @brief Linear density of the mooring line. */
+    double density_linear = 0.0;
     /** @brief Unstretched length of the mooring line. */
     double length = 0.0;
     /** @brief Drag coefficient of the mooring line. */
@@ -36,8 +36,16 @@ class MooringElasto : public ComponentElastoFEA {
      * @brief Builds the mooring (to call before assemble).
      */
     void build();
+
     void build_nodes(const std::vector<ReferencePointElasto>& discretized_points);
-    void compute_hydro_loads();
+
+    /**
+     * @brief Computes hydro loads on cable.
+     *
+     * param[in] gravitational_acceleration Gravitational acceleration vector.
+     * param[in] fluid_density Density of fluid.
+     */
+    void compute_hydro_loads(Vector3d& gravitational_acceleration, double fluid_density);
 
   private:
     /**

--- a/include/seahowl/elasto/mooring_elasto.h
+++ b/include/seahowl/elasto/mooring_elasto.h
@@ -25,10 +25,14 @@ class MooringElasto : public ComponentElastoFEA {
     double density_linear = 0.0;
     /** @brief Unstretched length of the mooring line. */
     double length = 0.0;
-    /** @brief Drag coefficient of the mooring line. */
-    double drag_coefficient = 0.5;
-    /** @brief Added mass coefficient of the mooring line. */
-    double added_mass_coefficient = 0.5;
+    /** @brief Drag coefficient (normal) of the mooring line. */
+    double drag_coefficient_normal = 2.0;
+    /** @brief Drag coefficient (tangential) of the mooring line. */
+    double drag_coefficient_tangential = 1.15;
+    /** @brief Added mass coefficient (normal) of the mooring line. */
+    double added_mass_coefficient_normal = 1.0;
+    /** @brief Added mass coefficient (tangential) of the mooring line. */
+    double added_mass_coefficient_tangential = 1.0;
 
     MooringElasto();
 

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -780,7 +780,7 @@ void SystemElastoChrono::add(MeshElasto& mesh) {
 }
 
 void SystemElastoChrono::add(Link& link) {
-    chobj->Add(dynamic_cast<LinkChrono&>(link).chobj);
+    chobj->Add(dynamic_cast<LinkChronoBase&>(link).chobj);
 }
 
 }  // namespace elasto

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -608,14 +608,19 @@ void ElementMooringElastoChrono::set_nodes(std::shared_ptr<NodeElasto> node1, st
                     std::dynamic_pointer_cast<NodeElastoChronoD>(node2)->chobj);
 }
 
-void ElementMooringElastoChrono::set_properties(double density, double diameter, double stiffness_axial) {
+void ElementMooringElastoChrono::set_properties(double density,
+                                                double diameter,
+                                                double stiffness_axial,
+                                                double stiffness_bending) {
     // create mooring section
     auto section = chrono_types::make_shared<chrono::fea::ChBeamSectionCable>();
     chobj->SetSection(section);
     section->SetDensity(density);
     double area = chrono::CH_C_PI * pow(diameter, 2) / 4.0;
     section->SetDiameter(diameter);
-    section->SetYoungModulus(stiffness_axial / area);
+    double young_modulus = stiffness_axial / area;
+    section->SetYoungModulus(young_modulus);
+    section->SetI(stiffness_bending / young_modulus);
 }
 
 void ElementMooringElastoChrono::set_rest_length(double rest_length) {
@@ -624,13 +629,6 @@ void ElementMooringElastoChrono::set_rest_length(double rest_length) {
 
 double ElementMooringElastoChrono::get_rest_length() const {
     return chobj->GetRestLength();
-}
-
-void ElementMooringElastoChrono::set_bending_inertia(double bending_inertia) {
-    chobj->GetSection()->SetI(bending_inertia);
-}
-double ElementMooringElastoChrono::get_bending_inertia() const {
-    return chobj->GetSection()->GetI();
 }
 
 LinkChrono::LinkChrono() {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -616,9 +616,7 @@ void ElementMooringElastoChrono::set_properties(double density, double diameter,
     double area = chrono::CH_C_PI * pow(diameter, 2) / 4.0;
     section->SetDiameter(diameter);
     section->SetYoungModulus(stiffness_axial / area);
-    // section->SetI(1e-10);
-    // section->SetGshearModulus(0.0);
-    // section->SetAsCircularSection(diameter);
+    section->SetI(0);
 }
 
 void ElementMooringElastoChrono::set_rest_length(double rest_length) {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -616,15 +616,21 @@ void ElementMooringElastoChrono::set_properties(double density, double diameter,
     double area = chrono::CH_C_PI * pow(diameter, 2) / 4.0;
     section->SetDiameter(diameter);
     section->SetYoungModulus(stiffness_axial / area);
-    section->SetI(0);
 }
 
 void ElementMooringElastoChrono::set_rest_length(double rest_length) {
     chobj->SetRestLength(rest_length);
 }
 
-double ElementMooringElastoChrono::get_rest_length() {
+double ElementMooringElastoChrono::get_rest_length() const {
     return chobj->GetRestLength();
+}
+
+void ElementMooringElastoChrono::set_bending_inertia(double bending_inertia) {
+    chobj->GetSection()->SetI(bending_inertia);
+}
+double ElementMooringElastoChrono::get_bending_inertia() const {
+    return chobj->GetSection()->GetI();
 }
 
 LinkChrono::LinkChrono() {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -7,8 +7,10 @@
 #include <chrono/core/ChMatrix.h>
 #include <chrono/fea/ChBeamSectionTaperedTimoshenkoFPM.h>
 #include <chrono/fea/ChElementBeamTaperedTimoshenkoFPM.h>
-#include <chrono/fea/ChElementBeamEuler.h>
+#include <chrono/fea/ChElementCableANCF.h>
 #include <chrono/physics/ChLinkMate.h>
+#include <chrono/fea/ChLinkPointPoint.h>
+#include <chrono/fea/ChLinkPointFrame.h>
 #include <chrono/physics/ChLinkRevolute.h>
 #include <chrono/fea/ChMesh.h>
 #include <chrono/physics/ChSystemSMC.h>
@@ -236,6 +238,7 @@ NodeElastoChrono::NodeElastoChrono(const Vector3d& position, const Quaternion& r
     chobj = chrono_types::make_shared<chrono::fea::ChNodeFEAxyzrot>(
         chrono::ChFrame<>(vec2ch(position), node_iec2ch(rotation)));
     EntityDynamicChrono::chobj = chobj;
+    NodeElastoChronoBase::chobj = chobj;
 }
 
 void NodeElastoChrono::set_rotation(const Quaternion& rotation) {
@@ -404,6 +407,105 @@ void NodeElastoChrono::set_properties(const TowerReferencePointElasto& ref) {
     section->SetBeamRaleyghDamping(damping_coefficients);
 }
 
+NodeElastoChronoD::NodeElastoChronoD(const Vector3d& position, const Vector3d& direction) {
+    chobj = chrono_types::make_shared<chrono::fea::ChNodeFEAxyzD>(vec2ch(position), vec2ch(direction));
+    NodeElastoChronoBase::chobj = chobj;
+}
+
+void NodeElastoChronoD::set_rotation(const Quaternion& rotation) {}
+
+Quaternion NodeElastoChronoD::get_rotation() const {
+    return Quaternion(1.0, 0.0, 0.0, 0.0);
+}
+
+Vector3d NodeElastoChronoD::get_direction() const {
+    return ch2vec(chobj->GetD());
+}
+
+void NodeElastoChronoD::reset_loads() {
+    set_force(Vector3d(0.0, 0.0, 0.0), false);
+    set_torque(Vector3d(0.0, 0.0, 0.0), true);
+}
+
+Vector3d NodeElastoChronoD::get_force(bool is_local) const {
+    if (is_local) {
+        throw std::runtime_error("Cannot get force locally from ChNodeFEAxyzD.");
+    } else {
+        return ch2vec(chobj->GetForce());
+    }
+}
+
+Vector3d NodeElastoChronoD::get_torque(bool is_local) const {
+    // no torque on ChNodeFEAxyzD
+    return Vector3d(0.0, 0.0, 0.0);
+}
+
+void NodeElastoChronoD::set_force(const Vector3d& force, bool is_local) {
+    if (is_local) {
+        chobj->SetForce(vec2ch(get_rotation() * force));
+    } else {
+        chobj->SetForce(vec2ch(force));
+    }
+}
+
+void NodeElastoChronoD::set_torque(const Vector3d& torque, bool is_local) {
+    // no torque on ChNodeFEAxyzD
+}
+
+void NodeElastoChronoD::accumulate_force(const Vector3d& force, bool is_local) {
+    set_force(get_force(is_local) + force, is_local);
+}
+
+void NodeElastoChronoD::accumulate_torque(const Vector3d& torque, bool is_local) {
+    set_torque(get_torque(is_local) + torque, is_local);
+}
+
+void NodeElastoChronoD::set_fixed(bool is_fixed) {
+    chobj->SetFixed(is_fixed);
+}
+
+void NodeElastoChronoD::set_position(const Vector3d& position) {
+    chobj->SetPos(vec2ch(position));
+}
+
+Vector3d NodeElastoChronoD::get_position() const {
+    return ch2vec(chobj->GetPos());
+}
+
+void NodeElastoChronoD::set_velocity(const Vector3d& velocity) {
+    chobj->SetPos_dt(vec2ch(velocity));
+}
+
+Vector3d NodeElastoChronoD::get_velocity() const {
+    return ch2vec(chobj->GetPos_dt());
+}
+
+void NodeElastoChronoD::set_acceleration(const Vector3d& acceleration) {
+    chobj->SetPos_dtdt(vec2ch(acceleration));
+}
+
+Vector3d NodeElastoChronoD::get_acceleration() const {
+    return ch2vec(chobj->GetPos_dt());
+}
+
+void NodeElastoChronoD::set_rotational_velocity(const Vector3d& rotational_velocity, bool is_local) {
+    // no rotational velocity on ChNodeFEAxyzD
+}
+
+Vector3d NodeElastoChronoD::get_rotational_velocity(bool is_local) const {
+    // no rotational velocity on ChNodeFEAxyzD
+    return Vector3d(0.0, 0.0, 0.0);
+}
+
+void NodeElastoChronoD::set_rotational_acceleration(const Vector3d& rotational_acceleration, bool is_local) {
+    // no rotational acceleration on ChNodeFEAxyzD
+}
+
+Vector3d NodeElastoChronoD::get_rotational_acceleration(bool is_local) const {
+    // no rotational acceleration on ChNodeFEAxyzD
+    return Vector3d(0.0, 0.0, 0.0);
+}
+
 void ElementElastoChrono::set_nodes(std::shared_ptr<NodeElasto> node1, std::shared_ptr<NodeElasto> node2) {
     nodes.clear();
     nodes.push_back(node1);
@@ -492,7 +594,7 @@ void ElementBladeElastoChronoFPM::set_prebend(const Quaternion& prebend) {
 }
 
 ElementMooringElastoChrono::ElementMooringElastoChrono() {
-    chobj = chrono_types::make_shared<chrono::fea::ChElementBeamEuler>();
+    chobj = chrono_types::make_shared<chrono::fea::ChElementCableANCF>();
     ElementElastoChrono::chobj = chobj;
 }
 
@@ -502,25 +604,35 @@ void ElementMooringElastoChrono::set_nodes(std::shared_ptr<NodeElasto> node1, st
     nodes.push_back(node2);
 
     // set nodes
-    chobj->SetNodes(std::dynamic_pointer_cast<NodeElastoChrono>(node1)->chobj,
-                    std::dynamic_pointer_cast<NodeElastoChrono>(node2)->chobj);
+    chobj->SetNodes(std::dynamic_pointer_cast<NodeElastoChronoD>(node1)->chobj,
+                    std::dynamic_pointer_cast<NodeElastoChronoD>(node2)->chobj);
 }
 
 void ElementMooringElastoChrono::set_properties(double density, double diameter, double stiffness_axial) {
     // create mooring section
-    auto section = chrono_types::make_shared<chrono::fea::ChBeamSectionEulerAdvanced>();
+    auto section = chrono_types::make_shared<chrono::fea::ChBeamSectionCable>();
     chobj->SetSection(section);
     section->SetDensity(density);
     double area = chrono::CH_C_PI * pow(diameter, 2) / 4.0;
-    section->SetArea(area);
+    section->SetDiameter(diameter);
     section->SetYoungModulus(stiffness_axial / area);
-    section->SetGshearModulus(0.0);
-    section->SetAsCircularSection(diameter);
+    // section->SetI(1e-10);
+    // section->SetGshearModulus(0.0);
+    // section->SetAsCircularSection(diameter);
+}
+
+void ElementMooringElastoChrono::set_rest_length(double rest_length) {
+    chobj->SetRestLength(rest_length);
+}
+
+double ElementMooringElastoChrono::get_rest_length() {
+    return chobj->GetRestLength();
 }
 
 LinkChrono::LinkChrono() {
     chobj = chrono_types::make_shared<chrono::ChLinkMateGeneric>();
     chobj->SetConstrainedCoords(true, true, true, true, true, true);
+    LinkChronoBase::chobj = chobj;
 }
 
 void LinkChrono::initialize(const BodyElasto& body1, const BodyElasto& body2) {
@@ -553,12 +665,46 @@ Vector3d LinkChrono::get_reaction_torque() const {
     return ch2vec(chobj->Get_react_torque());
 }
 
+LinkChronoCable::LinkChronoCable() {}
+
+void LinkChronoCable::initialize(const BodyElasto& body1, const BodyElasto& body2) {
+    throw std::runtime_error("Cannot link 2 bodies with cable link.");
+}
+
+void LinkChronoCable::initialize(const NodeElasto& node1, const BodyElasto& body2) {
+    auto link = chrono_types::make_shared<chrono::fea::ChLinkPointFrame>();
+    link->Initialize(dynamic_cast<const NodeElastoChronoD&>(node1).chobj,
+                     dynamic_cast<const BodyElastoChrono&>(body2).chobj);
+    chobj = link;
+    LinkChronoBase::chobj = chobj;
+}
+
+void LinkChronoCable::initialize(const NodeElasto& node1, const NodeElasto& node2) {
+    auto link = chrono_types::make_shared<chrono::fea::ChLinkPointPoint>();
+    link->Initialize(dynamic_cast<const NodeElastoChronoD&>(node1).chobj,
+                     dynamic_cast<const NodeElastoChronoD&>(node2).chobj);
+    chobj = link;
+    LinkChronoBase::chobj = chobj;
+}
+
+void LinkChronoCable::set_constraints(bool surge, bool sway, bool heave, bool roll, bool pitch, bool yaw) {
+    throw std::runtime_error("Cannot set individual constraints on cable link.");
+}
+
+Vector3d LinkChronoCable::get_reaction_force() const {
+    return ch2vec(chobj->Get_react_force());
+}
+
+Vector3d LinkChronoCable::get_reaction_torque() const {
+    return ch2vec(chobj->Get_react_torque());
+}
+
 MeshElastoChrono::MeshElastoChrono() {
     chobj = chrono_types::make_shared<chrono::fea::ChMesh>();
 }
 
 void MeshElastoChrono::add(NodeElasto& node) {
-    chobj->AddNode(dynamic_cast<NodeElastoChrono&>(node).chobj);
+    chobj->AddNode(dynamic_cast<NodeElastoChronoBase&>(node).chobj);
 }
 
 void MeshElastoChrono::add(ElementElasto& element) {

--- a/src/elasto/mooring_elasto.cpp
+++ b/src/elasto/mooring_elasto.cpp
@@ -63,16 +63,21 @@ void MooringElasto::build_elements() {
         // set element nodes
         element->set_nodes(nodes[ii - 1], nodes[ii]);
         // set section
+        auto area = PI * pow(diameter, 2) / 4.0;
+        auto density = density_linear / area;
         element->set_properties(density, diameter, stiffness_axial);
     }
 }
 
-void MooringElasto::compute_hydro_loads() {
-    auto density = 1000.0;
-
+void MooringElasto::compute_hydro_loads(Vector3d& gravitational_acceleration, double fluid_density) {
     for (int ii = 0; ii < nodes.size(); ii++) {
         nodes[ii]->set_force(Vector3d(0.0, 0.0, 0.0));
     }
+
+    auto area = PI * pow(diameter, 2) / 4.0;
+    // buoyancy
+    auto load_buoyancy = fluid_density * area * (-gravitational_acceleration);
+
     for (int ii = 0; ii < elements.size(); ii++) {
         auto& element = elements[ii];
         auto element_length = std::dynamic_pointer_cast<ElementMooringElastoChrono>(element)->get_rest_length();
@@ -91,9 +96,9 @@ void MooringElasto::compute_hydro_loads() {
             auto drag_coefficient_axial = drag_coefficient;
             auto drag_coefficient_normal = drag_coefficient;
             auto load_drag_axial =
-                0.5 * density * drag_coefficient * PI * diameter * velocity_tangent.norm() * velocity_tangent;
+                0.5 * fluid_density * drag_coefficient * PI * diameter * velocity_tangent.norm() * velocity_tangent;
             auto load_drag_normal =
-                0.5 * density * drag_coefficient * diameter * velocity_normal.norm() * velocity_normal;
+                0.5 * fluid_density * drag_coefficient * diameter * velocity_normal.norm() * velocity_normal;
             auto load_drag = load_drag_axial + load_drag_normal;
 
             // added mass
@@ -104,10 +109,9 @@ void MooringElasto::compute_hydro_loads() {
             // load added mass per unit length
             auto added_mass_coefficient_axial = added_mass_coefficient;
             auto added_mass_coefficient_normal = added_mass_coefficient;
-            auto area = PI * pow(diameter, 2) / 4.0;
-            auto load_added_mass_axial = density * added_mass_coefficient_axial * area * acceleration_tangent;
-            auto load_added_mass_normal = density * added_mass_coefficient_normal * area * acceleration_normal;
-            auto load_added_mass_fluid = density * area * fluid_acceleration;
+            auto load_added_mass_axial = fluid_density * added_mass_coefficient_axial * area * acceleration_tangent;
+            auto load_added_mass_normal = fluid_density * added_mass_coefficient_normal * area * acceleration_normal;
+            auto load_added_mass_fluid = fluid_density * area * fluid_acceleration;
             auto load_added_mass = load_added_mass_axial + load_added_mass_normal;
 
             // apply load drag over half element (each node gets half of a given element)

--- a/src/elasto/mooring_elasto.cpp
+++ b/src/elasto/mooring_elasto.cpp
@@ -69,7 +69,7 @@ void MooringElasto::build_elements() {
     }
 }
 
-void MooringElasto::compute_hydro_loads(Vector3d& gravitational_acceleration, double fluid_density) {
+void MooringElasto::compute_hydro_loads(const Vector3d& gravitational_acceleration, double fluid_density) {
     for (int ii = 0; ii < nodes.size(); ii++) {
         nodes[ii]->set_force(Vector3d(0.0, 0.0, 0.0));
     }

--- a/src/elasto/mooring_elasto.cpp
+++ b/src/elasto/mooring_elasto.cpp
@@ -89,27 +89,24 @@ void MooringElasto::compute_hydro_loads(Vector3d& gravitational_acceleration, do
             // drag
             auto fluid_velocity = Vector3d(0.0, 0.0, 0.0);
             auto velocity_relative = fluid_velocity - element->nodes[ii]->get_velocity();
-            auto velocity_tangent = dir * velocity_relative.dot(dir);
-            auto velocity_normal = velocity_relative - velocity_tangent;
+            auto velocity_tangential = dir * velocity_relative.dot(dir);
+            auto velocity_normal = velocity_relative - velocity_tangential;
 
             // load drag per unit length
-            auto drag_coefficient_axial = drag_coefficient;
-            auto drag_coefficient_normal = drag_coefficient;
-            auto load_drag_axial =
-                0.5 * fluid_density * drag_coefficient * PI * diameter * velocity_tangent.norm() * velocity_tangent;
+            auto load_drag_axial = 0.5 * fluid_density * drag_coefficient_tangential * PI * diameter *
+                                   velocity_tangential.norm() * velocity_tangential;
             auto load_drag_normal =
-                0.5 * fluid_density * drag_coefficient * diameter * velocity_normal.norm() * velocity_normal;
+                0.5 * fluid_density * drag_coefficient_normal * diameter * velocity_normal.norm() * velocity_normal;
             auto load_drag = load_drag_axial + load_drag_normal;
 
             // added mass
             auto fluid_acceleration = Vector3d(0.0, 0.0, 0.0);
             auto acceleration_relative = fluid_acceleration - element->nodes[ii]->get_acceleration();
-            auto acceleration_tangent = dir * acceleration_relative.dot(dir);
-            auto acceleration_normal = acceleration_relative - acceleration_tangent;
+            auto acceleration_tangential = dir * acceleration_relative.dot(dir);
+            auto acceleration_normal = acceleration_relative - acceleration_tangential;
             // load added mass per unit length
-            auto added_mass_coefficient_axial = added_mass_coefficient;
-            auto added_mass_coefficient_normal = added_mass_coefficient;
-            auto load_added_mass_axial = fluid_density * added_mass_coefficient_axial * area * acceleration_tangent;
+            auto load_added_mass_axial =
+                fluid_density * added_mass_coefficient_tangential * area * acceleration_tangential;
             auto load_added_mass_normal = fluid_density * added_mass_coefficient_normal * area * acceleration_normal;
             auto load_added_mass_fluid = fluid_density * area * fluid_acceleration;
             auto load_added_mass = load_added_mass_axial + load_added_mass_normal;

--- a/src/elasto/mooring_elasto.cpp
+++ b/src/elasto/mooring_elasto.cpp
@@ -20,10 +20,34 @@ void MooringElasto::build() {
     }
     // build
     build_nodes(points);
-    build_elements_euler();
+    build_elements();
 }
 
-void MooringElasto::build_elements_euler() {
+void MooringElasto::build_nodes(const std::vector<ReferencePointElasto>& discretized_points) {
+    nodes.clear();
+    const auto nnodes = discretized_points.size();
+
+    for (size_t ii = 0; ii < nnodes; ii++) {
+        auto& discretized_point = discretized_points[ii];
+        auto& node_pos = discretized_point.coordinates;
+
+        // get node main axis (direction)
+        Vector3d node_axis;
+        if (ii == 0) {
+            node_axis = (discretized_points[ii + 1].coordinates - node_pos).normalized();
+        } else if (ii == nnodes - 1) {
+            node_axis = (node_pos - discretized_points[ii - 1].coordinates).normalized();
+        } else {
+            node_axis = (discretized_points[ii + 1].coordinates - discretized_points[ii - 1].coordinates).normalized();
+        }
+
+        // make node
+        auto node = std::make_shared<NodeElastoChronoD>(node_pos, node_axis);
+        nodes.push_back(node);
+    };
+};
+
+void MooringElasto::build_elements() {
     elements.clear();
     const auto nelements = nodes.size() - 1;
 
@@ -40,5 +64,55 @@ void MooringElasto::build_elements_euler() {
         element->set_nodes(nodes[ii - 1], nodes[ii]);
         // set section
         element->set_properties(density, diameter, stiffness_axial);
+    }
+}
+
+void MooringElasto::compute_hydro_loads() {
+    auto density = 1000.0;
+
+    for (int ii = 0; ii < nodes.size(); ii++) {
+        nodes[ii]->set_force(Vector3d(0.0, 0.0, 0.0));
+    }
+    for (int ii = 0; ii < elements.size(); ii++) {
+        auto& element = elements[ii];
+        auto element_length = std::dynamic_pointer_cast<ElementMooringElastoChrono>(element)->get_rest_length();
+
+        // loads nodes
+        for (int ii = 0; ii < 2; ii++) {
+            auto dir = element->nodes[ii]->get_direction();
+
+            // drag
+            auto fluid_velocity = Vector3d(0.0, 0.0, 0.0);
+            auto velocity_relative = fluid_velocity - element->nodes[ii]->get_velocity();
+            auto velocity_tangent = dir * velocity_relative.dot(dir);
+            auto velocity_normal = velocity_relative - velocity_tangent;
+
+            // load drag per unit length
+            auto drag_coefficient_axial = drag_coefficient;
+            auto drag_coefficient_normal = drag_coefficient;
+            auto load_drag_axial =
+                0.5 * density * drag_coefficient * PI * diameter * velocity_tangent.norm() * velocity_tangent;
+            auto load_drag_normal =
+                0.5 * density * drag_coefficient * diameter * velocity_normal.norm() * velocity_normal;
+            auto load_drag = load_drag_axial + load_drag_normal;
+
+            // added mass
+            auto fluid_acceleration = Vector3d(0.0, 0.0, 0.0);
+            auto acceleration_relative = fluid_acceleration - element->nodes[ii]->get_acceleration();
+            auto acceleration_tangent = dir * acceleration_relative.dot(dir);
+            auto acceleration_normal = acceleration_relative - acceleration_tangent;
+            // load added mass per unit length
+            auto added_mass_coefficient_axial = added_mass_coefficient;
+            auto added_mass_coefficient_normal = added_mass_coefficient;
+            auto area = PI * pow(diameter, 2) / 4.0;
+            auto load_added_mass_axial = density * added_mass_coefficient_axial * area * acceleration_tangent;
+            auto load_added_mass_normal = density * added_mass_coefficient_normal * area * acceleration_normal;
+            auto load_added_mass_fluid = density * area * fluid_acceleration;
+            auto load_added_mass = load_added_mass_axial + load_added_mass_normal;
+
+            // apply load drag over half element (each node gets half of a given element)
+            auto load_half_element = (load_drag + load_added_mass) * 0.5 * element_length;
+            element->nodes[ii]->set_force(element->nodes[ii]->get_force() + load_half_element);
+        }
     }
 }

--- a/src/elasto/mooring_elasto.cpp
+++ b/src/elasto/mooring_elasto.cpp
@@ -65,7 +65,7 @@ void MooringElasto::build_elements() {
         // set section
         auto area = PI * pow(diameter, 2) / 4.0;
         auto density = density_linear / area;
-        element->set_properties(density, diameter, stiffness_axial);
+        element->set_properties(density, diameter, stiffness_axial, stiffness_bending);
     }
 }
 


### PR DESCRIPTION
This PR is for creating moorings with Chrono. One big change is the use of CableANCF elements instead of BeamEuler, mainly due to the ease of initial setup of cables when using CableANCF. The setup is done dynamically from an initial length of the cable corresponding to the distance between anchor and fairlead, until the cable reaches its final intended length.
This fixes #44 with the cable setup.

In this PR:
- [x] Replace BeamEuler by CableANCF
- [x] Make function for initial setup of cable (pre-simulation step)
- [x] Make seabed-mooring interaction / collision model
- [x] ~~Make seabed-mooring friction model~~ To be done in future PR dedicated to environmental conditions
- [x] ~~Add test~~ Only example for now
- [x] Add example

This is intended as a first implementation, with future steps (for future PRs) to:
- create a separate Soil/Seabed model
- make a common parent mooring class for this implementation and #71 coupling.
- make the connection mooring/floater