### PR TITLE
Refactor aero logic and workflow

### DIFF
--- a/data/IEA15MW/main.json
+++ b/data/IEA15MW/main.json
@@ -16,10 +16,7 @@
     {
       "file": "./turbine.json",
       "translation": [0, 0, 0],
-      "rotation": 0,
-      "use_aerodyn": false,
-      "file_aerodyn": "./aerodyn/IEA-15-240-RWT_AeroDyn15.dat",
-      "file_inflowwind": "./aerodyn/IEA-15-240-RWT_InflowWind.dat"
+      "rotation": 0
     }
   ]
 }

--- a/data/IEA15MW/main.json
+++ b/data/IEA15MW/main.json
@@ -14,9 +14,9 @@
   },
   "turbines": [
     {
+      "file": "./turbine.json",
       "translation": [0, 0, 0],
       "rotation": 0,
-      "file": "./turbine.json",
       "use_aerodyn": false,
       "file_aerodyn": "./aerodyn/IEA-15-240-RWT_AeroDyn15.dat",
       "file_inflowwind": "./aerodyn/IEA-15-240-RWT_InflowWind.dat"

--- a/data/IEA15MW/turbine.json
+++ b/data/IEA15MW/turbine.json
@@ -9,10 +9,9 @@
   },
   "rotor": {
     "type": "fea",
-    "fpm": false,
-    "inertia_total": 3.524605e8,
-    "mass_blades_total": 195e3,
-    "radius": 117,
+    "options": {
+      "fpm": false
+    },
     "discretization": {
       "elasto": [49],
       "aero": [49]

--- a/data/IEA15MW/turbine.json
+++ b/data/IEA15MW/turbine.json
@@ -1,9 +1,18 @@
 ﻿{
+  "aero": {
+    "solver": "BEMT",
+    "options": {
+      "hub_loss": true,
+      "tip_loss": true,
+      "tower_shadow": true
+    }
+  },
   "rotor": {
     "type": "fea",
     "fpm": false,
     "inertia_total": 3.524605e8,
     "mass_blades_total": 195e3,
+    "radius": 117,
     "discretization": {
       "elasto": [49],
       "aero": [49]

--- a/data/IEA15MW/turbine_disk.json
+++ b/data/IEA15MW/turbine_disk.json
@@ -4,6 +4,7 @@
     "fpm": false,
     "inertia_total": 3.524605e8,
     "mass_blades_total": 195e3,
+    "radius": 117,
     "performance_file": "./controller/Cp_Ct_Cq.IEA15MW_modified.txt",
     "discretization": {
       "elasto": [49],

--- a/data/IEA15MW/turbine_disk.json
+++ b/data/IEA15MW/turbine_disk.json
@@ -1,32 +1,16 @@
 ﻿{
+  "aero": {
+    "solver": "disk",
+    "options": {
+      "performance_file": "./controller/Cp_Ct_Cq.IEA15MW_modified.txt"
+    }
+},
   "rotor": {
     "type": "disk",
     "fpm": false,
     "inertia_total": 3.524605e8,
     "mass_blades_total": 195e3,
-    "radius": 117,
-    "performance_file": "./controller/Cp_Ct_Cq.IEA15MW_modified.txt",
-    "discretization": {
-      "elasto": [49],
-      "aero": [49]
-    },
-    "blades": [
-      {
-        "file": "./blade.json",
-        "initial_pitch": 0,
-        "precone": -4.0
-      },
-      {
-        "file": "./blade.json",
-        "initial_pitch": 0,
-        "precone": -4.0
-      },
-      {
-        "file": "./blade.json",
-        "initial_pitch": 0,
-        "precone": -4.0
-      }
-    ]
+    "radius": 117
   },
   "rna": {
     "initial_pitch_collective": 0,

--- a/data/IEA15MW/turbine_disk.json
+++ b/data/IEA15MW/turbine_disk.json
@@ -7,10 +7,11 @@
 },
   "rotor": {
     "type": "disk",
-    "fpm": false,
-    "inertia_total": 3.524605e8,
-    "mass_blades_total": 195e3,
-    "radius": 117
+    "options": {
+      "inertia_blades": 3.5148698e8,
+      "mass_blades": 195e3,
+      "radius": 117
+    }
   },
   "rna": {
     "initial_pitch_collective": 0,

--- a/data/IEA15MW/turbine_floating.json
+++ b/data/IEA15MW/turbine_floating.json
@@ -9,10 +9,9 @@
   },
   "rotor": {
     "type": "fea",
-    "fpm": false,
-    "inertia_total": 3.524605e8,
-    "mass_blades_total": 195e3,
-    "radius": 117,
+    "options": {
+      "fpm": false
+    },
     "discretization": {
       "elasto": [49],
       "aero": [49]

--- a/data/IEA15MW/turbine_floating.json
+++ b/data/IEA15MW/turbine_floating.json
@@ -1,9 +1,18 @@
 ﻿{
+  "aero": {
+    "solver": "BEMT",
+    "options": {
+      "hub_loss": true,
+      "tip_loss": true,
+      "tower_shadow": true
+    }
+  },
   "rotor": {
     "type": "fea",
     "fpm": false,
     "inertia_total": 3.524605e8,
     "mass_blades_total": 195e3,
+    "radius": 117,
     "discretization": {
       "elasto": [49],
       "aero": [49]

--- a/data/IEA15MW/turbine_nocontrol.json
+++ b/data/IEA15MW/turbine_nocontrol.json
@@ -9,10 +9,9 @@
   },
   "rotor": {
     "type": "fea",
-    "fpm": false,
-    "inertia_total": 3.524605e8,
-    "mass_blades_total": 195e3,
-    "radius": 117,
+    "options": {
+      "fpm": false
+    },
     "discretization": {
       "elasto": [49],
       "aero": [49]

--- a/data/IEA15MW/turbine_nocontrol_aerodyn.json
+++ b/data/IEA15MW/turbine_nocontrol_aerodyn.json
@@ -8,10 +8,9 @@
   },
   "rotor": {
     "type": "fea",
-    "fpm": false,
-    "inertia_total": 3.524605e8,
-    "mass_blades_total": 195e3,
-    "radius": 117,
+    "options": {
+      "fpm": false
+    },
     "discretization": {
       "elasto": [49],
       "aero": [49]

--- a/data/IEA15MW/turbine_nocontrol_aerodyn.json
+++ b/data/IEA15MW/turbine_nocontrol_aerodyn.json
@@ -1,10 +1,9 @@
 ﻿{
   "aero": {
-    "solver": "BEMT",
+    "solver": "aerodyn",
     "options": {
-      "hub_loss": true,
-      "tip_loss": true,
-      "tower_shadow": true
+      "file_aerodyn": "./aerodyn/IEA-15-240-RWT_AeroDyn15.dat",
+      "file_inflowwind": "./aerodyn/IEA-15-240-RWT_InflowWind.dat"
     }
   },
   "rotor": {
@@ -36,7 +35,7 @@
     ]
   },
   "rna": {
-    "initial_pitch_collective": 0,
+    "initial_pitch_collective": 0.31416,
     "file": "./rna.json"
   },
   "tower": {
@@ -47,6 +46,10 @@
     "file": "./tower.json"
   },
   "controller": {
-    "type": ""
+    "type": "",
+    "options": {
+      "infile": "./controller/DISCON.IN",
+      "libfile": "./controller/libdiscon.so"
+    }
   }
 }

--- a/data/IEA15MW/turbine_nocontrol_rigid.json
+++ b/data/IEA15MW/turbine_nocontrol_rigid.json
@@ -9,10 +9,10 @@
   },
   "rotor": {
     "type": "rigid",
-    "fpm": false,
-    "inertia_total": 3.524605e8,
-    "mass_blades_total": 195e3,
-    "radius": 117,
+    "options": {
+      "inertia_blades": 3.5148698e8,
+      "mass_blades": 195e3
+    },
     "discretization": {
       "elasto": [49],
       "aero": [49]

--- a/data/IEA15MW/turbine_nocontrol_rigid.json
+++ b/data/IEA15MW/turbine_nocontrol_rigid.json
@@ -1,9 +1,18 @@
 ﻿{
+  "aero": {
+    "solver": "BEMT",
+    "options": {
+      "hub_loss": true,
+      "tip_loss": true,
+      "tower_shadow": true
+    }
+  },
   "rotor": {
     "type": "rigid",
     "fpm": false,
     "inertia_total": 3.524605e8,
     "mass_blades_total": 195e3,
+    "radius": 117,
     "discretization": {
       "elasto": [49],
       "aero": [49]

--- a/include/seahowl/aero/aerodyn_adapter.h
+++ b/include/seahowl/aero/aerodyn_adapter.h
@@ -2,13 +2,16 @@
 
 #include <iostream>
 #include <cstring>
+#include <memory>
 
 #include <seahowl/commons/numerics.h>
+#include <seahowl/aero/turbine_aero.h>
+#include <seahowl/aero/rotor_aero.h>
 
 namespace seahowl {
-namespace aero {
-class TurbineAero;
-}  // namespace aero
+namespace env {
+class FluidModel;
+}  // namespace env
 }  // namespace seahowl
 
 /// <summary>
@@ -257,6 +260,30 @@ class AeroDynAdapter {
     void setMotionNac(seahowl::aero::TurbineAero& turbine);
     void setMotionRoot(seahowl::aero::TurbineAero& turbine);
     void setMotionMesh(seahowl::aero::TurbineAero& turbine);
+};
+
+class TurbineAeroDyn : public TurbineAero {
+  public:
+    /** @brief AeroDyn adapter. */
+    std::shared_ptr<seahowl::aero::AeroDynAdapter> aerodyn;
+    /** @brief Option to save VTK in AeroDyn, 0: none; 1: init only; 2: animation. */
+    int WrVTK = 0;
+    /** @brief VTK save type, 1: surface; 2: lines; 3: both. */
+    int WrVTK_Type = 1;
+    /** @brief VTK save time step. */
+    double WrVTK_dt;
+
+    TurbineAeroDyn();
+    void initialize(double time, double dt) override;
+    void compute_aero_loads(const env::FluidModel& wind_model, double time) override;
+};
+
+class RotorAeroDyn : public RotorAeroBEMT {
+  public:
+    float* loads_aerodyn;
+
+    RotorAeroDyn(TowerAero& tower_ref);
+    virtual void compute_aero_loads(const env::FluidModel& wind_model, double time) override;
 };
 
 }  // namespace aero

--- a/include/seahowl/aero/aerodyn_adapter.h
+++ b/include/seahowl/aero/aerodyn_adapter.h
@@ -124,9 +124,9 @@ struct AeroDynInflowLib {
     // aerodynamic load computed on mesh point
     float* MeshFrc;
 
-    void SetADINFILE(std::string name);
-    void SetIFWINFILE(std::string name);
-    void SetOUTNAME(std::string name);
+    void SetADINFILE(const std::string& name);
+    void SetIFWINFILE(const std::string& name);
+    void SetOUTNAME(const std::string& name);
 
     void SetTime(double time);
     void SetTimeStep(double dt);
@@ -158,7 +158,7 @@ struct AeroDynInflowLib {
     void Update();
     void End();
 
-  private:
+  public:
     // Input file string
     std::string ADinputFileString;
     std::string IfWinputFileString;
@@ -248,9 +248,11 @@ class AeroDynAdapter {
     seahowl::aero::AeroDynInflowLib pImpl;
     std::vector<Vector3d> loads;
 
+    AeroDynAdapter();
     AeroDynAdapter(std::string AerodynInfile, std::string InflowInfile);
     ~AeroDynAdapter();
 
+    void set_infiles(const std::string& AerodynInfile, const std::string& InflowInfile);
     void initialize(double time, double dt, seahowl::aero::TurbineAero& turbine);
     void calcul(double time, seahowl::aero::TurbineAero& turbine);
     void update(double time, double dt, seahowl::aero::TurbineAero& turbine);
@@ -265,7 +267,7 @@ class AeroDynAdapter {
 class TurbineAeroDyn : public TurbineAero {
   public:
     /** @brief AeroDyn adapter. */
-    std::shared_ptr<seahowl::aero::AeroDynAdapter> aerodyn;
+    seahowl::aero::AeroDynAdapter aerodyn;
     /** @brief Option to save VTK in AeroDyn, 0: none; 1: init only; 2: animation. */
     int WrVTK = 0;
     /** @brief VTK save type, 1: surface; 2: lines; 3: both. */

--- a/include/seahowl/aero/rotor_aero.h
+++ b/include/seahowl/aero/rotor_aero.h
@@ -19,60 +19,46 @@ class FluidModel;
 namespace seahowl {
 namespace aero {
 
-// The structure containing the coefficients for the rotor disk
-struct DiskCoefficients {
-    // Member variables
-    Eigen::MatrixXd thrust_coeff;
-    Eigen::MatrixXd power_coeff;
-    Eigen::VectorXd tsr_list;
-    Eigen::VectorXd pitch_list;
-    seahowl::Vector2d get_disk_coefficients_from_table(double TSR, double pitch);
-};
-
-/**
- * @brief Rotor-Nacelle Assembly (RNA) of wind turbine as an aero component.
- */
-class RotorNacelleAssemblyAero {
+class RotorAero {
   public:
     /** @brief List of blades. */
     std::vector<std::shared_ptr<seahowl::aero::BladeAero>> blades;
     /** @brief Hub. */
     EntityDynamicEigen body_hub;
-    /** @brief Hub. */
-    EntityDynamicEigen body_nacelle;
-    /** @brief Total radius of the rotor (hub + blades). */
-    double radius = 0.0;
     /** @brief Radius of hub. */
     double hub_radius = 0.0;
+    /** @brief Aerodynamic torque on hub. */
+    double hub_torque_aero = 0.0;
+    /** @brief Aerodynamic thrust on hub. */
+    double hub_thrust_aero = 0.0;
+    /** @brief Total radius of the rotor (hub + blades). */
+    double radius = 0.0;
     /** @brief Azimuth of rotor. */
     double azimuth = 0.0;
-
     /** @brief Collective pitch of blades (in radians). */
-    double pitch_collective = 0;
+    double pitch_collective = 0.0;
 
-    /** @brief The tables of actuator disk coefficients. */
-    DiskCoefficients disk_coefficients;
+    virtual void build() = 0;
+    virtual void initialize() = 0;
+    virtual void compute_aero_loads(const env::FluidModel& wind_model, double time) = 0;
+};
 
-    /** @brief Aerodynamic torque from disk coeffs. */
-    double torque_aero = 0;
+class RotorAeroBEMT : public RotorAero {
+  public:
+    /** @brief Reference to tower aero. */
+    TowerAero& tower_ref;
+    /** Whether to take tip loss into account or not. */
+    bool has_tip_loss = true;
+    /** Whether to take hub loss into account or not. */
+    bool has_hub_loss = true;
+    /** Whether to take tower shadow into account or not. */
+    bool has_tower_shadow = true;
 
-    /** @brief Aerodynamic thrust from disk coeffs. */
-    double thrust_aero = 0;
+    RotorAeroBEMT(TowerAero& tower_ref);
 
-    /**
-     * @brief Constructor.
-     */
-    RotorNacelleAssemblyAero();
-
-    /**
-     * @brief Builds the rotor.
-     */
-    void build();
-
-    /**
-     * @brief Initialize rotor related variables with current configuration.
-     */
-    void initialize();
+    virtual void build() override;
+    virtual void initialize() override;
+    virtual void compute_aero_loads(const env::FluidModel& wind_model, double time) override;
 
     /**
      * @brief Computes chord solidity on all aero nodes of blades.
@@ -93,55 +79,52 @@ class RotorNacelleAssemblyAero {
      * @brief Computes radius on all aero nodes of blades.
      */
     void compute_radii();
+};
+
+// The structure containing the coefficients for the rotor disk
+struct DiskCoefficients {
+    // Member variables
+    Eigen::MatrixXd thrust_coeff;
+    Eigen::MatrixXd power_coeff;
+    Eigen::VectorXd tsr_list;
+    Eigen::VectorXd pitch_list;
+    seahowl::Vector2d get_disk_coefficients_from_table(double TSR, double pitch);
+};
+
+class RotorAeroDisk : public RotorAero {
+  public:
+    /** @brief The tables of actuator disk coefficients. */
+    DiskCoefficients disk_coefficients;
+
+    virtual void build() override{};
+    void initialize() override;
+    void compute_aero_loads(const env::FluidModel& wind_model, double time) override;
+};
+
+/**
+ * @brief Rotor-Nacelle Assembly (RNA) of wind turbine as an aero component.
+ */
+class RotorNacelleAssemblyAero {
+  public:
+    /** @brief Rotor. */
+    std::shared_ptr<RotorAero> rotor;
+    /** @brief Nacelle. */
+    EntityDynamicEigen body_nacelle;
 
     /**
-     * @brief Computes wind loads on all aero nodes of blades.
-     *
-     * @param[in] wind_model Wind model to use for retrieving uninduced wind velocity at nodes.
-     * @param[in] time Time of simulation.
-     * @param[in] tower_aero Tower reference (for tower shadow effects).
-     * @param[in] tower_shadow Whether to take tower shadow effect into account or not.
-     * @param[in] tip_loss Whether to take tip loss into account or not.
-     * @param[in] hub_loss Whether to take hub loss into account or not.
+     * @brief Constructor.
      */
-    void compute_aero_loads(const env::FluidModel& wind_model,
-                            double time,
-                            const TowerAero& tower_aero,
-                            bool tower_shadow = true,
-                            bool tip_loss = true,
-                            bool hub_loss = true);
+    RotorNacelleAssemblyAero();
 
     /**
-     * @brief Computes wind loads on rotor.
-     *
-     * @param[in] wind_model Wind model to use for retrieving uninduced wind velocity at nodes.
-     * @param[in] time Time of simulation.
-     * @param[in] pitch collective pitch rotor (for getting performance from table).
-     * @param[in] RPM Rotor speed (for getting performance from table).
-     *
+     * @brief Builds rotor.
      */
-    void compute_aero_loads_disk(const env::FluidModel& wind_model, double time);
+    void build();
 
-#ifdef HAVE_AERODYN
     /**
-     * @brief Computes wind loads on all aero nodes of blades using AeroDyn.
-     *
-     * @param[out] LoadAeroDyn Array of loads.
-     * @param[in] wind_model Wind model to use for retrieving uninduced wind velocity at nodes.
-     * @param[in] time Time of simulation.
-     * @param[in] tower_aero Tower reference (for tower shadow effects).
-     * @param[in] tower_shadow Whether to take tower shadow effect into account or not.
-     * @param[in] tip_loss Whether to take tip loss into account or not.
-     * @param[in] hub_loss Whether to take hub loss into account or not.
+     * @brief Initializes rotor related variables with current configuration.
      */
-    void compute_aero_loads(float* LoadAeroDyn,
-                            env::FluidModel& wind_model,
-                            double time,
-                            const TowerAero& tower_aero,
-                            bool tower_shadow = true,
-                            bool tip_loss = true,
-                            bool hub_loss = true);
-#endif
+    void initialize();
 };
 
 }  // namespace aero

--- a/include/seahowl/aero/system_aero.h
+++ b/include/seahowl/aero/system_aero.h
@@ -14,7 +14,7 @@ namespace aero {
 class SystemAero {
   public:
     /** @brief Turbines in system. */
-    std::deque<TurbineAero> turbines{};
+    std::deque<std::shared_ptr<TurbineAero>> turbines{};
 };
 
 }  // namespace aero

--- a/include/seahowl/aero/tower_aero.h
+++ b/include/seahowl/aero/tower_aero.h
@@ -57,7 +57,7 @@ class TowerAero {
     /**
      * @brief Compute wind loads on tower using Morison's approach on cylindrical elements.
      */
-    void compute_aero_loads(env::FluidModel& wind_model, double time);
+    void compute_aero_loads(const env::FluidModel& wind_model, double time);
 };
 
 }  // namespace aero

--- a/include/seahowl/aero/turbine_aero.h
+++ b/include/seahowl/aero/turbine_aero.h
@@ -2,16 +2,13 @@
 
 #include "seahowl/aero/rotor_aero.h"
 #include "seahowl/aero/tower_aero.h"
-#ifdef HAVE_AERODYN
-    #include "seahowl/aero/aerodyn_adapter.h"
-#endif
 
 #include <vector>
 
 // forward declarations
 namespace seahowl {
 namespace env {
-    class WindModel;
+class WindModel;
 }  // namespace env
 }  // namespace seahowl
 
@@ -22,7 +19,7 @@ namespace seahowl {
 namespace aero {
 
 class ComponentAero {
-    virtual void compute_aero_loads(env::FluidModel& wind_model, double time){};
+    virtual void compute_aero_loads(const env::FluidModel& wind_model, double time){};
 };
 
 /**
@@ -38,22 +35,6 @@ class TurbineAero : public ComponentAero {
     seahowl::aero::RotorNacelleAssemblyAero rna;
     /** @brief Tower of the turbine. */
     seahowl::aero::TowerAero tower;
-
-    /** @brief Whether to use AeroDyn or not. */
-    bool use_aerodyn = false;
-
-    /** @brief Whether to use DiskTheory or not. */
-    bool use_disktheory = false;
-#ifdef HAVE_AERODYN
-    /** @brief AeroDyn adapter (only used if AeroDyn is enabled). */
-    std::shared_ptr<seahowl::aero::AeroDynAdapter> aerodyn;
-    /** @brief Option to save VTK in AeroDyn, 0: none; 1: init only; 2: animation. */
-    int WrVTK = 0;
-    /** @brief VTK save type, 1: surface; 2: lines; 3: both. */
-    int WrVTK_Type = 1;
-    /** @brief VTK save time step. */
-    double WrVTK_dt;
-#endif
 
     /**
      * @brief Constructor.
@@ -73,7 +54,7 @@ class TurbineAero : public ComponentAero {
      * @param[in] time Time of the simulation (usually 0 at init).
      * @param[in] dt Time step length.
      */
-    void initialize(double time, double dt);
+    virtual void initialize(double time, double dt);
 
     /**
      * @brief Computes aero loads on turbine.
@@ -81,7 +62,7 @@ class TurbineAero : public ComponentAero {
      * @param[in] wind_model Wind model to use for applying aero loads.
      * @param[in] time Time of simulation.
      */
-    virtual void compute_aero_loads(env::FluidModel& wind_model, double time) override;
+    virtual void compute_aero_loads(const env::FluidModel& wind_model, double time) override;
 };
 
 }  // namespace aero

--- a/include/seahowl/core/turbine.h
+++ b/include/seahowl/core/turbine.h
@@ -72,7 +72,7 @@ class Turbine : public ComponentDynamic {
      * @param[in] time Time of the simulation (usually 0 at init).
      * @param[in] dt Time step length.
      */
-    void initialize(double time, double dt) override;
+    virtual void initialize(double time, double dt) override;
 
     /**
      * @brief Prestep for turbine, called before elastodynamic stepping.

--- a/include/seahowl/core/turbine_floating.h
+++ b/include/seahowl/core/turbine_floating.h
@@ -39,7 +39,7 @@ class TurbineFloating : public Turbine {
      * @param[in] time Time of the simulation (usually 0 at init).
      * @param[in] dt Time step length.
      */
-    void initialize(double time, double dt) override;
+    virtual void initialize(double time, double dt) override;
 
     /**
      * @brief Prestep for turbine, called before elastodynamic stepping.

--- a/include/seahowl/io/read_json.h
+++ b/include/seahowl/io/read_json.h
@@ -140,6 +140,14 @@ void populate_rna_from_json(const std::string& filepath, seahowl::core::RotorNac
  * @brief Populates turbine given a json file.
  *
  * @param[in] filepath Path of the json file describing the turbine.
+ * @param[out] system_core System to add the new turbine.
+ */
+void add_turbine_to_system_from_json(const std::string& filepath, seahowl::core::System& system_core);
+
+/**
+ * @brief Populates turbine given a json file.
+ *
+ * @param[in] filepath Path of the json file describing the turbine.
  * @param[out] turbine Turbine to populate.
  */
 void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turbine& turbine);
@@ -156,6 +164,6 @@ void populate_environmental_conditions_from_json(const std::string& filepath, se
  * @brief Returns System instance given a json file.
  *
  * @param[in] filepath Path of the json file describing the system.
- * @param[out] system System to populate.
+ * @param[out] system_core System to populate.
  */
 void populate_system_from_json(const std::string& filepath_main, seahowl::core::System& system_core);

--- a/include/seahowl/io/read_rotor_perf.h
+++ b/include/seahowl/io/read_rotor_perf.h
@@ -10,4 +10,4 @@
  * @param[in] filepath Path of the .txt file describing the rotor disk performance.
  * @param[in] aero Object of class seahowl::aero::RotorAero
  */
-void get_disk_perf_from_table(std::string filepath, seahowl::aero::RotorNacelleAssemblyAero& aero);
+void get_disk_perf_from_table(std::string filepath, seahowl::aero::RotorAeroDisk& aero);

--- a/scripts/converters.py
+++ b/scripts/converters.py
@@ -891,6 +891,10 @@ def convert_openfast_fst(filename, save_directory=None, use_beamdyn=True):
                             f3.writelines(lines2)
 
         turbine_json = {
+            "aero": {
+                "solver": "BEMT",
+                "options": {"hub_loss": True, "tip_loss": True, "tower_shadow": True},
+            },
             "rotor": {
                 "fpm": False,
                 "type": "fea",

--- a/scripts/converters.py
+++ b/scripts/converters.py
@@ -896,8 +896,10 @@ def convert_openfast_fst(filename, save_directory=None, use_beamdyn=True):
                 "options": {"hub_loss": True, "tip_loss": True, "tower_shadow": True},
             },
             "rotor": {
-                "fpm": False,
                 "type": "fea",
+                "options": {
+                    "fpm": False,
+                },
                 "discretization": {
                     "elasto": blade_elasto_json["discretization_elasto"],
                     "aero": blade_aero_json["discretization_aero"],

--- a/src/aero/aerodyn_adapter.cpp
+++ b/src/aero/aerodyn_adapter.cpp
@@ -9,22 +9,24 @@
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <spdlog/spdlog.h>
 // #include <numeric>
 // #include <sstream>
 
-seahowl::aero::AeroDynAdapter::AeroDynAdapter(std::string AerodynInfile, std::string InflowInfile) {
-    std::cout << "Initialising Aerodyn15" << std::endl;
-
+seahowl::aero::AeroDynAdapter::AeroDynAdapter() {
+    spdlog::debug("Initialising Aerodyn15 adapter");
+    pImpl = AeroDynInflowLib();
     pImpl.ADinputFilePassed = false;
     pImpl.IfWinputFilePassed = false;
-
-    pImpl.SetADINFILE(AerodynInfile);
-    pImpl.SetIFWINFILE(InflowInfile);
-
     pImpl.SetOUTNAME("Turbine");
 }
 
 seahowl::aero::AeroDynAdapter::~AeroDynAdapter() {}
+
+void seahowl::aero::AeroDynAdapter::set_infiles(const std::string& AerodynInfile, const std::string& InflowInfile) {
+    pImpl.SetADINFILE(AerodynInfile);
+    pImpl.SetIFWINFILE(InflowInfile);
+}
 
 void seahowl::aero::AeroDynAdapter::initialize(double time, double dt, seahowl::aero::TurbineAero& turbine) {
     pImpl.SetTimeStep(dt);
@@ -234,28 +236,28 @@ void seahowl::aero::AeroDynInflowLib::CheckError() {
     if (ErrStat == 0) {
         return;
     } else if (ErrStat == 1) {
-        std::cout << "AeroDyn/InflowWind INFO: " << ErrMsg << std::endl;
+        spdlog::info("AeroDyn/InflowWind INFO: {}.", ErrMsg);
     } else if (ErrStat == 2) {
-        std::cerr << "AeroDyn/InflowWind WARNING: " << ErrMsg << std::endl;
+        spdlog::warn("AeroDyn/InflowWind WARNING: {}", ErrMsg);
     } else {
-        std::cerr << "AeroDyn/InflowWind ERROR: " << ErrMsg << std::endl;
+        spdlog::error("AeroDyn/InflowWind ERROR: {}.", ErrMsg);
     }
 }
 
-void seahowl::aero::AeroDynInflowLib::SetADINFILE(std::string name) {
-    std::cout << "Set Aeodyn INFILE: '" << name << "'\n";
+void seahowl::aero::AeroDynInflowLib::SetADINFILE(const std::string& name) {
+    spdlog::debug("Set AeroDyn INFILE: {}.", name);
     ADinputFileString = name;
     ADinputFileStringLength = ADinputFileString.length();
 }
 
-void seahowl::aero::AeroDynInflowLib::SetIFWINFILE(std::string name) {
-    std::cout << "Set InflowWind INFILE: '" << name << "'\n";
+void seahowl::aero::AeroDynInflowLib::SetIFWINFILE(const std::string& name) {
+    spdlog::debug("Set InflowWind INFILE: {}.", name);
     IfWinputFileString = name;
     IfWinputFileStringLength = IfWinputFileString.length();
 }
 
-void seahowl::aero::AeroDynInflowLib::SetOUTNAME(std::string name) {
-    std::cout << "Set Output filename: '" << name << "'\n";
+void seahowl::aero::AeroDynInflowLib::SetOUTNAME(const std::string& name) {
+    spdlog::debug("Set AeroDyn/InflowWind output file: {}.", name);
     strcpy(OutRootName, name.c_str());
 }
 
@@ -422,19 +424,20 @@ void seahowl::aero::AeroDynInflowLib::End() {
     // delete [] meshPos_C, meshOri_C, meshVel_C, meshAcc_C;
 }
 
-seahowl::aero::TurbineAeroDyn::TurbineAeroDyn() {
+seahowl::aero::TurbineAeroDyn::TurbineAeroDyn() : TurbineAero() {
     rna.rotor = std::make_shared<seahowl::aero::RotorAeroDyn>(tower);
 }
 
 void seahowl::aero::TurbineAeroDyn::initialize(double time, double dt) {
     TurbineAero::initialize(time, dt);
-    aerodyn->pImpl.SetVTK(WrVTK, WrVTK_Type, WrVTK_dt);
-    aerodyn->initialize(time, dt, *this);
+
+    aerodyn.pImpl.SetVTK(WrVTK, WrVTK_Type, WrVTK_dt);
+    aerodyn.initialize(time, dt, *this);
 }
 
 void seahowl::aero::TurbineAeroDyn::compute_aero_loads(const seahowl::env::FluidModel& wind_model, double time) {
-    aerodyn->calcul(time, *this);
-    dynamic_cast<seahowl::aero::RotorAeroDyn&>(*rna.rotor).loads_aerodyn = aerodyn->pImpl.MeshFrc;
+    aerodyn.calcul(time, *this);
+    dynamic_cast<seahowl::aero::RotorAeroDyn&>(*rna.rotor).loads_aerodyn = aerodyn.pImpl.MeshFrc;
     rna.rotor->compute_aero_loads(wind_model, time);
 }
 

--- a/src/aero/aerodyn_adapter.cpp
+++ b/src/aero/aerodyn_adapter.cpp
@@ -1,7 +1,8 @@
-#include "seahowl/aero/aerodyn_adapter.h"
+#include <seahowl/aero/aerodyn_adapter.h>
 
-#include "seahowl/aero/turbine_aero.h"
-#include "seahowl/aero/blade_aero.h"
+#include <seahowl/aero/turbine_aero.h>
+#include <seahowl/aero/blade_aero.h>
+#include <seahowl/env/fluid_models.h>
 
 #include <stdexcept>
 #include <vector>
@@ -28,7 +29,6 @@ seahowl::aero::AeroDynAdapter::~AeroDynAdapter() {}
 void seahowl::aero::AeroDynAdapter::initialize(double time, double dt, seahowl::aero::TurbineAero& turbine) {
     pImpl.SetTimeStep(dt);
     pImpl.SetTime(time);
-    pImpl.SetVTK(turbine.WrVTK, turbine.WrVTK_Type, turbine.WrVTK_dt);
     update_turbine_variables(turbine);
     pImpl.Init();
 }
@@ -69,12 +69,12 @@ void seahowl::aero::AeroDynAdapter::setMotionHub(seahowl::aero::TurbineAero& tur
     float* hubAcc_C = new float[6];
 
     // Get the information about hub
-    auto hubPos = turbine.rna.body_hub.get_position();
-    auto hubOri = turbine.rna.body_hub.get_rotation().toRotationMatrix();  // get a rotation matrix 3x3
-    auto hubTranVel = turbine.rna.body_hub.get_velocity();
-    auto hubRotVel = turbine.rna.body_hub.get_rotational_velocity(false);  // in global frame
-    auto hubTranAcc = turbine.rna.body_hub.get_acceleration();
-    auto hubRotAcc = turbine.rna.body_hub.get_rotational_acceleration(false);  // in global frame
+    auto hubPos = turbine.rna.rotor->body_hub.get_position();
+    auto hubOri = turbine.rna.rotor->body_hub.get_rotation().toRotationMatrix();  // get a rotation matrix 3x3
+    auto hubTranVel = turbine.rna.rotor->body_hub.get_velocity();
+    auto hubRotVel = turbine.rna.rotor->body_hub.get_rotational_velocity(false);  // in global frame
+    auto hubTranAcc = turbine.rna.rotor->body_hub.get_acceleration();
+    auto hubRotAcc = turbine.rna.rotor->body_hub.get_rotational_acceleration(false);  // in global frame
 
     for (int i = 0; i < 3; i++) {
         hubPos_C[i] = hubPos[i];
@@ -139,19 +139,20 @@ void seahowl::aero::AeroDynAdapter::setMotionNac(seahowl::aero::TurbineAero& tur
 }
 
 void seahowl::aero::AeroDynAdapter::setMotionRoot(seahowl::aero::TurbineAero& turbine) {
-    auto nblades = turbine.rna.blades.size();
+    auto nblades = turbine.rna.rotor->blades.size();
     float* bldRootPos_C = new float[3 * nblades];
     double* bldRootOri_C = new double[9 * nblades];
     float* bldRootVel_C = new float[6 * nblades];
     float* bldRootAcc_C = new float[6 * nblades];
 
     for (int i = 0; i < nblades; i++) {
-        auto bldRootPos = turbine.rna.blades[i]->nodes[0].get_position();
-        auto bldRootOri = turbine.rna.blades[i]->nodes[0].get_rotation().toRotationMatrix();
-        auto bldRootTranVel = turbine.rna.blades[i]->nodes[0].get_velocity();
-        auto bldRootRotVel = turbine.rna.blades[i]->nodes[0].get_rotational_velocity(false);  // in global frame
-        auto bldRootTranAcc = turbine.rna.blades[i]->nodes[0].get_acceleration();
-        auto bldRootRotAcc = turbine.rna.blades[i]->nodes[0].get_rotational_acceleration(false);  // in global frame
+        auto bldRootPos = turbine.rna.rotor->blades[i]->nodes[0].get_position();
+        auto bldRootOri = turbine.rna.rotor->blades[i]->nodes[0].get_rotation().toRotationMatrix();
+        auto bldRootTranVel = turbine.rna.rotor->blades[i]->nodes[0].get_velocity();
+        auto bldRootRotVel = turbine.rna.rotor->blades[i]->nodes[0].get_rotational_velocity(false);  // in global frame
+        auto bldRootTranAcc = turbine.rna.rotor->blades[i]->nodes[0].get_acceleration();
+        auto bldRootRotAcc =
+            turbine.rna.rotor->blades[i]->nodes[0].get_rotational_acceleration(false);  // in global frame
         for (int j = 0; j < 3; j++) {
             int p = i * 3 + j;
             int q = i * 6 + j;
@@ -181,8 +182,8 @@ void seahowl::aero::AeroDynAdapter::setMotionRoot(seahowl::aero::TurbineAero& tu
 }
 
 void seahowl::aero::AeroDynAdapter::setMotionMesh(seahowl::aero::TurbineAero& turbine) {
-    auto nblades = turbine.rna.blades.size();
-    auto nMeshPerBlade = turbine.rna.blades[0]->nodes.size();
+    auto nblades = turbine.rna.rotor->blades.size();
+    auto nMeshPerBlade = turbine.rna.rotor->blades[0]->nodes.size();
     auto nMesh = nMeshPerBlade * nblades;
     float* meshPos_C = new float[3 * nMesh];
     double* meshOri_C = new double[9 * nMesh];
@@ -191,12 +192,13 @@ void seahowl::aero::AeroDynAdapter::setMotionMesh(seahowl::aero::TurbineAero& tu
 
     for (int i = 0; i < nblades; i++) {
         for (int j = 0; j < nMeshPerBlade; j++) {
-            auto meshPos = turbine.rna.blades[i]->nodes[j].get_position();
-            auto meshOri = turbine.rna.blades[i]->nodes[j].get_rotation().toRotationMatrix();
-            auto meshTranVel = turbine.rna.blades[i]->nodes[j].get_velocity();
-            auto meshRotVel = turbine.rna.blades[i]->nodes[j].get_rotational_velocity(false);  // in global frame
-            auto meshTranAcc = turbine.rna.blades[i]->nodes[j].get_acceleration();
-            auto meshRotAcc = turbine.rna.blades[i]->nodes[j].get_rotational_acceleration(false);  // in global frame
+            auto meshPos = turbine.rna.rotor->blades[i]->nodes[j].get_position();
+            auto meshOri = turbine.rna.rotor->blades[i]->nodes[j].get_rotation().toRotationMatrix();
+            auto meshTranVel = turbine.rna.rotor->blades[i]->nodes[j].get_velocity();
+            auto meshRotVel = turbine.rna.rotor->blades[i]->nodes[j].get_rotational_velocity(false);  // in global frame
+            auto meshTranAcc = turbine.rna.rotor->blades[i]->nodes[j].get_acceleration();
+            auto meshRotAcc =
+                turbine.rna.rotor->blades[i]->nodes[j].get_rotational_acceleration(false);  // in global frame
 
             auto ii = i * nMeshPerBlade + j;
             for (int k = 0; k < 3; k++) {
@@ -418,4 +420,41 @@ void seahowl::aero::AeroDynInflowLib::End() {
     // delete [] nacPos_C, nacOri_C, nacVel_C, nacAcc_C;
     // delete [] bldRootPos_C, bldRootOri_C, bldRootVel_C, bldRootAcc_C;
     // delete [] meshPos_C, meshOri_C, meshVel_C, meshAcc_C;
+}
+
+seahowl::aero::TurbineAeroDyn::TurbineAeroDyn() {
+    rna.rotor = std::make_shared<seahowl::aero::RotorAeroDyn>(tower);
+}
+
+void seahowl::aero::TurbineAeroDyn::initialize(double time, double dt) {
+    TurbineAero::initialize(time, dt);
+    aerodyn->pImpl.SetVTK(WrVTK, WrVTK_Type, WrVTK_dt);
+    aerodyn->initialize(time, dt, *this);
+}
+
+void seahowl::aero::TurbineAeroDyn::compute_aero_loads(const seahowl::env::FluidModel& wind_model, double time) {
+    aerodyn->calcul(time, *this);
+    dynamic_cast<seahowl::aero::RotorAeroDyn&>(*rna.rotor).loads_aerodyn = aerodyn->pImpl.MeshFrc;
+    rna.rotor->compute_aero_loads(wind_model, time);
+}
+
+seahowl::aero::RotorAeroDyn::RotorAeroDyn(TowerAero& tower_ref) : RotorAeroBEMT(tower_ref) {}
+
+void seahowl::aero::RotorAeroDyn::compute_aero_loads(const seahowl::env::FluidModel& wind_model, double time) {
+    // get loads from AeroDyn
+    int count_blade = -1;
+    for (auto& blade : blades) {
+        count_blade += 1;
+        int count_node = -1;
+        for (auto& node : blade->nodes) {
+            count_node += 1;
+            // store load in global frame
+            int pp = (count_blade * (blade->elements.size() + 1) + count_node) * 6;
+            node.load = Vector3d(loads_aerodyn[pp], loads_aerodyn[pp + 1], loads_aerodyn[pp + 2]);
+        }
+        // update loads of blade
+        for (int ii = 0; ii < blade->elements.size(); ii++) {
+            blade->loads[ii] = blade->elements[ii].get_load();
+        }
+    }
 }

--- a/src/aero/rotor_aero.cpp
+++ b/src/aero/rotor_aero.cpp
@@ -8,11 +8,9 @@
 #include "seahowl/env/wind_models.h"
 
 #include <cmath>
+#include <spdlog/spdlog.h>
 
-using seahowl::aero::BladeAero;
-using seahowl::aero::RotorNacelleAssemblyAero;
-using seahowl::aero::TowerAero;
-using seahowl::aero::DiskCoefficients;
+using namespace seahowl::aero;
 using seahowl::env::FluidModel;
 using seahowl::Vector3d;
 using seahowl::Vector2d;
@@ -33,6 +31,19 @@ seahowl::Vector2d DiskCoefficients::get_disk_coefficients_from_table(double TSR,
 RotorNacelleAssemblyAero::RotorNacelleAssemblyAero() {}
 
 void RotorNacelleAssemblyAero::build() {
+    rotor->build();
+}
+
+void RotorNacelleAssemblyAero::initialize() {
+    if (!rotor) {
+        std::runtime_error("Cannot initialize aero RNA without having defined and attached a rotor to it.");
+    }
+    rotor->initialize();
+}
+
+RotorAeroBEMT::RotorAeroBEMT(TowerAero& tower_ref) : tower_ref(tower_ref) {}
+
+void RotorAeroBEMT::build() {
     // build blades
     for (auto& blade : blades) {
         blade->build();
@@ -49,7 +60,7 @@ void RotorNacelleAssemblyAero::build() {
     initialize();
 }
 
-void RotorNacelleAssemblyAero::initialize() {
+void RotorAeroBEMT::initialize() {
     // compute blade elements related values
     compute_distances_from_tip();
     compute_distances_from_hub();
@@ -57,7 +68,7 @@ void RotorNacelleAssemblyAero::initialize() {
     compute_chords_solidity();
 }
 
-void RotorNacelleAssemblyAero::compute_chords_solidity() {
+void RotorAeroBEMT::compute_chords_solidity() {
     auto nblades = blades.size();
     for (auto& blade : blades) {
         for (auto& node : blade->nodes) {
@@ -67,33 +78,28 @@ void RotorNacelleAssemblyAero::compute_chords_solidity() {
     }
 }
 
-void RotorNacelleAssemblyAero::compute_distances_from_hub() {
+void RotorAeroBEMT::compute_distances_from_hub() {
     for (int ii = 0; ii < blades.size(); ii++) {
         auto& blade = blades[ii];
         blade->compute_distances_from_hub(body_hub.get_position(), hub_radius);
     }
 }
 
-void RotorNacelleAssemblyAero::compute_distances_from_tip() {
+void RotorAeroBEMT::compute_distances_from_tip() {
     for (int ii = 0; ii < blades.size(); ii++) {
         auto& blade = blades[ii];
         blade->compute_distances_from_tip();
     }
 }
 
-void RotorNacelleAssemblyAero::compute_radii() {
+void RotorAeroBEMT::compute_radii() {
     for (int ii = 0; ii < blades.size(); ii++) {
         auto& blade = blades[ii];
         blade->compute_radii(body_hub.get_position());
     }
 }
 
-void RotorNacelleAssemblyAero::compute_aero_loads(const FluidModel& wind_model,
-                                                  double time,
-                                                  const TowerAero& tower_aero,
-                                                  bool tower_shadow,
-                                                  bool tip_loss,
-                                                  bool hub_loss) {
+void RotorAeroBEMT::compute_aero_loads(const FluidModel& wind_model, double time) {
     for (auto& blade : blades) {
         auto blade_azimuth = azimuth + blade->azimuth0;
         // check that blade_azimuth is between pi and -pi
@@ -114,9 +120,9 @@ void RotorNacelleAssemblyAero::compute_aero_loads(const FluidModel& wind_model,
             Vector3d wind_velocity = wind_velocity0;
 
             // correct wind velocity with tower shadow (if activated)
-            if (tower_shadow) {
+            if (has_tower_shadow) {
                 if (blade_azimuth > PI / 2.0 || blade_azimuth < -PI / 2.0) {
-                    seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity, position, tower_aero);
+                    seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity, position, tower_ref);
                 }
             }
 
@@ -143,8 +149,8 @@ void RotorNacelleAssemblyAero::compute_aero_loads(const FluidModel& wind_model,
             auto local_velocity0 = Vector2d(local_velocity_tangent, local_velocity_normal);
 
             double tol = 1e-6;
-            if (local_velocity0.norm() < tol || (node.distance_from_tip < tol && tip_loss) ||
-                (node.distance_from_hub < tol && hub_loss)) {
+            if (local_velocity0.norm() < tol || (node.distance_from_tip < tol && has_tip_loss) ||
+                (node.distance_from_hub < tol && has_hub_loss)) {
                 node.load = Vector3d(0.0, 0.0, 0.0);
             } else {
                 // get airfoil angle with rotor plane
@@ -156,8 +162,8 @@ void RotorNacelleAssemblyAero::compute_aero_loads(const FluidModel& wind_model,
                 }
 
                 // get induced velocity
-                auto local_velocity =
-                    get_induced_velocity(node, local_velocity0, airfoil_angle, blades.size(), tip_loss, hub_loss);
+                auto local_velocity = get_induced_velocity(node, local_velocity0, airfoil_angle, blades.size(),
+                                                           has_tip_loss, has_hub_loss);
 
                 // get coefficients from angle of attack
                 double phi = seahowl::aero::get_phi(local_velocity);
@@ -200,7 +206,13 @@ void RotorNacelleAssemblyAero::compute_aero_loads(const FluidModel& wind_model,
     }
 }
 
-void RotorNacelleAssemblyAero::compute_aero_loads_disk(const FluidModel& wind_model, double time) {
+void RotorAeroDisk::initialize() {
+    if (radius <= 0.0) {
+        throw std::runtime_error("Disk actuator rotor cannot be initialized if radius is not set.");
+    }
+}
+
+void RotorAeroDisk::compute_aero_loads(const FluidModel& wind_model, double time) {
     auto pos_hub = body_hub.get_position();
     auto vel_hub = body_hub.get_velocity();
     double density = wind_model.get_fluid_density(pos_hub, time);
@@ -246,37 +258,6 @@ void RotorNacelleAssemblyAero::compute_aero_loads_disk(const FluidModel& wind_mo
 
     // auto load_global = load_n_global + load_t_global;
 
-    torque_aero = load_t;
-    thrust_aero = load_n;
+    hub_torque_aero = load_t;
+    hub_thrust_aero = load_n;
 }
-
-#ifdef HAVE_AERODYN
-void RotorNacelleAssemblyAero::compute_aero_loads(float* LoadAeroDyn,
-                                                  FluidModel& wind_model,
-                                                  double time,
-                                                  const TowerAero& tower_aero,
-                                                  bool tower_shadow,
-                                                  bool tip_loss,
-                                                  bool hub_loss) {
-    int count_blade = -1;
-    for (auto& blade : blades) {
-        count_blade += 1;
-        auto blade_azimuth = azimuth + blade->azimuth0;
-        // check that blade_azimuth is between pi and -pi
-        if (blade_azimuth < -PI || blade_azimuth > PI) {
-            blade_azimuth = abs(std::fmod((blade_azimuth + 3 * PI), 2 * PI)) - PI;
-        }
-        int count_node = -1;
-        for (auto& node : blade->nodes) {
-            count_node += 1;
-            // store load in global frame
-            int pp = (count_blade * (blade->elements.size() + 1) + count_node) * 6;
-            node.load = Vector3d(LoadAeroDyn[pp], LoadAeroDyn[pp + 1], LoadAeroDyn[pp + 2]);
-        }
-        // update loads of blade
-        for (int ii = 0; ii < blade->elements.size(); ii++) {
-            blade->loads[ii] = blade->elements[ii].get_load();
-        }
-    }
-}
-#endif

--- a/src/aero/tower_aero.cpp
+++ b/src/aero/tower_aero.cpp
@@ -52,7 +52,7 @@ void TowerAero::build() {
     }
 }
 
-void TowerAero::compute_aero_loads(FluidModel& wind_model, double time) {
+void TowerAero::compute_aero_loads(const FluidModel& wind_model, double time) {
     for (int ii = 0; ii < elements.size(); ii++) {
         auto& element = elements[ii];
         auto& properties = element.properties;

--- a/src/aero/turbine_aero.cpp
+++ b/src/aero/turbine_aero.cpp
@@ -13,31 +13,9 @@ void TurbineAero::build() {
     tower.build();
 }
 
-void TurbineAero::initialize(double time, double dt) {
-#ifdef HAVE_AERODYN
-    if (use_aerodyn) {
-        aerodyn->initialize(time, dt, *this);
-    }
-#endif
-}
+void TurbineAero::initialize(double time, double dt) {}
 
-void TurbineAero::compute_aero_loads(FluidModel& wind_model, double time) {
-#ifdef HAVE_AERODYN
-    if (use_aerodyn) {
-        aerodyn->calcul(time, *this);
-        rna.compute_aero_loads(aerodyn->pImpl.MeshFrc, wind_model, time, tower, true, true, true);
-    } else {
-        if (use_disktheory)
-            rna.compute_aero_loads_disk(wind_model, time);
-        else
-            rna.compute_aero_loads(wind_model, time, tower, true, true, true);
-    }
-#else
-
-    if (use_disktheory)
-        rna.compute_aero_loads_disk(wind_model, time);
-    else
-        rna.compute_aero_loads(wind_model, time, tower, true, true, true);
-#endif
+void TurbineAero::compute_aero_loads(const FluidModel& wind_model, double time) {
+    rna.rotor->compute_aero_loads(wind_model, time);
     tower.compute_aero_loads(wind_model, time);
 }

--- a/src/bindings/pyseahowl_aero.cpp
+++ b/src/bindings/pyseahowl_aero.cpp
@@ -34,9 +34,12 @@ void initialize_pyseahowl_aero(py::module& m) {
     py::class_<seahowl::aero::RotorNacelleAssemblyAero, std::shared_ptr<seahowl::aero::RotorNacelleAssemblyAero>>(
         m_aero, "RotorNacelleAssemblyAero")
         .def(py::init<>())
-        .def_readwrite("blades", &seahowl::aero::RotorNacelleAssemblyAero::blades)
-        .def_readonly("body_hub", &seahowl::aero::RotorNacelleAssemblyAero::body_hub)
         .def_readonly("body_nacelle", &seahowl::aero::RotorNacelleAssemblyAero::body_nacelle);
+
+    // aero/rotor_aero.h
+    py::class_<seahowl::aero::RotorAero, std::shared_ptr<seahowl::aero::RotorAero>>(m_aero, "RotorAero")
+        .def_readwrite("blades", &seahowl::aero::RotorAero::blades)
+        .def_readonly("body_hub", &seahowl::aero::RotorAero::body_hub);
 
     // aero/turbine_aero.h
     py::class_<seahowl::aero::TurbineAero, std::shared_ptr<seahowl::aero::TurbineAero>>(m_aero, "TurbineAero")

--- a/src/core/rotor.cpp
+++ b/src/core/rotor.cpp
@@ -35,6 +35,10 @@ void RotorNacelleAssembly::prestep(double time, double dt) {
     for (auto& blade : blades) {
         blade->prestep(time, dt);
     }
+
+    // apply extra torque and thrust (if any) to hub
+    elasto.rotor->body_hub->accumulate_torque(Vector3d(aero.rotor->hub_torque_aero, 0, 0), true);
+    elasto.rotor->body_hub->accumulate_force(Vector3d(aero.rotor->hub_thrust_aero, 0, 0), true);
 }
 
 void RotorNacelleAssembly::poststep(double time, double dt) {
@@ -46,16 +50,16 @@ void RotorNacelleAssembly::poststep(double time, double dt) {
 
 void RotorNacelleAssembly::update_positions_aero() {
     // pitch collective
-    aero.pitch_collective = elasto.rotor->pitch_collective;
+    aero.rotor->pitch_collective = elasto.rotor->pitch_collective;
     // azimuth
-    aero.azimuth = elasto.get_azimuth();
+    aero.rotor->azimuth = elasto.get_azimuth();
     // body_hub
-    aero.body_hub.set_position(elasto.rotor->body_hub->get_position());
-    aero.body_hub.set_rotation(elasto.rotor->body_hub->get_rotation());
-    aero.body_hub.set_velocity(elasto.rotor->body_hub->get_velocity());
-    aero.body_hub.set_acceleration(elasto.rotor->body_hub->get_acceleration());
-    aero.body_hub.set_rotational_velocity(elasto.rotor->body_hub->get_rotational_velocity());
-    aero.body_hub.set_rotational_acceleration(elasto.rotor->body_hub->get_rotational_acceleration());
+    aero.rotor->body_hub.set_position(elasto.rotor->body_hub->get_position());
+    aero.rotor->body_hub.set_rotation(elasto.rotor->body_hub->get_rotation());
+    aero.rotor->body_hub.set_velocity(elasto.rotor->body_hub->get_velocity());
+    aero.rotor->body_hub.set_acceleration(elasto.rotor->body_hub->get_acceleration());
+    aero.rotor->body_hub.set_rotational_velocity(elasto.rotor->body_hub->get_rotational_velocity());
+    aero.rotor->body_hub.set_rotational_acceleration(elasto.rotor->body_hub->get_rotational_acceleration());
     // body_nacelle
     aero.body_nacelle.set_position(elasto.body_nacelle->get_position());
     aero.body_nacelle.set_rotation(elasto.body_nacelle->get_rotation());

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -30,11 +30,6 @@ void Turbine::initialize(double time, double dt) {
 void Turbine::prestep(double time, double dt) {
     rna.prestep(time, dt);
     tower.prestep(time, dt);
-
-    if (aero.use_disktheory) {
-        rna.elasto.rotor->body_hub->accumulate_torque(Vector3d(rna.aero.torque_aero, 0, 0), true);
-        rna.elasto.rotor->body_hub->accumulate_force(Vector3d(rna.aero.thrust_aero, 0, 0), true);
-    }
 }
 
 void Turbine::poststep(double time, double dt) {

--- a/src/env/inflowwind_adapter.cpp
+++ b/src/env/inflowwind_adapter.cpp
@@ -3,7 +3,6 @@
 #include <stdexcept>
 #include <vector>
 #include <string>
-#include <iostream>
 #include <fstream>
 #include <spdlog/spdlog.h>
 
@@ -39,7 +38,7 @@ seahowl::Vector3d InflowWindAdapter::get_fluid_velocity(const seahowl::Vector3d&
 }
 
 void InflowWindLib::SetIFWINFILE(std::string name) {
-    spdlog::info("Set InflowWind INFILE: {name}.", name);
+    spdlog::info("Set InflowWind INFILE: {}.", name);
     std::ifstream file(name);
     if (!file.is_open()) {
         throw std::runtime_error("Failed to open inflowwind input file.");
@@ -70,11 +69,11 @@ void InflowWindLib::CheckError() {
     if (ErrStat == 0) {
         return;
     } else if (ErrStat == 1) {
-        std::cout << "InflowWind INFO: " << ErrMsg << std::endl;
+        spdlog::info("InflowWind INFO: {}.", ErrMsg);
     } else if (ErrStat == 2) {
-        std::cerr << "InflowWind WARNING: " << ErrMsg << std::endl;
+        spdlog::warn("InflowWind WARNING: {}.", ErrMsg);
     } else {
-        std::cerr << "InflowWind ERROR: " << ErrMsg << std::endl;
+        spdlog::error("InflowWind ERROR: {}.", ErrMsg);
     }
 }
 

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -477,8 +477,9 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
     }
 
     // check rotor type
+    auto rotor_options = rotor_json.at("options");
     if (rotor_json.at("type") == "fea") {
-        if (rotor_json.at("fpm") == true) {
+        if (rotor_options.at("fpm") == true) {
             spdlog::info("Rotor type: finite element blades (FPM).");
         } else {
             spdlog::info("Rotor type: finite element blades.");
@@ -505,7 +506,7 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
                 blade_elasto = std::make_shared<seahowl::elasto::BladeElastoFEA>();
                 auto& blade_elasto_fea = dynamic_cast<seahowl::elasto::BladeElastoFEA&>(*blade_elasto);
                 rotor_json.at("discretization").at("elasto").get_to(blade_elasto_fea.discretization_fractions);
-                rotor_json.at("fpm").get_to(blade_elasto_fea.fpm_mode);
+                rotor_options.at("fpm").get_to(blade_elasto_fea.fpm_mode);
             } else if (rotor_json.at("type").get<std::string>() == "rigid") {
                 blade_elasto = std::make_shared<seahowl::elasto::BladeElastoRigid>();
             }
@@ -535,21 +536,23 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
 
     // update info if rotor is rigid
     if (rotor_json.at("type").get<std::string>() == "rigid" || rotor_json.at("type").get<std::string>() == "disk") {
-        if (!rotor_json.contains("inertia_total")) {
-            throw std::runtime_error("The \"inertia_total\" key must be provided for rigid/disk rotors.");
+        if (!rotor_options.contains("inertia_blades")) {
+            throw std::runtime_error(
+                "The \"inertia_blades\" key (rotor options) must be provided for rigid/disk rotors.");
         }
-        if (!rotor_json.contains("mass_blades_total")) {
-            throw std::runtime_error("The \"mass_blades_total\" key must be given for rigid/disk rotors.");
+        if (!rotor_options.contains("mass_blades")) {
+            throw std::runtime_error("The \"mass_blades\" key (rotor options) must be given for rigid/disk rotors.");
         }
-        auto rotor_inertia = rotor_json.at("inertia_total").get<double>();
-        turbine.rna.elasto.rotor->hub.inertia = rotor_inertia;
-        auto blades_mass = rotor_json.at("mass_blades_total").get<double>();
+        auto blades_inertia = rotor_options.at("inertia_blades").get<double>();
+        turbine.rna.elasto.rotor->hub.inertia += blades_inertia;
+        auto blades_mass = rotor_options.at("mass_blades").get<double>();
         turbine.rna.elasto.rotor->hub.mass += blades_mass;
         if (rotor_json.at("type").get<std::string>() == "disk") {
-            if (!rotor_json.contains("radius")) {
-                throw std::runtime_error("The \"radius\" key must be given for rotors using actuator disk theory.");
+            if (!rotor_options.contains("radius")) {
+                throw std::runtime_error(
+                    "The \"radius\" key (rotor options) must be given for rotors using actuator disk theory.");
             } else {
-                rotor_json.at("radius").get_to(turbine.rna.aero.rotor->radius);
+                rotor_options.at("radius").get_to(turbine.rna.aero.rotor->radius);
             }
         }
     }

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -30,6 +30,9 @@
     #include "seahowl/hydro/hydrochrono_adapter.h"
     #include "seahowl/elasto/chrono_adapters.h"
 #endif
+#ifdef HAVE_AERODYN
+    #include "seahowl/aero/aerodyn_adapter.h"
+#endif
 
 #include <string>
 #include <memory>
@@ -357,7 +360,7 @@ void populate_rna_aero_from_json(const std::string& filepath, seahowl::aero::Rot
     //
     // hub
     auto hub = json_obj.at("hub");
-    hub.at("radius").get_to(rna.hub_radius);
+    hub.at("radius").get_to(rna.rotor->hub_radius);
 }
 
 void populate_rna_from_json(const std::string& filepath, seahowl::core::RotorNacelleAssembly& rna) {
@@ -377,19 +380,23 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
     auto rna_json = json_obj.at("rna");
     auto controller_json = json_obj.at("controller");
 
-    if (rotor_json.at("type").get<std::string>() == "disk") {
-        turbine.aero.use_disktheory = true;
-        spdlog::info("Aerodynamic model: Actuator Disk Theory.");
-        // get rotor performance from table
-        if (!rotor_json.contains("performance_file")) {
-            throw std::runtime_error("The \"performance_file\" key must be given for actuator disk rotor.");
+    try {
+        // do nothing if rotor aero was already defined for AeroDyn
+        dynamic_cast<seahowl::aero::TurbineAeroDyn&>(turbine.aero);
+    } catch (const std::exception& e) {
+        if (rotor_json.at("type").get<std::string>() == "disk") {
+            auto rotor_disk = std::make_shared<seahowl::aero::RotorAeroDisk>();
+            turbine.rna.aero.rotor = rotor_disk;
+            spdlog::info("Aerodynamic model: Actuator Disk Theory.");
+            // get rotor performance from table
+            if (!rotor_json.contains("performance_file")) {
+                throw std::runtime_error("The \"performance_file\" key must be given for actuator disk rotor.");
+            }
+            get_disk_perf_from_table((DATADIR / rotor_json.at("performance_file")).generic_string(), *rotor_disk);
+        } else {
+            turbine.rna.aero.rotor = std::make_shared<seahowl::aero::RotorAeroBEMT>(turbine.aero.tower);
+            spdlog::info("Aerodynamic model: Blade Element Momentum Theory (BEMT).");
         }
-        get_disk_perf_from_table((DATADIR / rotor_json.at("performance_file")).generic_string(), turbine.rna.aero);
-        if (turbine.aero.use_aerodyn == true) {
-            throw std::runtime_error("When Disk Theory is activated, you can't ask for AeroDyn module.");
-        }
-    } else {
-        spdlog::info("Aerodynamic model: Blade Element Momentum Theory (BEMT).");
     }
 
     // check rotor type
@@ -441,8 +448,15 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
     }
 
     turbine.elasto.rna.rotor->blades = blades_elasto;
-    turbine.aero.rna.blades = blades_aero;
+    turbine.aero.rna.rotor->blades = blades_aero;
     turbine.rna.blades = blades;
+
+    // empty blades list of rotor type is disk
+    if (rotor_json.at("type").get<std::string>() == "disk") {
+        turbine.elasto.rna.rotor->blades.clear();
+        turbine.aero.rna.rotor->blades.clear();
+        turbine.rna.blades.clear();
+    }
 
     // RNA
     auto filepath_rna = (DATADIR / rna_json.at("file").get<std::string>()).generic_string();
@@ -452,15 +466,22 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
     // update info if rotor is rigid
     if (rotor_json.at("type").get<std::string>() == "rigid" || rotor_json.at("type").get<std::string>() == "disk") {
         if (!rotor_json.contains("inertia_total")) {
-            throw std::runtime_error("The \"inertia_total\" key must be provided for rigid rotors.");
+            throw std::runtime_error("The \"inertia_total\" key must be provided for rigid/disk rotors.");
         }
         if (!rotor_json.contains("mass_blades_total")) {
-            throw std::runtime_error("The \"mass_blades_total\" key must be given for rigid rotors.");
+            throw std::runtime_error("The \"mass_blades_total\" key must be given for rigid/disk rotors.");
         }
         auto rotor_inertia = rotor_json.at("inertia_total").get<double>();
         turbine.rna.elasto.rotor->hub.inertia = rotor_inertia;
         auto blades_mass = rotor_json.at("mass_blades_total").get<double>();
         turbine.rna.elasto.rotor->hub.mass += blades_mass;
+        if (rotor_json.at("type").get<std::string>() == "disk") {
+            if (!rotor_json.contains("radius")) {
+                throw std::runtime_error("The \"radius\" key must be given for rotors using actuator disk theory.");
+            } else {
+                rotor_json.at("radius").get_to(turbine.rna.aero.rotor->radius);
+            }
+        }
     }
 
     // tower
@@ -695,36 +716,15 @@ void populate_system_from_json(const std::string& filepath, seahowl::core::Syste
         auto turbine_json = turbines_json[ii];
         auto filepath_turbine = (DATADIR / turbine_json.at("file").get<std::string>()).generic_string();
         // make turbine aero
-        system_core.system_aero->turbines.push_back(seahowl::aero::TurbineAero());
-        // check if floater defined
-        auto json_obj_turbine = get_json_from_file(filepath_turbine);
-        bool is_floating = false;
-        if (json_obj_turbine.contains("floater")) {
-            // floating turbine if floater is defined
-            auto floating_turbine_elasto = std::make_shared<seahowl::elasto::TurbineFloatingElasto>();
-            system_core.system_elasto->turbines.push_back(floating_turbine_elasto);
-            is_floating = true;
-            system_core.turbines.push_back(std::move(std::make_shared<seahowl::core::TurbineFloating>(
-                *floating_turbine_elasto, system_core.system_aero->turbines[ii])));
-        } else {
-            system_core.system_elasto->turbines.push_back(std::make_shared<seahowl::elasto::TurbineElasto>());
-            // simple turbine if floater is not defined
-            system_core.turbines.push_back(std::move(std::make_shared<seahowl::core::Turbine>(
-                *system_core.system_elasto->turbines[ii], system_core.system_aero->turbines[ii])));
-        }
-        // get reference to turbine object
-        auto& turbine = *system_core.turbines.back();
-        populate_turbine_from_json(filepath_turbine, turbine);
-
-        // aerodyn option
+        if (turbine_json.at("use_aerodyn").get<bool>()) {
 #ifdef HAVE_AERODYN
-        turbine.aero.use_aerodyn = turbine_json.at("use_aerodyn").get<bool>();
-        bool output_vtk = json_obj.at("outputs").at("VTK").get<bool>();
-        if (output_vtk) {
-            turbine.aero.WrVTK = 2;
-        }
-        turbine.aero.WrVTK_dt = json_obj.at("outputs").at("dt").get<double>();
-        if (turbine.aero.use_aerodyn) {
+            auto turbine_aero = std::make_shared<seahowl::aero::TurbineAeroDyn>();
+            turbine_aero->rna.rotor = std::make_shared<seahowl::aero::RotorAeroDyn>(turbine_aero->tower);
+            bool output_vtk = json_obj.at("outputs").at("VTK").get<bool>();
+            if (output_vtk) {
+                turbine_aero->WrVTK = 2;
+            }
+            turbine_aero->WrVTK_dt = json_obj.at("outputs").at("dt").get<double>();
             spdlog::info("Aerodynamic model: AeroDyn.");
             std::string inflowwind_filepath;
             std::string aerodyn_filepath;
@@ -738,10 +738,35 @@ void populate_system_from_json(const std::string& filepath, seahowl::core::Syste
             } else {
                 throw std::runtime_error("Turbine set to use aerodyn but InflowWind file not defined.");
             }
-            turbine.aero.aerodyn =
+            turbine_aero->aerodyn =
                 std::make_shared<seahowl::aero::AeroDynAdapter>(aerodyn_filepath, inflowwind_filepath);
-        }
+            system_core.system_aero->turbines.push_back(turbine_aero);
+#else
+            throw std::runtime_error(
+                "Trying to use AeroDyn for turbine (use_aerodyn is set to true) but the code was not compiled with "
+                "AeroDyn adapter enabled.");
 #endif
+        } else {
+            auto turbine_aero = std::make_shared<seahowl::aero::TurbineAero>();
+            system_core.system_aero->turbines.push_back(turbine_aero);
+        }
+        // check if floater defined
+        auto json_obj_turbine = get_json_from_file(filepath_turbine);
+        bool is_floating = false;
+        if (json_obj_turbine.contains("floater")) {
+            // floating turbine if floater is defined
+            auto floating_turbine_elasto = std::make_shared<seahowl::elasto::TurbineFloatingElasto>();
+            system_core.system_elasto->turbines.push_back(floating_turbine_elasto);
+            is_floating = true;
+        } else {
+            // simple turbine if floater is not defined
+            system_core.system_elasto->turbines.push_back(std::make_shared<seahowl::elasto::TurbineElasto>());
+        }
+        system_core.turbines.push_back(std::move(std::make_shared<seahowl::core::Turbine>(
+            *system_core.system_elasto->turbines[ii], *system_core.system_aero->turbines[ii])));
+        // get reference to turbine object
+        auto& turbine = *system_core.turbines.back();
+        populate_turbine_from_json(filepath_turbine, turbine);
 
         // build turbine
         turbine.build();

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -798,6 +798,19 @@ void populate_system_from_json(const std::string& filepath, seahowl::core::Syste
         // get ref to turbine added last
         auto& turbine = *system_core.turbines.back();
 
+#ifdef HAVE_AERODYN
+        try {
+            // set VTK options if using AeroDyn
+            auto& turbine_aero = dynamic_cast<seahowl::aero::TurbineAeroDyn&>(turbine.aero);
+            if (outputs_json.at("VTK").get<bool>()) {
+                turbine_aero.WrVTK = 2;
+                turbine_aero.WrVTK_dt = outputs_json.at("dt").get<double>();
+            }
+        } catch (const std::bad_cast& e) {
+            // do nothing if not using AeroDyn
+        }
+#endif
+
         // build turbine
         turbine.build();
         // rotate turbine to align tower with gravity vector

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -396,8 +396,15 @@ void add_turbine_to_system_from_json(const std::string& filepath, seahowl::core:
     }
 
     // add turbine to system
-    auto turbine = std::make_shared<seahowl::core::Turbine>(*system_core.system_elasto->turbines.back(),
-                                                            *system_core.system_aero->turbines.back());
+    std::shared_ptr<seahowl::core::Turbine> turbine;
+    if (json_obj.contains("floater")) {
+        turbine = std::make_shared<seahowl::core::TurbineFloating>(
+            dynamic_cast<seahowl::elasto::TurbineFloatingElasto&>(*system_core.system_elasto->turbines.back()),
+            *system_core.system_aero->turbines.back());
+    } else {
+        turbine = std::make_shared<seahowl::core::Turbine>(*system_core.system_elasto->turbines.back(),
+                                                           *system_core.system_aero->turbines.back());
+    }
     system_core.turbines.push_back(turbine);
 
     // populate turbine
@@ -434,7 +441,8 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
         turbine.rna.aero.rotor = rotor_disk;
         auto aero_options = aero_json.at("options");
         // get rotor performance from table
-        get_disk_perf_from_table((DATADIR / aero_options.at("performance_file").get<std::string>()), *rotor_disk);
+        auto perf_filepath = (DATADIR / aero_options.at("performance_file").get<std::string>()).generic_string();
+        get_disk_perf_from_table(perf_filepath, *rotor_disk);
     } else if (aero_json.at("solver").get<std::string>() == "aerodyn" ||
                aero_json.at("solver").get<std::string>() == "AeroDyn") {
         spdlog::info("Aerodynamic model: AeroDyn.");

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -369,6 +369,41 @@ void populate_rna_from_json(const std::string& filepath, seahowl::core::RotorNac
     populate_rna_aero_from_json(filepath, rna.aero);
 }
 
+void add_turbine_to_system_from_json(const std::string& filepath, seahowl::core::System& system_core) {
+    spdlog::debug("Adding turbine to system from " + filepath + " file.");
+    auto json_obj = get_json_from_file(filepath);
+
+    // make turbine aero
+    if (json_obj.at("aero").at("solver") == "aerodyn" || json_obj.at("aero").at("solver") == "AeroDyn") {
+#ifdef HAVE_AERODYN
+        auto turbine_aero = std::make_shared<seahowl::aero::TurbineAeroDyn>();
+        system_core.system_aero->turbines.push_back(turbine_aero);
+#endif
+    } else {
+        auto turbine_aero = std::make_shared<seahowl::aero::TurbineAero>();
+        system_core.system_aero->turbines.push_back(turbine_aero);
+    }
+
+    // make turbine elasto
+    if (json_obj.contains("floater")) {
+        // floating turbine if floater is defined
+        auto turbine_elasto = std::make_shared<seahowl::elasto::TurbineFloatingElasto>();
+        system_core.system_elasto->turbines.push_back(turbine_elasto);
+    } else {
+        // simple turbine if floater is not defined
+        auto turbine_elasto = std::make_shared<seahowl::elasto::TurbineElasto>();
+        system_core.system_elasto->turbines.push_back(turbine_elasto);
+    }
+
+    // add turbine to system
+    auto turbine = std::make_shared<seahowl::core::Turbine>(*system_core.system_elasto->turbines.back(),
+                                                            *system_core.system_aero->turbines.back());
+    system_core.turbines.push_back(turbine);
+
+    // populate turbine
+    populate_turbine_from_json(filepath, *turbine);
+}
+
 void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turbine& turbine) {
     spdlog::debug("Populating turbine from " + filepath + " file.");
     auto json_obj = get_json_from_file(filepath);
@@ -379,24 +414,58 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
     auto tower_json = json_obj.at("tower");
     auto rna_json = json_obj.at("rna");
     auto controller_json = json_obj.at("controller");
+    auto aero_json = json_obj.at("aero");
 
-    try {
-        // do nothing if rotor aero was already defined for AeroDyn
-        dynamic_cast<seahowl::aero::TurbineAeroDyn&>(turbine.aero);
-    } catch (const std::exception& e) {
-        if (rotor_json.at("type").get<std::string>() == "disk") {
-            auto rotor_disk = std::make_shared<seahowl::aero::RotorAeroDisk>();
-            turbine.rna.aero.rotor = rotor_disk;
-            spdlog::info("Aerodynamic model: Actuator Disk Theory.");
-            // get rotor performance from table
-            if (!rotor_json.contains("performance_file")) {
-                throw std::runtime_error("The \"performance_file\" key must be given for actuator disk rotor.");
-            }
-            get_disk_perf_from_table((DATADIR / rotor_json.at("performance_file")).generic_string(), *rotor_disk);
-        } else {
-            turbine.rna.aero.rotor = std::make_shared<seahowl::aero::RotorAeroBEMT>(turbine.aero.tower);
-            spdlog::info("Aerodynamic model: Blade Element Momentum Theory (BEMT).");
+    if (aero_json.at("solver").get<std::string>() == "bemt" || aero_json.at("solver").get<std::string>() == "BEMT") {
+        spdlog::info("Aerodynamic model: Blade Element Momentum Theory (BEMT).");
+        auto rotor_aero = std::make_shared<seahowl::aero::RotorAeroBEMT>(turbine.aero.tower);
+        turbine.rna.aero.rotor = rotor_aero;
+        auto aero_options = aero_json.at("options");
+        aero_options.at("hub_loss").get_to(rotor_aero->has_hub_loss);
+        aero_options.at("tip_loss").get_to(rotor_aero->has_tip_loss);
+        aero_options.at("tower_shadow").get_to(rotor_aero->has_tower_shadow);
+
+    } else if (aero_json.at("solver").get<std::string>() == "disk") {
+        spdlog::info("Aerodynamic model: Actuator Disk Theory.");
+        if (rotor_json.at("type").get<std::string>() != "disk") {
+            throw std::runtime_error("Only rotor type \"disk\" can be used with aero solver \"disk\".");
         }
+        auto rotor_disk = std::make_shared<seahowl::aero::RotorAeroDisk>();
+        turbine.rna.aero.rotor = rotor_disk;
+        auto aero_options = aero_json.at("options");
+        // get rotor performance from table
+        get_disk_perf_from_table((DATADIR / aero_options.at("performance_file").get<std::string>()), *rotor_disk);
+    } else if (aero_json.at("solver").get<std::string>() == "aerodyn" ||
+               aero_json.at("solver").get<std::string>() == "AeroDyn") {
+        spdlog::info("Aerodynamic model: AeroDyn.");
+#ifdef HAVE_AERODYN
+        // check that right turbine type was defined for AeroDyn
+        try {
+            auto& turbine_aero = dynamic_cast<seahowl::aero::TurbineAeroDyn&>(turbine.aero);
+        } catch (const std::exception& e) {
+            throw std::runtime_error("Wrong aero turbine type to use AeroDyn solver (needs to be TurbineAeroDyn).");
+        }
+        auto& turbine_aero = dynamic_cast<seahowl::aero::TurbineAeroDyn&>(turbine.aero);
+        auto aero_options = aero_json.at("options");
+        std::string inflowwind_filepath;
+        std::string aerodyn_filepath;
+        if (aero_options.contains("file_aerodyn")) {
+            aerodyn_filepath = (DATADIR / aero_options.at("file_aerodyn").get<std::string>()).generic_string();
+        } else {
+            throw std::runtime_error("Turbine set to use aerodyn but AeroDyn file path not defined.");
+        }
+        if (aero_options.contains("file_inflowwind")) {
+            inflowwind_filepath = (DATADIR / aero_options.at("file_inflowwind").get<std::string>()).generic_string();
+        } else {
+            throw std::runtime_error("Turbine set to use aerodyn but InflowWind file not defined.");
+        }
+        turbine_aero.aerodyn.set_infiles(aerodyn_filepath, inflowwind_filepath);
+        turbine_aero.rna.rotor = std::make_shared<seahowl::aero::RotorAeroDyn>(turbine.aero.tower);
+#else
+        throw std::runtime_error("Trying to use AeroDyn for turbine but the code was not compiled for using AeroDyn.");
+#endif
+    } else {
+        throw std::runtime_error("Unknown aero solver \"" + aero_json.at("solver").get<std::string>() + "\".");
     }
 
     // check rotor type
@@ -415,47 +484,40 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
     }
 
     // blades
-    std::vector<std::shared_ptr<seahowl::core::Blade>> blades;
-    std::vector<std::shared_ptr<seahowl::elasto::BladeElasto>> blades_elasto;
-    std::vector<std::shared_ptr<seahowl::aero::BladeAero>> blades_aero;
-    auto blades_json = rotor_json.at("blades");
-    for (auto& blade_json : blades_json) {
-        auto filepath_blade = (DATADIR / blade_json.at("file").get<std::string>()).generic_string();
-        std::shared_ptr<seahowl::elasto::BladeElasto> blade_elasto;
-        if (rotor_json.at("type").get<std::string>() == "fea") {
-            blade_elasto = std::make_shared<seahowl::elasto::BladeElastoFEA>();
-            auto& blade_elasto_fea = dynamic_cast<seahowl::elasto::BladeElastoFEA&>(*blade_elasto);
-            rotor_json.at("discretization").at("elasto").get_to(blade_elasto_fea.discretization_fractions);
-            rotor_json.at("fpm").get_to(blade_elasto_fea.fpm_mode);
-        } else if (rotor_json.at("type").get<std::string>() == "rigid") {
-            blade_elasto = std::make_shared<seahowl::elasto::BladeElastoRigid>();
-        } else if (rotor_json.at("type").get<std::string>() == "disk") {
-            blade_elasto = std::make_shared<seahowl::elasto::BladeElastoRigid>();
+    // only make blades if rotor type is not disk
+    if (rotor_json.at("type").get<std::string>() != "disk") {
+        std::vector<std::shared_ptr<seahowl::core::Blade>> blades;
+        std::vector<std::shared_ptr<seahowl::elasto::BladeElasto>> blades_elasto;
+        std::vector<std::shared_ptr<seahowl::aero::BladeAero>> blades_aero;
+        auto blades_json = rotor_json.at("blades");
+        for (auto& blade_json : blades_json) {
+            auto filepath_blade = (DATADIR / blade_json.at("file").get<std::string>()).generic_string();
+            std::shared_ptr<seahowl::elasto::BladeElasto> blade_elasto;
+            if (rotor_json.at("type").get<std::string>() == "fea") {
+                blade_elasto = std::make_shared<seahowl::elasto::BladeElastoFEA>();
+                auto& blade_elasto_fea = dynamic_cast<seahowl::elasto::BladeElastoFEA&>(*blade_elasto);
+                rotor_json.at("discretization").at("elasto").get_to(blade_elasto_fea.discretization_fractions);
+                rotor_json.at("fpm").get_to(blade_elasto_fea.fpm_mode);
+            } else if (rotor_json.at("type").get<std::string>() == "rigid") {
+                blade_elasto = std::make_shared<seahowl::elasto::BladeElastoRigid>();
+            }
+            auto blade_aero = std::make_shared<seahowl::aero::BladeAero>();
+            auto blade = std::make_shared<seahowl::core::Blade>(*blade_elasto, *blade_aero);
+            populate_blade_from_json(filepath_blade, *blade);
+            rotor_json.at("discretization").at("aero").get_to(blade->aero.discretization_fractions);
+            blade_json.at("initial_pitch").get_to(blade->elasto.pitch);
+            blade_elasto->precone = blade_json.at("precone").get<double>() * PI / 180.0;
+            // no precone if blade is rigid (assumed that blade is on rotor disc)
+            if (rotor_json.at("type").get<std::string>() == "rigid") {
+                blade_elasto->precone = 0.0;
+            }
+            blades_elasto.push_back(blade_elasto);
+            blades_aero.push_back(blade_aero);
+            blades.push_back(blade);
         }
-        auto blade_aero = std::make_shared<seahowl::aero::BladeAero>();
-        auto blade = std::make_shared<seahowl::core::Blade>(*blade_elasto, *blade_aero);
-        populate_blade_from_json(filepath_blade, *blade);
-        rotor_json.at("discretization").at("aero").get_to(blade->aero.discretization_fractions);
-        blade_json.at("initial_pitch").get_to(blade->elasto.pitch);
-        blade_elasto->precone = blade_json.at("precone").get<double>() * PI / 180.0;
-        // no precone if blade is rigid (assumed that blade is on rotor disc)
-        if (rotor_json.at("type").get<std::string>() == "rigid" || rotor_json.at("type").get<std::string>() == "disk") {
-            blade_elasto->precone = 0.0;
-        }
-        blades_elasto.push_back(blade_elasto);
-        blades_aero.push_back(blade_aero);
-        blades.push_back(blade);
-    }
-
-    turbine.elasto.rna.rotor->blades = blades_elasto;
-    turbine.aero.rna.rotor->blades = blades_aero;
-    turbine.rna.blades = blades;
-
-    // empty blades list of rotor type is disk
-    if (rotor_json.at("type").get<std::string>() == "disk") {
-        turbine.elasto.rna.rotor->blades.clear();
-        turbine.aero.rna.rotor->blades.clear();
-        turbine.rna.blades.clear();
+        turbine.elasto.rna.rotor->blades = blades_elasto;
+        turbine.aero.rna.rotor->blades = blades_aero;
+        turbine.rna.blades = blades;
     }
 
     // RNA
@@ -528,6 +590,11 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
     turbine.rna.elasto.rotor->hub.inertia += drivetrain_inertia;
 
     if (json_obj.contains("floater")) {
+        try {
+            auto& turbine_elasto = dynamic_cast<seahowl::elasto::TurbineFloatingElasto&>(turbine.elasto);
+        } catch (const std::exception& e) {
+            throw std::runtime_error("Wrong elasto turbine type to use floater (needs to be TurbineFloatingElasto).");
+        }
         auto floater_json = json_obj.at("floater");
         auto json_obj_floater =
             get_json_from_file((DATADIR / floater_json.at("file").get<std::string>()).generic_string());
@@ -570,6 +637,8 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
                 }
             }
             body.set_inertia_matrix(body_inertia_matrix);
+#else
+            throw std::runtime_error("Trying to use HydroChrono but did not compile with HydroChrono dependency.");
 #endif
         } else {
             throw std::runtime_error("Type of floater defined in turbine json file does not exist.");
@@ -713,60 +782,13 @@ void populate_system_from_json(const std::string& filepath, seahowl::core::Syste
     // turbines
     auto turbines_json = json_obj.at("turbines");
     for (int ii = 0; ii < turbines_json.size(); ii++) {
+        // add turbine to system
         auto turbine_json = turbines_json[ii];
         auto filepath_turbine = (DATADIR / turbine_json.at("file").get<std::string>()).generic_string();
-        // make turbine aero
-        if (turbine_json.at("use_aerodyn").get<bool>()) {
-#ifdef HAVE_AERODYN
-            auto turbine_aero = std::make_shared<seahowl::aero::TurbineAeroDyn>();
-            turbine_aero->rna.rotor = std::make_shared<seahowl::aero::RotorAeroDyn>(turbine_aero->tower);
-            bool output_vtk = json_obj.at("outputs").at("VTK").get<bool>();
-            if (output_vtk) {
-                turbine_aero->WrVTK = 2;
-            }
-            turbine_aero->WrVTK_dt = json_obj.at("outputs").at("dt").get<double>();
-            spdlog::info("Aerodynamic model: AeroDyn.");
-            std::string inflowwind_filepath;
-            std::string aerodyn_filepath;
-            if (turbine_json.contains("file_aerodyn")) {
-                aerodyn_filepath = (DATADIR / turbine_json.at("file_aerodyn")).generic_string();
-            } else {
-                throw std::runtime_error("Turbine set to use aerodyn but AeroDyn file path not defined.");
-            }
-            if (turbine_json.contains("file_inflowwind")) {
-                inflowwind_filepath = (DATADIR / turbine_json.at("file_inflowwind")).generic_string();
-            } else {
-                throw std::runtime_error("Turbine set to use aerodyn but InflowWind file not defined.");
-            }
-            turbine_aero->aerodyn =
-                std::make_shared<seahowl::aero::AeroDynAdapter>(aerodyn_filepath, inflowwind_filepath);
-            system_core.system_aero->turbines.push_back(turbine_aero);
-#else
-            throw std::runtime_error(
-                "Trying to use AeroDyn for turbine (use_aerodyn is set to true) but the code was not compiled with "
-                "AeroDyn adapter enabled.");
-#endif
-        } else {
-            auto turbine_aero = std::make_shared<seahowl::aero::TurbineAero>();
-            system_core.system_aero->turbines.push_back(turbine_aero);
-        }
-        // check if floater defined
-        auto json_obj_turbine = get_json_from_file(filepath_turbine);
-        bool is_floating = false;
-        if (json_obj_turbine.contains("floater")) {
-            // floating turbine if floater is defined
-            auto floating_turbine_elasto = std::make_shared<seahowl::elasto::TurbineFloatingElasto>();
-            system_core.system_elasto->turbines.push_back(floating_turbine_elasto);
-            is_floating = true;
-        } else {
-            // simple turbine if floater is not defined
-            system_core.system_elasto->turbines.push_back(std::make_shared<seahowl::elasto::TurbineElasto>());
-        }
-        system_core.turbines.push_back(std::move(std::make_shared<seahowl::core::Turbine>(
-            *system_core.system_elasto->turbines[ii], *system_core.system_aero->turbines[ii])));
-        // get reference to turbine object
+        add_turbine_to_system_from_json(filepath_turbine, system_core);
+
+        // get ref to turbine added last
         auto& turbine = *system_core.turbines.back();
-        populate_turbine_from_json(filepath_turbine, turbine);
 
         // build turbine
         turbine.build();
@@ -794,9 +816,12 @@ void populate_system_from_json(const std::string& filepath, seahowl::core::Syste
         turbine.rna.elasto.rotor->apply_collective_pitch_increment(rotor_pitch0);
         turbine.rna.elasto.rotor->pitch_collective = rotor_pitch0;
 
-        if (is_floating) {
-            turbine.tower.elasto.nodes.front()->set_fixed(false);
-        } else {
+        try {
+            // if floating: do not fix tower
+            auto& turbine_elasto = dynamic_cast<seahowl::elasto::TurbineFloatingElasto&>(turbine.elasto);
+            turbine_elasto.tower.nodes.front()->set_fixed(false);
+        } catch (const std::exception& e) {
+            // if not floating: fix tower
             turbine.tower.elasto.nodes.front()->set_fixed(true);
         }
     }

--- a/src/io/read_rotor_perf.cpp
+++ b/src/io/read_rotor_perf.cpp
@@ -21,7 +21,7 @@ const std::string& get_disk_perf_line(std::vector<std::string>& lines, int index
     return line;
 }
 
-void get_disk_perf_from_table(std::string filepath, seahowl::aero::RotorNacelleAssemblyAero& aero) {
+void get_disk_perf_from_table(std::string filepath, seahowl::aero::RotorAeroDisk& aero) {
     std::string appo;
 
     if (!fs::exists(filepath)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,7 @@ void output_results(seahowl::core::System& system_core) {
     output_sstring << "    turbine info -> rpm: " << std::setprecision(3) << turbine.rna.elasto.get_rpm()
                    << ", power: " << turbine.get_generated_power();
     int nblades = turbine.rna.blades.size();
-    if (nblades <= 3) {
+    if (nblades <= 3 && nblades > 0) {
         for (int ii = 0; ii < turbine.rna.blades.size(); ii++) {
             output_sstring << ", pitch" << ii + 1 << ": " << turbine.rna.elasto.rotor->pitch_collective;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,12 +144,6 @@ void run_simulation(int argc, char* argv[]) {
     draw_system_init(system_chrono, application);
 #endif
 
-#ifdef HAVE_AERODYN
-    if (system_core.turbines[0]->aero.use_aerodyn) {
-        remove_all("./output/vtk-ADI");
-    }
-#endif
-
     // simulation loop
 
     // initialization

--- a/src/servo/controller.cpp
+++ b/src/servo/controller.cpp
@@ -47,7 +47,7 @@ void ControllerVariableTorque::step(double time, double dt, const seahowl::core:
 
         // @todo Line below is specific to actuator disk (otherwise torque_aero is zero), need to move it
         // inside turbine.rna.elasto.get_axial_torque()
-        torque_aero += turbine.rna.aero.torque_aero;
+        torque_aero += turbine.rna.aero.rotor->hub_torque_aero;
 
         torque_elec = torque_aero * std::pow(rpm / target_rpm, 2);
         // torque_elec must be the torque at the generator --> scaled by gearbox ratio and efficiency

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -94,6 +94,11 @@ void seahowl::servo::ControllerDISCON::update_turbine_variables(double time,
 
 void seahowl::servo::ControllerDISCON::initialize(double time, double dt, const seahowl::core::Turbine& turbine) {
     auto nblades = turbine.rna.blades.size();
+    if (nblades == 0) {
+        spdlog::warn(
+            "DISCON: number of blades is 0 (expected for actuator disk approach), setting it to 3 for control.");
+        nblades = 3;
+    }
 
     pImpl.SetNumberOfBlades(nblades);
 

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -586,13 +586,12 @@ TEST(test_aerodyn, rpm_initial_pitch) {
     auto turbine_elasto = seahowl::elasto::TurbineElasto();
     auto turbine_aero = seahowl::aero::TurbineAeroDyn();
     auto turbine = seahowl::core::Turbine(turbine_elasto, turbine_aero);
-    populate_turbine_from_json((DATADIR / "turbine_nocontrol.json").generic_string(), turbine);
+    populate_turbine_from_json((DATADIR / "turbine_nocontrol_aerodyn.json").generic_string(), turbine);
     // remove controller
     turbine.controller = std::make_shared<seahowl::servo::Controller>();
 
-    turbine_aero.aerodyn = std::make_shared<seahowl::aero::AeroDynAdapter>(
-        (DATADIR / "aerodyn/IEA-15-240-RWT_AeroDyn15.dat").generic_string(),
-        (DATADIR / "aerodyn/IEA-15-240-RWT_InflowWind.dat").generic_string());
+    turbine_aero.aerodyn.set_infiles((DATADIR / "aerodyn/IEA-15-240-RWT_AeroDyn15.dat").generic_string(),
+                                     (DATADIR / "aerodyn/IEA-15-240-RWT_InflowWind.dat").generic_string());
 
     turbine.build();
     turbine.elasto.assemble(system_elasto);

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -319,8 +319,6 @@ TEST(test_turbine, rpm_initial_pitch) {
     auto turbine = seahowl::core::Turbine(turbine_elasto, turbine_aero);
     populate_turbine_from_json((DATADIR / "turbine_nocontrol.json").generic_string(), turbine);
 
-    turbine.aero.use_aerodyn = false;
-
     // remove controller
     turbine.controller = std::make_shared<seahowl::servo::Controller>();
     turbine.build();
@@ -380,8 +378,6 @@ TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
     auto turbine = seahowl::core::Turbine(turbine_elasto, turbine_aero);
     populate_turbine_from_json((DATADIR / "turbine_nocontrol_rigid.json").generic_string(), turbine);
 
-    turbine.aero.use_aerodyn = false;
-
     // remove controller
     turbine.controller = std::make_shared<seahowl::servo::Controller>();
     turbine.build();
@@ -440,8 +436,6 @@ TEST(test_turbine, controller_target_rpm) {
     auto turbine_aero = seahowl::aero::TurbineAero();
     auto turbine = seahowl::core::Turbine(turbine_elasto, turbine_aero);
     populate_turbine_from_json((DATADIR / "turbine_nocontrol_rigid.json").generic_string(), turbine);
-
-    turbine.aero.use_aerodyn = false;
 
     // remove controller
     double target_rpm = 2.0;
@@ -506,8 +500,6 @@ TEST(test_turbine, actuator_disk) {
     auto turbine_aero = seahowl::aero::TurbineAero();
     auto turbine = seahowl::core::Turbine(turbine_elasto, turbine_aero);
     populate_turbine_from_json((DATADIR / "turbine_disk.json").generic_string(), turbine);
-
-    turbine.aero.use_aerodyn = false;
 
     // remove controller
     double target_rpm = 7.56;
@@ -592,15 +584,13 @@ TEST(test_aerodyn, rpm_initial_pitch) {
 
     // turbine
     auto turbine_elasto = seahowl::elasto::TurbineElasto();
-    auto turbine_aero = seahowl::aero::TurbineAero();
+    auto turbine_aero = seahowl::aero::TurbineAeroDyn();
     auto turbine = seahowl::core::Turbine(turbine_elasto, turbine_aero);
     populate_turbine_from_json((DATADIR / "turbine_nocontrol.json").generic_string(), turbine);
     // remove controller
     turbine.controller = std::make_shared<seahowl::servo::Controller>();
 
-    turbine.aero.use_aerodyn = true;
-
-    turbine.aero.aerodyn = std::make_shared<seahowl::aero::AeroDynAdapter>(
+    turbine_aero.aerodyn = std::make_shared<seahowl::aero::AeroDynAdapter>(
         (DATADIR / "aerodyn/IEA-15-240-RWT_AeroDyn15.dat").generic_string(),
         (DATADIR / "aerodyn/IEA-15-240-RWT_InflowWind.dat").generic_string());
 
@@ -666,9 +656,9 @@ TEST(test_turbine, multiturbines) {
     auto nturbines = 3;
     for (int ii = 0; ii < nturbines; ii++) {
         system_core.system_elasto->turbines.push_back(std::make_shared<seahowl::elasto::TurbineElasto>());
-        system_core.system_aero->turbines.push_back(seahowl::aero::TurbineAero());
+        system_core.system_aero->turbines.push_back(std::make_shared<seahowl::aero::TurbineAero>());
         system_core.turbines.push_back(std::make_shared<seahowl::core::Turbine>(
-            *system_core.system_elasto->turbines.back(), system_core.system_aero->turbines.back()));
+            *system_core.system_elasto->turbines.back(), *system_core.system_aero->turbines.back()));
         auto& turbine = *system_core.turbines.back();
         populate_turbine_from_json(turbine_file, turbine);
         // empty controller
@@ -737,8 +727,6 @@ TEST(test_inflowwind, rpm_initial_pitch) {
     populate_turbine_from_json((DATADIR / "turbine_nocontrol.json").generic_string(), turbine);
     // remove controller
     turbine.controller = std::make_shared<seahowl::servo::Controller>();
-
-    turbine.aero.use_aerodyn = false;
 
     // remove controller
     turbine.controller = std::make_shared<seahowl::servo::Controller>();


### PR DESCRIPTION
In this PR:
- Specific classes for aero rotors when using BEMT, actuator disk, or AeroDyn
- All AeroDyn adapter logic within its own file only
- New "aero" options in turbine.json, with different solvers possible: "bemt", "disk", "aerodyn". Each solver has its own options (see "turbine_nocontrol_aerodyn.json" for example)
- Reworked read_sjon to make it easier to add turbines