### PR TITLE
Update controller comms for IPC and FF

### DIFF
--- a/include/seahowl/servo/controller.h
+++ b/include/seahowl/servo/controller.h
@@ -60,6 +60,13 @@ class Controller {
      * @brief Returns collective pitch to apply.
      */
     virtual double get_collective_pitch() const;
+
+    /**
+     * @brief Returns pitch to apply on blade.
+     *
+     * @param[in] index_blade Index of blade (0, 1, or 2).
+     */
+    virtual double get_pitch_blade(int index_blade) const;
 };
 
 /**

--- a/include/seahowl/servo/controller_discon.h
+++ b/include/seahowl/servo/controller_discon.h
@@ -66,6 +66,8 @@ struct DisconController {
     /// <param name="pitch_angle"></param>
     void SetPitch(double pitch_angle);
 
+    void SetPitchBlade(int index_blade, double pitch_angle);
+
     /// <summary>
     /// Helper to set Inflow wind speed
     /// </summary>
@@ -205,6 +207,13 @@ class ControllerDISCON : public Controller {
      * @brief Returns collective pitch to apply.
      */
     virtual double get_collective_pitch() const override;
+
+    /**
+     * @brief Returns pitch to apply on blade.
+     *
+     * @param[in] index_blade Index of blade (0, 1, or 2).
+     */
+    virtual double get_pitch_blade(int index_blade) const override;
 
   private:
     /** @brief Filepath of dynamic library (for DISCON routine). */

--- a/include/seahowl/servo/controller_discon.h
+++ b/include/seahowl/servo/controller_discon.h
@@ -70,6 +70,10 @@ struct DisconController {
 
     void SetRootMomentBlade(int index_blade, double flap, double edge);
 
+    void SetTowerTopAcceleration(double foreaft, double sideside);
+
+    void SetNacelleRotationalAcceleration(double roll, double pitch, double yaw);
+
     /// <summary>
     /// Helper to set Inflow wind speed
     /// </summary>

--- a/include/seahowl/servo/controller_discon.h
+++ b/include/seahowl/servo/controller_discon.h
@@ -68,6 +68,8 @@ struct DisconController {
 
     void SetPitchBlade(int index_blade, double pitch_angle);
 
+    void SetRootMomentBlade(int index_blade, double flap, double edge);
+
     /// <summary>
     /// Helper to set Inflow wind speed
     /// </summary>

--- a/include/seahowl/servo/controller_discon.h
+++ b/include/seahowl/servo/controller_discon.h
@@ -210,32 +210,8 @@ class ControllerDISCON : public Controller {
     /** @brief Filepath of dynamic library (for DISCON routine). */
     std::string libfile;
 
-    // init called from other init function
-    void initialize(double time,
-                    double dt,
-                    double omega_rotor,
-                    double omega_generator,
-                    double pitch_collective,
-                    double rotor_azimuth,
-                    size_t nblades);
-
     // updates turbine variables of object communicating with DISCON module
-    void update_turbine_variables(double time,
-                                  double dt,
-                                  double omega_rotor,
-                                  double omega_generator,
-                                  double pitch_collective,
-                                  double rotor_azimuth,
-                                  double power);
-
-    // step called from other step function
-    void step(double time,
-              double dt,
-              double omega_rotor,
-              double omega_generator,
-              double pitch_collective,
-              double rotor_azimuth,
-              double power);
+    void update_turbine_variables(double time, double dt, const seahowl::core::Turbine& turbine);
 };
 
 }  // namespace servo

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -37,6 +37,16 @@ void Turbine::poststep(double time, double dt) {
     if (controller->has_pitch_control) {
         auto collective_pitch_increment = controller->get_collective_pitch() - rotor.elasto.pitch_collective;
         rotor.elasto.apply_collective_pitch_increment(collective_pitch_increment);
+        if (rotor.blades.size() <= 3) {
+            // individual pitch only works with up to 3 blades
+            for (int idx_blade = 0; idx_blade < rotor.blades.size(); idx_blade++) {
+                auto& blade = rotor.blades[idx_blade]->elasto;
+                // individual pitch increment difference with collective pitch increment that was already applied
+                auto blade_pitch_increment =
+                    (controller->get_pitch_blade(idx_blade) - collective_pitch_increment) - blade.pitch;
+                blade.apply_pitch_increment(blade_pitch_increment);
+            }
+        }
     }
 
     // poststeps

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,9 +29,18 @@ using std::filesystem::remove_all;
 
 void output_results(seahowl::core::System& system_core, int step) {
     // output
+    auto& turbine = system_core.turbines[0];
     std::cout << "time: " << system_core.get_time() << ", step: " << step
-              << ", rpm: " << system_core.turbines[0].rotor.elasto.get_rpm()
-              << ", pitch: " << system_core.turbines[0].rotor.elasto.pitch_collective << std::endl;
+              << ", rpm: " << turbine.rotor.elasto.get_rpm();
+    int nblades = turbine.rotor.blades.size();
+    if (nblades <= 3) {
+        for (int ii = 0; ii < turbine.rotor.blades.size(); ii++) {
+            std::cout << ", pitch" << ii << ": " << turbine.rotor.blades[ii]->elasto.pitch;
+        }
+    } else {
+        std::cout << ", pitch: " << turbine.rotor.elasto.pitch_collective;
+    }
+    std::cout << std::endl;
     write_turbine_info_to_csv("./output/output", system_core, system_core.get_time());
 }
 

--- a/src/servo/controller.cpp
+++ b/src/servo/controller.cpp
@@ -23,6 +23,10 @@ double Controller::get_collective_pitch() const {
     return 0.0;
 }
 
+double Controller::get_pitch_blade(int index_blade) const {
+    return 0.0;
+}
+
 ControllerVariableTorque::ControllerVariableTorque() {
     has_pitch_control = false;
     has_torque_control = true;

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -54,6 +54,9 @@ void seahowl::servo::ControllerDISCON::update_turbine_variables(double time,
         auto& blade = *turbine.rotor.elasto.blades[index_blade];
         // pitch
         pImpl.SetPitchBlade(index_blade, blade.pitch);
+        // moment
+        auto root_moment = blade.get_blade_root_moment();
+        pImpl.SetRootMomentBlade(index_blade, root_moment[0], root_moment[1]);
     }
 
     // generator
@@ -455,6 +458,25 @@ void seahowl::servo::DisconController::SetPitchBlade(int index_blade, double pit
             break;
         case 2:
             SetAvrSWAP(34, static_cast<float>(pitch_angle));
+            break;
+        default:
+            throw std::runtime_error("Index of blade can only be (0, 1, 2).");
+    }
+}
+
+void seahowl::servo::DisconController::SetRootMomentBlade(int index_blade, double flap, double edge) {
+    switch (index_blade) {
+        case 0:
+            SetAvrSWAP(30, static_cast<float>(flap));
+            SetAvrSWAP(69, static_cast<float>(edge));
+            break;
+        case 1:
+            SetAvrSWAP(31, static_cast<float>(flap));
+            SetAvrSWAP(70, static_cast<float>(edge));
+            break;
+        case 2:
+            SetAvrSWAP(32, static_cast<float>(flap));
+            SetAvrSWAP(71, static_cast<float>(edge));
             break;
         default:
             throw std::runtime_error("Index of blade can only be (0, 1, 2).");

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -37,32 +37,31 @@ void seahowl::servo::ControllerDISCON::step(double time, double dt, const seahow
 void seahowl::servo::ControllerDISCON::update_turbine_variables(double time,
                                                                 double dt,
                                                                 const seahowl::core::Turbine& turbine) {
-    auto omega_rotor = turbine.rotor.elasto.get_rpm() * (2 * PI / 60.0);
-    auto omega_generator = turbine.get_generator_rpm() * (2 * PI / 60.0);
-    auto pitch_collective = turbine.rotor.elasto.pitch_collective;
-    auto rotor_azimuth = turbine.rotor.elasto.get_azimuth();
-    auto power = turbine.get_generated_power();
-
-    // rotor speed
-    pImpl.SetRotorSpeed(omega_rotor);
-    // generator speed
-    pImpl.SetGeneratorSpeed(omega_generator);
-
     // time
     pImpl.SetTime(time);
     pImpl.SetDeltaTime(dt);
 
-    // collective pitch
-    pImpl.SetPitch(pitch_collective);
-
+    // rotor
+    // speed
+    auto omega_rotor = turbine.rotor.elasto.get_rpm() * (2 * PI / 60.0);
+    pImpl.SetRotorSpeed(omega_rotor);
     // azimuth
-    // auto rotor_azimuth = pImpl.GetAvrSWAP(60) + omega * dt;
-    // if (rotor_azimuth > 2 * 3.14) {
-    //    rotor_azimuth -= 2 * 3.14;
-    //}
+    auto rotor_azimuth = turbine.rotor.elasto.get_azimuth();
     pImpl.SetRotorAzimuth(rotor_azimuth);
 
+    // blades
+    for (int index_blade = 0; index_blade < turbine.rotor.elasto.blades.size(); index_blade++) {
+        auto& blade = *turbine.rotor.elasto.blades[index_blade];
+        // pitch
+        pImpl.SetPitchBlade(index_blade, blade.pitch);
+    }
+
+    // generator
+    // speed
+    auto omega_generator = turbine.get_generator_rpm() * (2 * PI / 60.0);
+    pImpl.SetGeneratorSpeed(omega_generator);
     // power
+    auto power = turbine.get_generated_power();
     pImpl.SetGeneratedPower(power);
 }
 
@@ -90,6 +89,24 @@ double seahowl::servo::ControllerDISCON::get_torque_elec() const {
 double seahowl::servo::ControllerDISCON::get_collective_pitch() const {
     double collective_pitch = pImpl.GetAvrSWAP(45);
     return collective_pitch;
+}
+
+double seahowl::servo::ControllerDISCON::get_pitch_blade(int index_blade) const {
+    double pitch;
+    switch (index_blade) {
+        case 0:
+            pitch = pImpl.GetAvrSWAP(42);
+            break;
+        case 1:
+            pitch = pImpl.GetAvrSWAP(43);
+            break;
+        case 2:
+            pitch = pImpl.GetAvrSWAP(44);
+            break;
+        default:
+            throw std::runtime_error("Index of blade can only be (0, 1, 2).");
+    }
+    return pitch;
 }
 
 /**@brief Discon controller */
@@ -426,6 +443,22 @@ void seahowl::servo::DisconController::SetPitch(double pitch_angle) {
     SetAvrSWAP(4, static_cast<float>(pitch_angle));
     SetAvrSWAP(33, static_cast<float>(pitch_angle));
     SetAvrSWAP(34, static_cast<float>(pitch_angle));
+}
+
+void seahowl::servo::DisconController::SetPitchBlade(int index_blade, double pitch_angle) {
+    switch (index_blade) {
+        case 0:
+            SetAvrSWAP(4, static_cast<float>(pitch_angle));
+            break;
+        case 1:
+            SetAvrSWAP(33, static_cast<float>(pitch_angle));
+            break;
+        case 2:
+            SetAvrSWAP(34, static_cast<float>(pitch_angle));
+            break;
+        default:
+            throw std::runtime_error("Index of blade can only be (0, 1, 2).");
+    }
 }
 
 void seahowl::servo::DisconController::SetWindSpeed(double ws) {

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -27,23 +27,8 @@ seahowl::servo::ControllerDISCON::ControllerDISCON(std::string infile, std::stri
 }
 
 void seahowl::servo::ControllerDISCON::step(double time, double dt, const seahowl::core::Turbine& turbine) {
-    auto omega_rotor = turbine.rotor.elasto.get_rpm() * (2 * PI / 60.0);
-    auto omega_generator = turbine.get_generator_rpm() * (2 * PI / 60.0);
-    auto pitch_collective = turbine.rotor.elasto.pitch_collective;
-    auto rotor_azimuth = turbine.rotor.elasto.get_azimuth();
-    auto power = turbine.get_generated_power();
-    this->step(time, dt, omega_rotor, omega_generator, pitch_collective, rotor_azimuth, power);
-}
-
-void seahowl::servo::ControllerDISCON::step(double time,
-                                            double dt,
-                                            double omega_rotor,
-                                            double omega_generator,
-                                            double pitch_collective,
-                                            double rotor_azimuth,
-                                            double power) {
     // update variables
-    update_turbine_variables(time, dt, omega_rotor, omega_generator, pitch_collective, rotor_azimuth, power);
+    update_turbine_variables(time, dt, turbine);
 
     // call controller
     pImpl.Call();
@@ -51,11 +36,13 @@ void seahowl::servo::ControllerDISCON::step(double time,
 
 void seahowl::servo::ControllerDISCON::update_turbine_variables(double time,
                                                                 double dt,
-                                                                double omega_rotor,
-                                                                double omega_generator,
-                                                                double pitch_collective,
-                                                                double rotor_azimuth,
-                                                                double power) {
+                                                                const seahowl::core::Turbine& turbine) {
+    auto omega_rotor = turbine.rotor.elasto.get_rpm() * (2 * PI / 60.0);
+    auto omega_generator = turbine.get_generator_rpm() * (2 * PI / 60.0);
+    auto pitch_collective = turbine.rotor.elasto.pitch_collective;
+    auto rotor_azimuth = turbine.rotor.elasto.get_azimuth();
+    auto power = turbine.get_generated_power();
+
     // rotor speed
     pImpl.SetRotorSpeed(omega_rotor);
     // generator speed
@@ -85,20 +72,10 @@ void seahowl::servo::ControllerDISCON::initialize(double time, double dt, const 
     auto pitch_collective = turbine.rotor.elasto.pitch_collective;
     auto rotor_azimuth = turbine.rotor.elasto.get_azimuth();
     auto nblades = turbine.rotor.blades.size();
-    this->initialize(time, dt, omega_rotor, omega_generator, pitch_collective, rotor_azimuth, nblades);
-}
 
-void seahowl::servo::ControllerDISCON::initialize(double time,
-                                                  double dt,
-                                                  double omega_rotor,
-                                                  double omega_generator,
-                                                  double pitch_collective,
-                                                  double rotor_azimuth,
-                                                  size_t nblades) {
     pImpl.SetNumberOfBlades(nblades);
 
-    // update variables
-    update_turbine_variables(time, dt, omega_rotor, omega_generator, pitch_collective, rotor_azimuth, 0.0);
+    update_turbine_variables(time, dt, turbine);
 
     pImpl.SetAvrSWAP(27, 10.0);  // estimated wind speed (needs to be != 0 at init for it to work in ROSCO!)
 

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -50,13 +50,19 @@ void seahowl::servo::ControllerDISCON::update_turbine_variables(double time,
     pImpl.SetRotorAzimuth(rotor_azimuth);
 
     // blades
-    for (int index_blade = 0; index_blade < turbine.rotor.elasto.blades.size(); index_blade++) {
-        auto& blade = *turbine.rotor.elasto.blades[index_blade];
-        // pitch
-        pImpl.SetPitchBlade(index_blade, blade.pitch);
-        // moment
-        auto root_moment = blade.get_blade_root_moment();
-        pImpl.SetRootMomentBlade(index_blade, root_moment[0], root_moment[1]);
+    int nblades = turbine.rotor.elasto.blades.size();
+    if (nblades <= 3) {
+        // individual pitch only works with up to 3 blades
+        for (int index_blade = 0; index_blade < nblades; index_blade++) {
+            auto& blade = *turbine.rotor.elasto.blades[index_blade];
+            // pitch
+            pImpl.SetPitchBlade(index_blade, blade.pitch);
+            // moment
+            auto root_moment = blade.get_blade_root_moment();
+            pImpl.SetRootMomentBlade(index_blade, root_moment[0], root_moment[1]);
+        }
+    } else {
+        pImpl.SetPitch(turbine.rotor.elasto.pitch_collective);
     }
 
     // nacelle/towertop

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -59,6 +59,18 @@ void seahowl::servo::ControllerDISCON::update_turbine_variables(double time,
         pImpl.SetRootMomentBlade(index_blade, root_moment[0], root_moment[1]);
     }
 
+    // nacelle/towertop
+    // consider nacelle COG as towertop (for translational acceleration) as link is rigid
+    auto& nacelle = *turbine.rotor.elasto.body_nacelle;
+    // get local acceleration
+    auto nacelle_acceleration = nacelle.get_rotation().inverse() * nacelle.get_acceleration();
+    pImpl.SetTowerTopAcceleration(nacelle_acceleration[0], nacelle_acceleration[1]);
+    // get local rotational acceleration in shaft (tilted) coordinate system
+    auto& shaft = *turbine.rotor.elasto.body_shaft;
+    auto nacelle_acceleration_rotational = shaft.get_rotation().inverse() * nacelle.get_rotational_acceleration();
+    pImpl.SetNacelleRotationalAcceleration(nacelle_acceleration_rotational[0], nacelle_acceleration_rotational[1],
+                                           nacelle_acceleration_rotational[2]);
+
     // generator
     // speed
     auto omega_generator = turbine.get_generator_rpm() * (2 * PI / 60.0);
@@ -69,10 +81,6 @@ void seahowl::servo::ControllerDISCON::update_turbine_variables(double time,
 }
 
 void seahowl::servo::ControllerDISCON::initialize(double time, double dt, const seahowl::core::Turbine& turbine) {
-    auto omega_rotor = turbine.rotor.elasto.get_rpm() * (2 * PI / 60.0);
-    auto omega_generator = turbine.get_generator_rpm() * (2 * PI / 60.0);
-    auto pitch_collective = turbine.rotor.elasto.pitch_collective;
-    auto rotor_azimuth = turbine.rotor.elasto.get_azimuth();
     auto nblades = turbine.rotor.blades.size();
 
     pImpl.SetNumberOfBlades(nblades);
@@ -228,9 +236,9 @@ static std::vector<discon::ParamDef> ArrayInfo{
     {79, "out", 'I', "Request for loads", "-"},
     {80, "out", 'I', "1 = Variable slip current demand at position 81", "-"},
     {81, "both", 'R', "Variable slip current demand", "A"},
-    {82, "in", 'R', "Nacelle roll acceleration", "rad/s2"},
+    {82, "in", 'R', "Nacelle roll acceleration -- in shaft (tilted) coordinate system", "rad/s2"},
     {83, "in", 'R', "Nacelle nodding acceleration", "rad/s"},
-    {84, "in", 'R', "Nacelle yaw acceleration", "rad/s2"},
+    {84, "in", 'R', "Nacelle yaw acceleration -- in shaft (tilted) coordinate system", "rad/s2"},
     {85, "", 'R', "Reserved", "-"},
     {86, "", 'R', "Reserved", "-"},
     {87, "", 'R', "Reserved", "-"},
@@ -482,6 +490,17 @@ void seahowl::servo::DisconController::SetRootMomentBlade(int index_blade, doubl
             throw std::runtime_error("Index of blade can only be (0, 1, 2).");
     }
 }
+
+void seahowl::servo::DisconController::SetTowerTopAcceleration(double foreaft, double sideside) {
+    SetAvrSWAP(53, static_cast<float>(foreaft));
+    SetAvrSWAP(54, static_cast<float>(sideside));
+};
+
+void seahowl::servo::DisconController::SetNacelleRotationalAcceleration(double roll, double pitch, double yaw) {
+    SetAvrSWAP(82, static_cast<float>(roll));
+    SetAvrSWAP(83, static_cast<float>(pitch));
+    SetAvrSWAP(84, static_cast<float>(yaw));
+};
 
 void seahowl::servo::DisconController::SetWindSpeed(double ws) {
     SetAvrSWAP(27, static_cast<float>(ws));


### PR DESCRIPTION
This PR updates controller communication for Individual Pitch Control (IPC) and Floating Feedback (FF).
New variables passed to controller:
- individual blade pitch (for up to 3 blades)
- individual blade root moment  (for up to 3 blades)
- towertop acceleration
- nacelle rotational acceleration

New features for elasto model:
- apply pitch to blades collectively **and then individually** (if any difference with demanded collective pitch)