### PR TITLE
Update BEMT to use actual airfoil angle

### DIFF
--- a/include/seahowl/aero/bemt.h
+++ b/include/seahowl/aero/bemt.h
@@ -52,14 +52,14 @@ AirfoilCoefficients get_aero_coefficients_from_alpha(const double alpha,
  *
  * @param[out] node Node on which induced velocity in computed.
  * @param[in] local_velocity_rotor0 Local uninduced velocity at node.
- * @param[in] blade_pitch Pitch of blade on which node is placed.
+ * @param[in] pitch Pitch of blade on which node is placed.
  * @param[in] nblades Number of blade.
  * @param[in] tip_loss Whether to take tip loss into account or not.
  * @param[in] hub_loss Whether to take hub loss into account or not.
  */
 Vector2d get_induced_velocity(BladeNodeAero& node,
                               const Vector2d& local_velocity_rotor0,
-                              const double blade_pitch = 0.0,
+                              const double pitch = 0.0,
                               const size_t nblades = 3,
                               const bool tip_loss = true,
                               const bool hub_loss = true);

--- a/include/seahowl/aero/blade_aero.h
+++ b/include/seahowl/aero/blade_aero.h
@@ -53,21 +53,6 @@ struct BladeNodeAero : public EntityDynamicEigen {
      * @brief Get aero offset in global frame of reference.
      */
     Vector3d get_offset_aero_absolute() const;
-
-    /**
-     * @brief Returns induced velocity.
-     *
-     * @param[in] local_velocity_rotor0 Local uninduced velocity at node.
-     * @param[in] blade_pitch Pitch of blade on which node is placed.
-     * @param[in] nblades Number of blade.
-     * @param[in] tip_loss Whether to take tip loss into account or not.
-     * @param[in] hub_loss Whether to take hub loss into account or not.
-     */
-    Vector2d get_induced_velocity_rotor(const Vector2d& local_velocity_rotor0,
-                                        double blade_pitch = 0.0,
-                                        size_t nblades = 3,
-                                        bool tip_loss = true,
-                                        bool hub_loss = true);
 };
 
 /**

--- a/src/aero/bemt.cpp
+++ b/src/aero/bemt.cpp
@@ -41,14 +41,13 @@ seahowl::aero::AirfoilCoefficients seahowl::aero::get_aero_coefficients_from_alp
 
 Vector2d seahowl::aero::get_induced_velocity(seahowl::aero::BladeNodeAero& node,
                                              const Vector2d& local_velocity_rotor0,
-                                             const double blade_pitch,
+                                             const double pitch,
                                              const size_t nblades,
                                              const bool tip_loss,
                                              const bool hub_loss) {
     // local_velocity is in local element frame
     Vector2d local_velocity;
     Vector2d local_velocity_rotor;
-    double pitch_twist = blade_pitch + node.properties.structural_twist;
 
     double tol_rel = 1e-3;
     double tol_abs = 1e-3;
@@ -81,7 +80,7 @@ Vector2d seahowl::aero::get_induced_velocity(seahowl::aero::BladeNodeAero& node,
 
         // get coefficients from angle of attack
         double phi = seahowl::aero::get_phi(local_velocity_rotor);
-        alpha = seahowl::aero::get_alpha_from_phi(phi, (blade_pitch + node.properties.structural_twist));
+        alpha = seahowl::aero::get_alpha_from_phi(phi, pitch);
         auto coefficients = seahowl::aero::get_aero_coefficients_from_alpha(alpha, node.properties.airfoil_properties);
 
         // get drag and lift coefficients

--- a/src/aero/blade_aero.cpp
+++ b/src/aero/blade_aero.cpp
@@ -9,7 +9,6 @@
 using seahowl::aero::BladeNodeAero;
 using seahowl::aero::BladeElementAero;
 using seahowl::aero::BladeAero;
-using seahowl::aero::get_induced_velocity;
 using seahowl::Vector3d;
 using seahowl::Vector2d;
 using seahowl::Quaternion;
@@ -25,14 +24,6 @@ BladeNodeAero::BladeNodeAero(BladeReferencePointAero& point) {
     wind_velocity = Vector3d(0.0, 0.0, 0.0);
     wind_velocity_shadowed = Vector3d(0.0, 0.0, 0.0);
     relative_velocity_induced = Vector3d(0.0, 0.0, 0.0);
-}
-
-Vector2d BladeNodeAero::get_induced_velocity_rotor(const Vector2d& local_velocity_rotor0,
-                                                   double blade_pitch,
-                                                   size_t nblades,
-                                                   bool tip_loss,
-                                                   bool hub_loss) {
-    return get_induced_velocity(*this, local_velocity_rotor0, blade_pitch, nblades, tip_loss, hub_loss);
 }
 
 Vector3d BladeNodeAero::get_offset_aero_absolute() const {

--- a/src/aero/rotor_aero.cpp
+++ b/src/aero/rotor_aero.cpp
@@ -147,9 +147,15 @@ void RotorNacelleAssemblyAero::compute_aero_loads(const FluidModel& wind_model,
                 (node.distance_from_hub < tol && hub_loss)) {
                 node.load = Vector3d(0.0, 0.0, 0.0);
             } else {
-                double airfoil_angle =
-                    seahowl::PI / 2 - acos(global_direction_normal.dot(node.get_rotation() * Vector3d(0.0, 1.0, 0.0)));
-                // get induced velocity (2D) from blade node
+                // get airfoil angle with rotor plane
+                auto airfoil_direction = node.get_rotation() * Vector3d(0.0, -1.0, 0.0);
+                double airfoil_angle = acos(airfoil_direction.dot(global_direction_normal)) - seahowl::PI / 2;
+                // check direction of airfoil axis
+                if (airfoil_direction.dot(global_direction_tangent) < 0) {
+                    airfoil_angle = seahowl::PI - airfoil_angle;
+                }
+
+                // get induced velocity
                 auto local_velocity =
                     get_induced_velocity(node, local_velocity0, airfoil_angle, blades.size(), tip_loss, hub_loss);
 
@@ -195,7 +201,6 @@ void RotorNacelleAssemblyAero::compute_aero_loads(const FluidModel& wind_model,
 }
 
 void RotorNacelleAssemblyAero::compute_aero_loads_disk(const FluidModel& wind_model, double time) {
-
     auto pos_hub = body_hub.get_position();
     auto vel_hub = body_hub.get_velocity();
     double density = wind_model.get_fluid_density(pos_hub, time);

--- a/src/aero/rotor_aero.cpp
+++ b/src/aero/rotor_aero.cpp
@@ -147,14 +147,14 @@ void RotorNacelleAssemblyAero::compute_aero_loads(const FluidModel& wind_model,
                 (node.distance_from_hub < tol && hub_loss)) {
                 node.load = Vector3d(0.0, 0.0, 0.0);
             } else {
+                double airfoil_angle = blade->pitch + node.properties.structural_twist;
                 // get induced velocity (2D) from blade node
                 auto local_velocity =
-                    node.get_induced_velocity_rotor(local_velocity0, blade->pitch, blades.size(), tip_loss, hub_loss);
+                    get_induced_velocity(node, local_velocity0, airfoil_angle, blades.size(), tip_loss, hub_loss);
 
                 // get coefficients from angle of attack
                 double phi = seahowl::aero::get_phi(local_velocity);
-                double alpha =
-                    seahowl::aero::get_alpha_from_phi(phi, (blade->pitch + node.properties.structural_twist));
+                double alpha = seahowl::aero::get_alpha_from_phi(phi, airfoil_angle);
                 auto coefficients =
                     seahowl::aero::get_aero_coefficients_from_alpha(alpha, node.properties.airfoil_properties);
 

--- a/src/aero/rotor_aero.cpp
+++ b/src/aero/rotor_aero.cpp
@@ -147,7 +147,8 @@ void RotorNacelleAssemblyAero::compute_aero_loads(const FluidModel& wind_model,
                 (node.distance_from_hub < tol && hub_loss)) {
                 node.load = Vector3d(0.0, 0.0, 0.0);
             } else {
-                double airfoil_angle = blade->pitch + node.properties.structural_twist;
+                double airfoil_angle =
+                    seahowl::PI / 2 - acos(global_direction_normal.dot(node.get_rotation() * Vector3d(0.0, 1.0, 0.0)));
                 // get induced velocity (2D) from blade node
                 auto local_velocity =
                     get_induced_velocity(node, local_velocity0, airfoil_angle, blades.size(), tip_loss, hub_loss);

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -237,7 +237,15 @@ seahowl::EntityDynamicEigen BladeElastoRigid::get_entity_along_blade(double eta,
     // position
     Vector3d position = body_root->get_position() + body_root->get_rotation() * Vector3d(0.0, 0.0, z_position);
     entity.set_position(position);
-    entity.set_rotation(body_root->get_rotation());
+
+    // get structural twist
+    std::vector<double> eta_vector = {0.5 * (eta + 1.0)};
+    auto twist = seahowl::get_discretized_points(eta_vector, reference_points)[0].structural_twist;
+
+    // rotation
+    auto twist_matrix = AngleAxisd(-twist, body_root->get_rotation() * Vector3d(0.0, 0.0, 1.0));
+    auto rotation_matrix = twist_matrix * body_root->get_rotation().toRotationMatrix();
+    entity.set_rotation(Quaternion(rotation_matrix));
 
     // below has to be explicitly declared as Vector3d or there is an issue;
     Vector3d pos1 = entity.get_position();

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -352,7 +352,7 @@ TEST(test_turbine, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.822343, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.8025926, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {


### PR DESCRIPTION
This PR improves BEMT by retrieving actual airfoil angle relative to rotor disk plane, instead of the (blade pitch + structural twist) value.
It also adds consideration of structural twist for rigid blades when retrieving entities along blade.