### PR TITLE
Apply gearbox losses to rotor torque directly

### DIFF
--- a/include/seahowl/core/turbine.h
+++ b/include/seahowl/core/turbine.h
@@ -118,6 +118,11 @@ class Turbine : public ComponentDynamic {
     void rotate(double angle, Vector3d axis);
 
     /**
+     * @brief Returns shaft power.
+     */
+    double get_shaft_power() const;
+
+    /**
      * @brief Returns generated power.
      */
     double get_generated_power() const;

--- a/include/seahowl/servo/controller_discon.h
+++ b/include/seahowl/servo/controller_discon.h
@@ -117,6 +117,12 @@ struct DisconController {
     void SetGeneratedPower(double power);
 
     /// <summary>
+    /// Helper to set the shaft power
+    /// </summary>
+    /// <param name="power">The shaft power. W</param>
+    void SetShaftPower(double power);
+
+    /// <summary>
     /// Helper to set number of blades
     /// </summary>
     /// <param name="nblades">The number of blades.</param>

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -29,18 +29,22 @@ void Turbine::prestep(double time, double dt) {
 }
 
 void Turbine::poststep(double time, double dt) {
-    auto torque_elec_previous = controller->get_torque_elec() * gearbox_ratio * gearbox_efficiency;
+    // hub loads
+    // reset external loads applied on rotor hub
+    rna.elasto.rotor->body_hub->reset_loads();
+    // apply aero torque losses from gearbox efficiency for next step
+    auto aero_torque = rna.elasto.get_axial_torque();
+    if (controller->has_torque_control) {
+        // remove previously applied electrical torque from total rotor torque
+        aero_torque += controller->get_torque_elec() * gearbox_ratio * gearbox_efficiency;
+    }
+    rna.elasto.accumulate_axial_torque(-aero_torque * (1.0 - gearbox_efficiency));
 
     // controller step
     controller->step(time, dt, *this);
-    // apply torque from comtroller
+    // apply torque from controller
     if (controller->has_torque_control) {
         auto torque_elec = controller->get_torque_elec() * gearbox_ratio * gearbox_efficiency;
-        // apply torque elec to hub rigid body
-        rna.elasto.rotor->body_hub->reset_loads();
-        // apply aero torque losses from gearbox efficiency
-        rna.elasto.accumulate_axial_torque(-(rna.elasto.get_axial_torque() + torque_elec_previous) *
-                                           (1.0 - gearbox_efficiency));
         // torque elec is applied on hub body (locally)
         rna.elasto.accumulate_axial_torque(-torque_elec);
     }

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -29,6 +29,8 @@ void Turbine::prestep(double time, double dt) {
 }
 
 void Turbine::poststep(double time, double dt) {
+    auto torque_elec_previous = controller->get_torque_elec() * gearbox_ratio * gearbox_efficiency;
+
     // controller step
     controller->step(time, dt, *this);
     // apply torque from comtroller
@@ -36,6 +38,9 @@ void Turbine::poststep(double time, double dt) {
         auto torque_elec = controller->get_torque_elec() * gearbox_ratio * gearbox_efficiency;
         // apply torque elec to hub rigid body
         rna.elasto.rotor->body_hub->reset_loads();
+        // apply aero torque losses from gearbox efficiency
+        rna.elasto.accumulate_axial_torque(-(rna.elasto.get_axial_torque() + torque_elec_previous) *
+                                           (1.0 - gearbox_efficiency));
         // torque elec is applied on hub body (locally)
         rna.elasto.accumulate_axial_torque(-torque_elec);
     }
@@ -78,9 +83,20 @@ void Turbine::rotate(double angle, Vector3d axis) {
     tower.elasto.rotate(angle, axis);
 }
 
+double Turbine::get_shaft_power() const {
+    // get generator rotation in rad/s scaled by gearbox ratio and efficiency
+    auto rot_rads = rna.elasto.get_rpm() * (2.0 * PI / 60.0) * gearbox_ratio;
+    // get torque elec from rotor
+    auto torque_elec = controller->get_torque_elec();
+
+    // calculate power
+    auto power = torque_elec * rot_rads;
+    return power;
+}
+
 double Turbine::get_generated_power() const {
     // get generator rotation in rad/s scaled by gearbox ratio and efficiency
-    auto rot_rads = rna.elasto.get_rpm() * (2.0 * PI / 60.0) * gearbox_ratio * gearbox_efficiency;
+    auto rot_rads = get_generator_rpm() * (2.0 * PI / 60.0);
     // get torque elec from rotor
     auto torque_elec = controller->get_torque_elec();
 
@@ -91,6 +107,6 @@ double Turbine::get_generated_power() const {
 
 double Turbine::get_generator_rpm() const {
     // get generator rotation in rad/s scaled by gearbox ratio and efficiency
-    auto rpm = rna.elasto.get_rpm() * gearbox_ratio * gearbox_efficiency;
+    auto rpm = rna.elasto.get_rpm() * gearbox_ratio;
     return rpm;
 }

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -87,8 +87,10 @@ void seahowl::servo::ControllerDISCON::update_turbine_variables(double time,
     auto omega_generator = turbine.get_generator_rpm() * (2 * PI / 60.0);
     pImpl.SetGeneratorSpeed(omega_generator);
     // power
-    auto power = turbine.get_generated_power();
-    pImpl.SetGeneratedPower(power);
+    // generator
+    pImpl.SetGeneratedPower(turbine.get_generated_power());
+    // shaft
+    pImpl.SetShaftPower(turbine.get_shaft_power());
 }
 
 void seahowl::servo::ControllerDISCON::initialize(double time, double dt, const seahowl::core::Turbine& turbine) {
@@ -539,6 +541,10 @@ void seahowl::servo::DisconController::SetRotorAzimuth(double azimuth) {
 
 void seahowl::servo::DisconController::SetGeneratedPower(double power) {
     SetAvrSWAP(15, power);
+}
+
+void seahowl::servo::DisconController::SetShaftPower(double power) {
+    SetAvrSWAP(14, power);
 }
 
 void seahowl::servo::DisconController::SetNumberOfBlades(size_t nblades) {


### PR DESCRIPTION
This PR applies the gearbox losses to the rotor torque in the post-step. Shaft power (before generator losses) is also passed to the controller.
Validated on IEA 3.4MW (compared to OpenFAST results below).

![IEA3 4MW_power_ramp](https://github.com/Total-RD/seahowl/assets/12599696/bc1ffa16-55d6-4ce4-a1f5-47d081020c97)
![IEA3 4MW_rpm_pitch_ramp](https://github.com/Total-RD/seahowl/assets/12599696/eedb70cf-46cb-41c2-b7d3-7bd1cb9a685b)
