### PR TITLE
Update CMakeLists to match Chrono template project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,7 +264,11 @@ set(SEAHOWL_FILES
     ${SEAHOWL_IO_SOURCES}
     ${SEAHOWL_IO_HEADERS}
 )
-target_sources(seahowl_core PRIVATE ${SEAHOWL_FILES})
+
+target_sources(
+    seahowl_core
+    PRIVATE ${SEAHOWL_FILES}
+)
 
 target_include_directories(
     seahowl_core
@@ -272,21 +276,30 @@ target_include_directories(
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ ${CMAKE_CURRENT_SOURCE_DIR}/include ${CHRONO_INCLUDE_DIRS}
 )
 
-target_compile_features(seahowl_core PRIVATE cxx_std_17)
-
-set_target_properties(
+target_compile_features(
     seahowl_core
-    PROPERTIES LINKER_LANGUAGE CXX
-               CXX_EXTENSIONS OFF
-               COMPILE_FLAGS "${CHRONO_CXX_FLAGS} ${EXTRA_COMPILE_FLAGS}"
-               COMPILE_DEFINITIONS "CHRONO_DATA_DIR=\"${CHRONO_DATA_DIR}\""
-               LINK_FLAGS "${CHRONO_LINKER_FLAGS}"
-               POSITION_INDEPENDENT_CODE ON
+    PRIVATE cxx_std_17
+)
+
+target_compile_definitions(
+    seahowl_core
+    PRIVATE "CHRONO_DATA_DIR=\"${CHRONO_DATA_DIR}\""
+)
+
+target_compile_options(
+    seahowl_core
+    PRIVATE ${CHRONO_CXX_FLAGS}
+)
+
+target_link_options(
+    seahowl_core
+    PRIVATE ${CHRONO_LINKER_FLAGS}
 )
 
 target_link_libraries(seahowl_core
     PUBLIC Eigen3::Eigen
-    PRIVATE nlohmann_json::nlohmann_json ${CHRONO_LIBRARIES})
+    PRIVATE nlohmann_json::nlohmann_json ${CHRONO_LIBRARIES}
+)
 
 if(SEAHOWL_ENABLE_VTK)
     target_link_libraries(seahowl_core PRIVATE VTK::CommonDataModel VTK::IOXML)
@@ -318,14 +331,7 @@ target_include_directories(
 
 target_compile_features(seahowl_driver PRIVATE cxx_std_17)
 
-set_target_properties(
-    seahowl_driver
-    PROPERTIES LINKER_LANGUAGE CXX
-               CXX_EXTENSIONS OFF
-               COMPILE_FLAGS "${CHRONO_CXX_FLAGS} ${EXTRA_COMPILE_FLAGS}"
-               COMPILE_DEFINITIONS "CHRONO_DATA_DIR=\"${CHRONO_DATA_DIR}\""
-               LINK_FLAGS "${CHRONO_LINKER_FLAGS}"
-)
+target_compile_options(seahowl_driver PRIVATE ${CHRONO_CXX_FLAGS})
 
 target_link_libraries(seahowl_driver PRIVATE seahowl_core nlohmann_json::nlohmann_json ${CHRONO_LIBRARIES})
 
@@ -381,4 +387,6 @@ if (SEAHOWL_ENABLE_PYTHON)
         ${PYSEAHOWL_DIR}/pyseahowl_core.cpp
     )
     target_link_libraries(pyseahowl PRIVATE seahowl_core)
+
+    target_compile_options(pyseahowl PRIVATE ${CHRONO_CXX_FLAGS})
 endif (SEAHOWL_ENABLE_PYTHON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,12 @@ target_sources(
     PRIVATE ${SEAHOWL_FILES}
 )
 
+set_target_properties(
+    seahowl_core
+    PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+	)
+
 target_include_directories(
     seahowl_core
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
@@ -387,6 +393,4 @@ if (SEAHOWL_ENABLE_PYTHON)
         ${PYSEAHOWL_DIR}/pyseahowl_core.cpp
     )
     target_link_libraries(pyseahowl PRIVATE seahowl_core)
-
-    target_compile_options(pyseahowl PRIVATE ${CHRONO_CXX_FLAGS})
 endif (SEAHOWL_ENABLE_PYTHON)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,94 +1,44 @@
 
 if (SEAHOWL_ENABLE_ROSCO)
 
-
-add_executable( ex_rosco
-)
+add_executable(ex_rosco)
 
 target_sources(ex_rosco
-
     PRIVATE
     ex_rosco.cpp
 )
 
 target_include_directories(ex_rosco
-
-
-	PUBLIC
-	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-	$<INSTALL_INTERFACE:include>
-
     PRIVATE
+	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 	${CMAKE_CURRENT_SOURCE_DIR}/
-	${CMAKE_PROJECT_SOURCE_DIR}
+	${CHRONO_INCLUDE_DIRS}
 )
-
-target_compile_features(
-	ex_rosco
-
-	PRIVATE
-	cxx_std_17
-)
-
-set_target_properties(ex_rosco
-
-    PROPERTIES
-        FOLDER examples
-        LINKER_LANGUAGE CXX
-        CXX_EXTENSIONS OFF
-	    COMPILE_FLAGS "${CHRONO_CXX_FLAGS} ${EXTRA_COMPILE_FLAGS}"
-	    COMPILE_DEFINITIONS "CHRONO_DATA_DIR=\"${CHRONO_DATA_DIR}\""
-	    LINK_FLAGS "${CHRONO_LINKER_FLAGS}"
-)
-
 
 target_link_libraries(ex_rosco
     PRIVATE
 	seahowl_core
 )
 
-
 endif (SEAHOWL_ENABLE_ROSCO)
 
 # ===================
 # BLADE Example
 # ===================
-add_executable( ex_blade )
+add_executable(ex_blade)
 
 target_sources(ex_blade
-
     PRIVATE
     ex_blade.cpp
 )
 
 target_include_directories(ex_blade
-
     PRIVATE
 	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 	${CMAKE_CURRENT_SOURCE_DIR}/
 	${CHRONO_INCLUDE_DIRS}
-
 )
 
-target_compile_features(
-	ex_blade
-
-	PRIVATE
-	cxx_std_17
-)
-
-set_target_properties(ex_blade
-
-    PROPERTIES
-        FOLDER examples
-        LINKER_LANGUAGE CXX
-        CXX_EXTENSIONS OFF
-	    COMPILE_FLAGS "${CHRONO_CXX_FLAGS} ${EXTRA_COMPILE_FLAGS}"
-	    COMPILE_DEFINITIONS "CHRONO_DATA_DIR=\"${CHRONO_DATA_DIR}\""
-	    LINK_FLAGS "${CHRONO_LINKER_FLAGS}"
-)
-
-message("CHRONO ${CHRONO_DATA_DIR}")
 target_link_libraries(ex_blade
     PRIVATE
 	seahowl_core
@@ -112,23 +62,6 @@ target_include_directories(ex_mooring
 	${CHRONO_INCLUDE_DIRS}
 )
 
-target_compile_features(
-	ex_mooring
-	PRIVATE
-	cxx_std_17
-)
-
-set_target_properties(ex_mooring
-    PROPERTIES
-        FOLDER examples
-        LINKER_LANGUAGE CXX
-        CXX_EXTENSIONS OFF
-	    COMPILE_FLAGS "${CHRONO_CXX_FLAGS} ${EXTRA_COMPILE_FLAGS}"
-	    COMPILE_DEFINITIONS "CHRONO_DATA_DIR=\"${CHRONO_DATA_DIR}\""
-	    LINK_FLAGS "${CHRONO_LINKER_FLAGS}"
-)
-
-message("CHRONO ${CHRONO_DATA_DIR}")
 target_link_libraries(ex_mooring
     PRIVATE
 	seahowl_core

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -125,15 +125,7 @@ void BladeElasto::evaluate_position_rotation(Vector3d& position,
                                              Quaternion& rotation,
                                              int element_index,
                                              double eta) const {
-    auto element = std::dynamic_pointer_cast<ElementBladeElastoChrono>(elements[element_index]);
-
-    // // unfortunately line below does not always work (returns nans sometimes when fpm_mode is true)
-    // // @todo fix this (Chrono issue ?)
-    // element->evaluate_position_rotation(eta, position, rotation);
-    auto w1 = std::abs(eta - 1.0) * 0.5;
-    auto w2 = std::abs(eta + 1.0) * 0.5;
-    position = w1 * element->nodes[0]->get_position() + w2 * element->nodes[1]->get_position();
-    rotation = element->nodes[0]->get_rotation();
+    elements[element_index]->evaluate_position_rotation(eta, position, rotation);
 }
 
 void BladeElasto::apply_pitch_increment(double pitch_increment) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,16 @@ target_include_directories(test_01
 	${CHRONO_INCLUDE_DIRS}
 )
 
+target_compile_features(
+    test_01
+    PRIVATE cxx_std_17
+)
+
+target_compile_options(
+    test_01
+    PRIVATE ${CHRONO_CXX_FLAGS}
+)
+
 target_link_libraries(test_01
     PRIVATE
 	seahowl_core

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,32 +6,18 @@ find_package(GTest CONFIG REQUIRED)
 
 add_executable(test_01 unit_tests/test_components.cpp )
 
-set_target_properties(test_01
-
-	PROPERTIES
-
-		CXX_EXTENSIONS OFF
-		COMPILE_FLAGS "${CHRONO_CXX_FLAGS} ${EXTRA_COMPILE_FLAGS}"
-		COMPILE_DEFINITIONS "CHRONO_DATA_DIR=\"${CHRONO_DATA_DIR}\""
-		LINK_FLAGS "${CHRONO_LINKER_FLAGS}"
-)
-
-target_compile_features(
-	test_01
-
-	PRIVATE
-	cxx_std_17
-)
-
-
-# target_link_libraries(test_01 seahowl_core ${CHRONO_LIBRARIES} -lgtest)
-
-target_link_libraries(test_01 seahowl_core ${CHRONO_LIBRARIES} GTest::gtest GTest::gtest_main GTest::gmock_main GTest::gmock Threads::Threads)
-
 target_include_directories(test_01
-	PRIVATE
-	${PROJECT_SOURCE_DIR}
-	$<TARGET_PROPERTY:seahowl_core,INCLUDE_DIRECTORIES>)
+    PRIVATE
+	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+	${CMAKE_CURRENT_SOURCE_DIR}/
+	${CHRONO_INCLUDE_DIRS}
+)
+
+target_link_libraries(test_01
+    PRIVATE
+	seahowl_core
+	GTest::gtest GTest::gtest_main GTest::gmock_main GTest::gmock Threads::Threads
+)
 
 add_test(
 	NAME test_01

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -3,11 +3,6 @@
 #include <cmath>
 #include <memory>
 
-#include <chrono/physics/ChSystemSMC.h>
-#include <chrono/solver/ChDirectSolverLS.h>
-#include <chrono/solver/ChIterativeSolverLS.h>
-#include <chrono/fea/ChNodeFEAxyzrot.h>
-
 #include <seahowl/elasto/blade_elasto.h>
 #include <seahowl/elasto/rotor_elasto.h>
 #include <seahowl/elasto/tower_elasto.h>
@@ -29,7 +24,6 @@
     #include "seahowl/aero/inflowwind_adapter.h"
 #endif
 
-using namespace chrono;
 using namespace seahowl::elasto;
 using namespace seahowl;
 
@@ -63,7 +57,6 @@ TEST(test_blade, mass_deflection) {
     // system
     auto system_elasto = SystemElastoChrono();
     system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
-    auto system_chrono = system_elasto.chobj;
 
     // blade
     auto blade = seahowl::elasto::BladeElasto();
@@ -86,13 +79,13 @@ TEST(test_blade, mass_deflection) {
     // check deflection from gravity (edge)
     double deflection_edge = -0.8580;
     blade.rotate(PI, Vector3d(0.0, 0.0, 1.0));
-    system_chrono->DoStaticLinear();
+    system_elasto.do_statics(true, 0);
     ASSERT_NEAR(deflection_edge, blade.nodes.back()->get_position().y(), 0.001);
 
     // check deflection from gravity (flap)
     double deflection_flap = 2.91411;
     blade.rotate(PI / 2.0, Vector3d(0.0, 0.0, 1.0));
-    system_chrono->DoStaticLinear();
+    system_elasto.do_statics(true, 0);
     ASSERT_NEAR(deflection_flap, blade.nodes.back()->get_position().y(), 0.001);
 }
 
@@ -100,7 +93,6 @@ TEST(test_rotor, mass) {
     // system
     auto system_elasto = SystemElastoChrono();
     system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
-    auto system_chrono = system_elasto.chobj;
 
     std::vector<std::shared_ptr<seahowl::elasto::BladeElasto>> blades;
     for (int ii = 0; ii < 3; ii++) {
@@ -131,7 +123,6 @@ TEST(test_tower, mass) {
     // system
     auto system_elasto = SystemElastoChrono();
     system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
-    auto system_chrono = system_elasto.chobj;
 
     // tower
     auto tower = seahowl::elasto::TowerElasto();
@@ -150,7 +141,6 @@ TEST(test_blade, natural_period_dynamic_edge) {
     // system
     auto system_elasto = SystemElastoChrono();
     system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
-    auto system_chrono = system_elasto.chobj;
 
     // blade
     auto blade = seahowl::elasto::BladeElasto();
@@ -192,7 +182,7 @@ TEST(test_blade, natural_period_dynamic_edge) {
             }
         }
         pos_y = blade.nodes.back()->get_position().y();
-        system_chrono->DoStepDynamics(dt);
+        system_elasto.step(dt);
         time += dt;
         step += 1;
     }
@@ -206,7 +196,6 @@ TEST(test_blade, natural_period_dynamic_flap) {
     // system
     auto system_elasto = SystemElastoChrono();
     system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
-    auto system_chrono = system_elasto.chobj;
 
     // blade
     auto blade = seahowl::elasto::BladeElasto();
@@ -251,7 +240,7 @@ TEST(test_blade, natural_period_dynamic_flap) {
             }
         }
         pos_y = blade.nodes.back()->get_position().y();
-        system_chrono->DoStepDynamics(dt);
+        system_elasto.step(dt);
         time += dt;
         step += 1;
     }
@@ -268,13 +257,12 @@ TEST(test_turbine, rpm_initial_pitch) {
     // solver
     auto verbose = false;
     // timestepping
-    auto timestepper_type = ChTimestepper::Type::HHT;
     double dt = 0.1;
     // wind
     auto wind_model = seahowl::aero::ConstantWind();
     wind_model.set_wind_velocity(Vector3d(8.0, 0.0, 0.0));
     // turbine
-    double initial_pitch = CH_C_PI / 8.0;
+    double initial_pitch = seahowl::PI / 8.0;
 
     // system
     auto system_elasto = SystemElastoChrono();
@@ -314,7 +302,7 @@ TEST(test_turbine, rpm_initial_pitch) {
         turbine.prestep(time, dt);
 
         system_elasto.step(dt);
-        time += system_chrono->GetStep();
+        time += dt;
 
         // poststep
         turbine.poststep(time, dt);
@@ -331,18 +319,16 @@ TEST(test_aerodyn, rpm_initial_pitch) {
     // solver
     auto verbose = false;
     // timestepping
-    auto timestepper_type = ChTimestepper::Type::HHT;
     double dt = 0.1;
     // wind
     auto wind_model = seahowl::aero::ConstantWind();
     wind_model.set_wind_velocity(Vector3d(8.0, 0.0, 0.0));
     // turbine
-    double initial_pitch = CH_C_PI / 8.0;
+    double initial_pitch = seahowl::PI / 8.0;
 
     // system
     auto system_elasto = SystemElastoChrono();
     system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
-    auto system_chrono = system_elasto.chobj;
 
     // turbine
     auto turbine_elasto = seahowl::elasto::TurbineElasto();
@@ -381,7 +367,7 @@ TEST(test_aerodyn, rpm_initial_pitch) {
         turbine.prestep(time, dt);
 
         system_elasto.step(dt);
-        time += system_chrono->GetStep();
+        time += dt;
 
         // poststep
         turbine.poststep(time, dt);
@@ -398,18 +384,16 @@ TEST(test_turbine, multiturbines) {
     // solver
     auto verbose = false;
     // timestepping
-    auto timestepper_type = ChTimestepper::Type::HHT;
     double dt = 0.1;
     // wind
     auto wind_model = std::make_shared<seahowl::aero::ConstantWind>();
     wind_model->set_wind_velocity(Vector3d(8.0, 0.0, 0.0));
     // turbine
-    double initial_pitch = CH_C_PI / 8.0;
+    double initial_pitch = seahowl::PI / 8.0;
 
     // system
     auto system_elasto = std::make_shared<SystemElastoChrono>();
     system_elasto->set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
-    auto system_chrono = system_elasto->chobj;
 
     // system core
     seahowl::core::System system_core;
@@ -455,7 +439,7 @@ TEST(test_turbine, multiturbines) {
 
         // step
         system_core.step(dt);
-        time += system_chrono->GetStep();
+        time += dt;
 
         // poststep
         system_core.poststep(time, dt);
@@ -474,7 +458,6 @@ TEST(test_inflowwind, rpm_initial_pitch) {
     // solver
     auto verbose = false;
     // timestepping
-    auto timestepper_type = ChTimestepper::Type::HHT;
     double dt = 0.1;
     // wind
     auto wind_model =
@@ -482,12 +465,11 @@ TEST(test_inflowwind, rpm_initial_pitch) {
                                          (DATADIR / "aerodyn/long_step_wind.wnd").generic_string());
     wind_model.init(dt);
     // turbine
-    double initial_pitch = CH_C_PI / 8.0;
+    double initial_pitch = seahowl::PI / 8.0;
 
     // system
     auto system_elasto = SystemElastoChrono();
     system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
-    auto system_chrono = system_elasto.chobj;
 
     // turbine
     auto turbine_elasto = seahowl::elasto::TurbineElasto();
@@ -524,7 +506,7 @@ TEST(test_inflowwind, rpm_initial_pitch) {
         turbine.prestep(time, dt);
 
         system_elasto.step(dt);
-        time += system_chrono->GetStep();
+        time += dt;
 
         // poststep
         turbine.poststep(time, dt);


### PR DESCRIPTION
This PR updates CMakeLists to use the same syntax as Chrono template project, and fixes #37.
Checklist:
- [x] can use FPM blades
- [x] compiles on Windows
- [x] compiles on Linux / WSL
- [x] compiles python bindings