### PR TITLE
Instantiate System by dependency injection + default gravity

### DIFF
--- a/examples/python/ex_system.py
+++ b/examples/python/ex_system.py
@@ -10,9 +10,7 @@ t_output_next = 0.0
 # get system
 system_elasto = pyseahowl.elasto.SystemElastoChrono()
 system_aero = pyseahowl.aero.SystemAero()
-system_core = pyseahowl.core.System()
-system_core.system_elasto = system_elasto
-system_core.system_aero = system_aero
+system_core = pyseahowl.core.System(system_elasto, system_aero)
 pyseahowl.populate_system_from_json(filepath, system_core)
 
 # fix tower bottom nodes
@@ -32,11 +30,11 @@ while t_sim < t_end:
     step += 1
     system_core.poststep(t_sim, dt)
 
-    t_sim = system_core.system_elasto.get_time()
+    t_sim = system_core.get_time()
     if t_sim >= t_output_next - 1e-6:
         turbine = system_core.turbines[0]
         print(
-            "time: {time}, step: {step}, rpm: {rpm}, pitch: {pitch}".format(
+            "time: {time:.3f}, step: {step:.3f}, rpm: {rpm:.3f}, pitch: {pitch:.3f}".format(
                 time=t_sim,
                 step=step,
                 rpm=turbine.rna.elasto.get_rpm(),

--- a/include/seahowl/core/system.h
+++ b/include/seahowl/core/system.h
@@ -36,11 +36,18 @@ class System : public ComponentDynamic {
     /** @brief Soil model. */
     std::shared_ptr<seahowl::env::SoilModel> soil_model;
     /** @brief System for elastodynamics. */
-    std::shared_ptr<seahowl::elasto::SystemElasto> system_elasto;
+    seahowl::elasto::SystemElasto& elasto;
     /** @brief System for aerodynamics. */
-    std::shared_ptr<seahowl::aero::SystemAero> system_aero;
-
-    System();
+    seahowl::aero::SystemAero& aero;
+    /**
+     * @brief Constructor.
+     *
+     * Instantiates system for communication between elasto, aero, servo, hydro components.
+     *
+     * @param[in] elasto Elastodynamic system.
+     * @param[in] aero Aerodynamic system.
+     */
+    System(seahowl::elasto::SystemElasto& elasto, seahowl::aero::SystemAero& aero);
 
     /**
      * @brief Initialize system.

--- a/src/bindings/pyseahowl_core.cpp
+++ b/src/bindings/pyseahowl_core.cpp
@@ -66,11 +66,11 @@ void initialize_pyseahowl_core(py::module& m) {
     // core/system.h
     py::class_<seahowl::core::System, std::shared_ptr<seahowl::core::System>, seahowl::core::ComponentDynamic>(m_core,
                                                                                                                "System")
-        .def(py::init<>())
+        .def(py::init<seahowl::elasto::SystemElasto&, seahowl::aero::SystemAero&>())
         .def("step", &seahowl::core::System::step)
         .def("get_time", &seahowl::core::System::get_time)
         .def_readonly("turbines", &seahowl::core::System::turbines)
         .def_readwrite("fluid_model", &seahowl::core::System::fluid_model)
-        .def_readwrite("system_elasto", &seahowl::core::System::system_elasto)
-        .def_readwrite("system_aero", &seahowl::core::System::system_aero);
+        .def_property_readonly("elasto", [](seahowl::core::System& system) { return &system.elasto; })
+        .def_property_readonly("aero", [](seahowl::core::System& system) { return &system.aero; });
 }

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -17,7 +17,7 @@
 
 using namespace seahowl::core;
 
-System::System() {}
+System::System(seahowl::elasto::SystemElasto& elasto, seahowl::aero::SystemAero& aero) : elasto(elasto), aero(aero) {}
 
 void System::initialize(double time, double dt) {
     for (auto& turbine : turbines) {
@@ -49,7 +49,7 @@ void System::prestep(double time, double dt) {
 }
 
 void System::step(double dt) {
-    system_elasto->step(dt);
+    elasto.step(dt);
 }
 
 void System::poststep(double time, double dt) {
@@ -61,16 +61,16 @@ void System::poststep(double time, double dt) {
 
 void System::assemble() {
     for (auto& turbine : turbines) {
-        turbine->elasto.assemble(*(system_elasto.get()));
+        turbine->elasto.assemble(elasto);
     }
 }
 
 double System::get_time() {
-    return system_elasto->get_time();
+    return elasto.get_time();
 }
 
 void System::set_time(double time) {
-    system_elasto->set_time(time);
+    elasto.set_time(time);
 }
 
 void System::run_presetup(double presetup_duration, double presetup_dt) {
@@ -166,7 +166,7 @@ void System::run_presetup(double presetup_duration, double presetup_dt) {
                                 mooring.diameter, mooring.stiffness_axial, mooring.stiffness_bending);
                         }
                     }
-                    mooring.compute_hydro_loads(system_elasto->get_gravitational_acceleration(), 1000.);
+                    mooring.compute_hydro_loads(elasto.get_gravitational_acceleration(), 1000.);
 
                     if (soil_model) {
                         mooring.compute_seabed_loads(*soil_model);
@@ -177,7 +177,7 @@ void System::run_presetup(double presetup_duration, double presetup_dt) {
             }
         }
 
-        system_elasto->step(presetup_dt);
+        elasto.step(presetup_dt);
     }
 
     std::cout << "|" << std::endl;

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -730,6 +730,7 @@ void MeshElastoChrono::add(ElementElasto& element) {
 
 SystemElastoChrono::SystemElastoChrono() {
     chobj = chrono_types::make_shared<chrono::ChSystemSMC>();
+    set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
 
     // solver
     auto solver = chrono_types::make_shared<chrono::ChSolverSparseLU>();

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -377,33 +377,33 @@ void add_turbine_to_system_from_json(const std::string& filepath, seahowl::core:
     if (json_obj.at("aero").at("solver") == "aerodyn" || json_obj.at("aero").at("solver") == "AeroDyn") {
 #ifdef HAVE_AERODYN
         auto turbine_aero = std::make_shared<seahowl::aero::TurbineAeroDyn>();
-        system_core.system_aero->turbines.push_back(turbine_aero);
+        system_core.aero.turbines.push_back(turbine_aero);
 #endif
     } else {
         auto turbine_aero = std::make_shared<seahowl::aero::TurbineAero>();
-        system_core.system_aero->turbines.push_back(turbine_aero);
+        system_core.aero.turbines.push_back(turbine_aero);
     }
 
     // make turbine elasto
     if (json_obj.contains("floater")) {
         // floating turbine if floater is defined
         auto turbine_elasto = std::make_shared<seahowl::elasto::TurbineFloatingElasto>();
-        system_core.system_elasto->turbines.push_back(turbine_elasto);
+        system_core.elasto.turbines.push_back(turbine_elasto);
     } else {
         // simple turbine if floater is not defined
         auto turbine_elasto = std::make_shared<seahowl::elasto::TurbineElasto>();
-        system_core.system_elasto->turbines.push_back(turbine_elasto);
+        system_core.elasto.turbines.push_back(turbine_elasto);
     }
 
     // add turbine to system
     std::shared_ptr<seahowl::core::Turbine> turbine;
     if (json_obj.contains("floater")) {
         turbine = std::make_shared<seahowl::core::TurbineFloating>(
-            dynamic_cast<seahowl::elasto::TurbineFloatingElasto&>(*system_core.system_elasto->turbines.back()),
-            *system_core.system_aero->turbines.back());
+            dynamic_cast<seahowl::elasto::TurbineFloatingElasto&>(*system_core.elasto.turbines.back()),
+            *system_core.aero.turbines.back());
     } else {
-        turbine = std::make_shared<seahowl::core::Turbine>(*system_core.system_elasto->turbines.back(),
-                                                           *system_core.system_aero->turbines.back());
+        turbine = std::make_shared<seahowl::core::Turbine>(*system_core.elasto.turbines.back(),
+                                                           *system_core.aero.turbines.back());
     }
     system_core.turbines.push_back(turbine);
 
@@ -736,8 +736,8 @@ void populate_environmental_conditions_from_json(const std::string& filepath, se
 
     // gravity
     auto gravity = environment_json.at("gravity").get<std::vector<double>>();
-    system_core.system_elasto->set_gravitational_acceleration(Vector3d(gravity[0], gravity[1], gravity[2]));
-    auto gravity_vector = system_core.system_elasto->get_gravitational_acceleration();
+    system_core.elasto.set_gravitational_acceleration(Vector3d(gravity[0], gravity[1], gravity[2]));
+    auto gravity_vector = system_core.elasto.get_gravitational_acceleration();
     auto gravity_direction = gravity_vector / gravity_vector.norm();
 
     // environment
@@ -788,8 +788,7 @@ void populate_environmental_conditions_from_json(const std::string& filepath, se
         auto v1 = wind_options.at("velocity_end").get<std::vector<double>>();
         wind_model.set_wind_ramp(Vector3d(v0[0], v0[1], v0[2]), wind_options.at("time_start").get<double>(),
                                  Vector3d(v1[0], v1[1], v1[2]), wind_options.at("time_end").get<double>());
-        wind_model.direction_gravity =
-            Vector3d(system_core.system_elasto->get_gravitational_acceleration()).normalized();
+        wind_model.direction_gravity = Vector3d(system_core.elasto.get_gravitational_acceleration()).normalized();
         wind_model.reference_height = wind_options.at("reference_height").get<double>();
         wind_model.shear_coefficient = wind_options.at("shear_coefficient").get<double>();
         wind_model.density = wind_json.at("air_density").get<double>();
@@ -888,7 +887,7 @@ void populate_system_from_json(const std::string& filepath, seahowl::core::Syste
         // build turbine
         turbine.build();
         // rotate turbine to align tower with gravity vector
-        auto v1 = Vector3d(-system_core.system_elasto->get_gravitational_acceleration()).normalized();
+        auto v1 = Vector3d(-system_core.elasto.get_gravitational_acceleration()).normalized();
         auto v2 = (turbine.tower.elasto.nodes[1]->get_position() - turbine.tower.elasto.nodes[0]->get_position())
                       .normalized();
         auto rot_axis = v2.cross(v1);
@@ -896,7 +895,7 @@ void populate_system_from_json(const std::string& filepath, seahowl::core::Syste
         turbine.rotate(rot_angle, rot_axis);
         // rotation around axis opposite to gravity (yaw)
         turbine.rotate(turbine_json.at("rotation").get<double>(),
-                       Vector3d(-system_core.system_elasto->get_gravitational_acceleration()).normalized());
+                       Vector3d(-system_core.elasto.get_gravitational_acceleration()).normalized());
         // translate turbine
         auto trans = turbine_json.at("translation").get<std::vector<double>>();
         turbine.translate(Vector3d(trans[0], trans[1], trans[2]));
@@ -940,7 +939,7 @@ void initialize_system_from_json(const std::string& filepath, seahowl::core::Sys
     auto linear_step = statics_json.at("linear_step").get<bool>();
     auto nonlinear_steps = statics_json.at("nonlinear_steps").get<int>();
     if (linear_step && nonlinear_steps > 0) {
-        system_core.system_elasto->do_statics(linear_step, nonlinear_steps);
+        system_core.elasto.do_statics(linear_step, nonlinear_steps);
         spdlog::debug("Performed statics prestep with linear step as {} and {} nonlinear steps.", linear_step,
                       nonlinear_steps);
     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,15 +89,13 @@ void run_simulation(int argc, char* argv[]) {
     }
 
     // system elasto
-    auto system_elasto = std::make_shared<seahowl::elasto::SystemElastoChrono>();
-    auto system_chrono = system_elasto->chobj;
+    auto system_elasto = seahowl::elasto::SystemElastoChrono();
+    auto system_chrono = system_elasto.chobj;
     system_chrono->SetNumThreads(chrono::ChOMP::GetNumProcs(), 0, 1);
     // system aero
-    auto system_aero = std::make_shared<seahowl::aero::SystemAero>();
+    auto system_aero = seahowl::aero::SystemAero();
     // system core
-    auto system_core = seahowl::core::System();
-    system_core.system_elasto = system_elasto;
-    system_core.system_aero = system_aero;
+    auto system_core = seahowl::core::System(system_elasto, system_aero);
 
     populate_system_from_json(filepath_main.generic_string(), system_core);
     spdlog::debug("Populated system.");
@@ -163,7 +161,7 @@ void run_simulation(int argc, char* argv[]) {
 #ifdef HAVE_VTK
     if (output_vtk) {
         for (auto const& vtk_output : vtk_outputs) {
-            vtk_output.write(system_elasto->get_time(), step);
+            vtk_output.write(system_elasto.get_time(), step);
         }
     }
 #endif
@@ -175,7 +173,7 @@ void run_simulation(int argc, char* argv[]) {
     spdlog::info("Resetting simulation stopwatch to 0s.");
     spdlog::info("**************************************************************");
     spdlog::stopwatch sw_total;
-    while (system_elasto->get_time() < t_end) {
+    while (system_core.get_time() < t_end) {
         // prestep
         system_core.prestep(system_core.get_time(), dt);
 
@@ -188,7 +186,7 @@ void run_simulation(int argc, char* argv[]) {
 
         // output
         if (system_core.get_time() >= (time_outputs - 1e-6)) {
-            spdlog::info("time: {:.6}s, step: {}, stopwatch: {:.3}s", system_elasto->get_time(), step, sw_total);
+            spdlog::info("time: {:.6}s, step: {}, stopwatch: {:.3}s", system_core.get_time(), step, sw_total);
             output_results(system_core);
 #ifdef HAVE_VTK
             if (output_vtk) {

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -95,7 +95,6 @@ TEST(test_blade, mass_deflection) {
 TEST(test_rotor, mass) {
     // system
     auto system_elasto = SystemElastoChrono();
-    system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
 
     std::vector<std::shared_ptr<seahowl::elasto::BladeElasto>> blades;
     for (int ii = 0; ii < 3; ii++) {
@@ -125,7 +124,6 @@ TEST(test_rotor, mass) {
 TEST(test_tower, mass) {
     // system
     auto system_elasto = SystemElastoChrono();
-    system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
 
     // tower
     auto tower = seahowl::elasto::TowerElasto();
@@ -256,6 +254,7 @@ TEST(test_blade, natural_period_dynamic_flap) {
 TEST(test_tower, tower_shadow_check) {
     // system
     auto system_elasto = SystemElastoChrono();
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
 
     // tower
     auto tower_elasto = seahowl::elasto::TowerElasto();
@@ -310,7 +309,7 @@ TEST(test_turbine, rpm_initial_pitch) {
 
     // system
     auto system_elasto = SystemElastoChrono();
-    system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
     auto system_chrono = system_elasto.chobj;
 
     // turbine
@@ -369,7 +368,7 @@ TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
 
     // system
     auto system_elasto = SystemElastoChrono();
-    system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
     auto system_chrono = system_elasto.chobj;
 
     // turbine
@@ -428,7 +427,7 @@ TEST(test_turbine, controller_target_rpm) {
 
     // system
     auto system_elasto = SystemElastoChrono();
-    system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
     auto system_chrono = system_elasto.chobj;
 
     // turbine
@@ -492,7 +491,7 @@ TEST(test_turbine, actuator_disk) {
 
     // system
     auto system_elasto = SystemElastoChrono();
-    system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
     auto system_chrono = system_elasto.chobj;
 
     // turbine
@@ -580,7 +579,7 @@ TEST(test_aerodyn, rpm_initial_pitch) {
 
     // system
     auto system_elasto = SystemElastoChrono();
-    system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
 
     // turbine
     auto turbine_elasto = seahowl::elasto::TurbineElasto();
@@ -641,23 +640,22 @@ TEST(test_turbine, multiturbines) {
     double initial_pitch = seahowl::PI / 8.0;
 
     // system
-    auto system_elasto = std::make_shared<SystemElastoChrono>();
-    system_elasto->set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
+    auto system_elasto = SystemElastoChrono();
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
+    auto system_aero = seahowl::aero::SystemAero();
 
     // system core
-    seahowl::core::System system_core;
+    auto system_core = seahowl::core::System(system_elasto, system_aero);
     system_core.fluid_model = wind_model;
-    system_core.system_elasto = system_elasto;
-    system_core.system_aero = std::make_shared<seahowl::aero::SystemAero>();
 
     // turbines
     auto turbine_file = (DATADIR / "turbine_nocontrol_rigid.json").generic_string();
     auto nturbines = 3;
     for (int ii = 0; ii < nturbines; ii++) {
-        system_core.system_elasto->turbines.push_back(std::make_shared<seahowl::elasto::TurbineElasto>());
-        system_core.system_aero->turbines.push_back(std::make_shared<seahowl::aero::TurbineAero>());
-        system_core.turbines.push_back(std::make_shared<seahowl::core::Turbine>(
-            *system_core.system_elasto->turbines.back(), *system_core.system_aero->turbines.back()));
+        system_core.elasto.turbines.push_back(std::make_shared<seahowl::elasto::TurbineElasto>());
+        system_core.aero.turbines.push_back(std::make_shared<seahowl::aero::TurbineAero>());
+        system_core.turbines.push_back(std::make_shared<seahowl::core::Turbine>(*system_core.elasto.turbines.back(),
+                                                                                *system_core.aero.turbines.back()));
         auto& turbine = *system_core.turbines.back();
         populate_turbine_from_json(turbine_file, turbine);
         // empty controller
@@ -674,7 +672,7 @@ TEST(test_turbine, multiturbines) {
 
     // statics
     if (statics_prestep) {
-        system_elasto->do_statics(true, 10);
+        system_elasto.do_statics(true, 10);
     }
 
     double time = 0.0;
@@ -717,7 +715,7 @@ TEST(test_inflowwind, rpm_initial_pitch) {
 
     // system
     auto system_elasto = SystemElastoChrono();
-    system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
 
     // turbine
     auto turbine_elasto = seahowl::elasto::TurbineElasto();

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -56,10 +56,10 @@ int main(int argc, char** argv) {
     return RUN_ALL_TESTS();
 }
 
-TEST(test_blade, mass_deflection) {
+TEST(test_blade, mass_geometry) {
     // system
     auto system_elasto = SystemElastoChrono();
-    system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
 
     // blade
     auto blade = seahowl::elasto::BladeElastoFEA();
@@ -73,23 +73,19 @@ TEST(test_blade, mass_deflection) {
     blade.assemble(system_elasto);
     blade.nodes.front()->set_fixed(true);
 
+    // check geometry
+    for (int ii = 0; ii < blade.nodes.size(); ii++) {
+        ASSERT_NEAR(blade.discretized_points[ii].coordinates.x(), blade.nodes[ii]->get_position().x(), 1e-4);
+        ASSERT_NEAR(blade.discretized_points[ii].coordinates.y(), blade.nodes[ii]->get_position().y(), 1e-4);
+        ASSERT_NEAR(blade.discretized_points[ii].coordinates.z(), blade.nodes[ii]->get_position().z(), 1e-4);
+    }
+
+    // statics
     system_elasto.do_statics(true, 0);
 
     // check mass
     double blade_mass = 67051.5;
     ASSERT_NEAR(blade_mass, blade.get_mass(), 1.0);
-
-    // check deflection from gravity (edge)
-    double deflection_edge = -0.8580;
-    blade.rotate(PI, Vector3d(0.0, 0.0, 1.0));
-    system_elasto.do_statics(true, 0);
-    ASSERT_NEAR(deflection_edge, blade.nodes.back()->get_position().y(), 0.001);
-
-    // check deflection from gravity (flap)
-    double deflection_flap = 2.91411;
-    blade.rotate(PI / 2.0, Vector3d(0.0, 0.0, 1.0));
-    system_elasto.do_statics(true, 0);
-    ASSERT_NEAR(deflection_flap, blade.nodes.back()->get_position().y(), 0.001);
 }
 
 TEST(test_rotor, mass) {
@@ -138,10 +134,10 @@ TEST(test_tower, mass) {
     ASSERT_NEAR(tower_mass, tower.get_mass(), 1.0);
 }
 
-TEST(test_blade, natural_period_dynamic_edge) {
+TEST(test_blade, edgewise) {
     // system
     auto system_elasto = SystemElastoChrono();
-    system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
 
     // blade
     auto blade = seahowl::elasto::BladeElastoFEA();
@@ -155,10 +151,22 @@ TEST(test_blade, natural_period_dynamic_edge) {
     blade.assemble(system_elasto);
     blade.nodes.front()->set_fixed(true);
 
-    system_elasto.do_statics(true, 0);
+    // rotate blade (flat along y axis)
+    blade.rotate(PI / 2.0, Vector3d(1.0, 0.0, 0.0));
+    ASSERT_NEAR(blade.reference_points.back().coordinates.y(), blade.nodes.back()->get_position().z(), 1e-4);
+
+    // test deflection
+    system_elasto.do_statics(true, 10);
+    double deflection_edge = -0.954337;
+    ASSERT_NEAR(deflection_edge, blade.nodes.back()->get_position().z(), 1e-4);
+    // flip blade
+    blade.rotate(PI, Vector3d(0.0, 1.0, 0.0));
+    system_elasto.do_statics(true, 10);
+    double deflection_edge2 = -1.197823;
+    ASSERT_NEAR(deflection_edge2, blade.nodes.back()->get_position().z(), 1e-4);
 
     // static position of blade tip
-    double pos0 = blade.nodes.back()->get_position().y();
+    double pos0 = blade.nodes.back()->get_position().z();
 
     // check zero-crossings (static position of blade tip)
     int step = 0;
@@ -169,11 +177,11 @@ TEST(test_blade, natural_period_dynamic_edge) {
     double time = 0.0;
     double end_time = 10.0;
     double start_time = 0.0;
-    blade.nodes.back()->set_force(Vector3d(0.0, 1000.0, 0.0), false);
+    blade.nodes.back()->set_force(Vector3d(0.0, 0.0, 1000.0), false);
     while (time < end_time) {
         if (time > 0.5) {
             blade.nodes.back()->reset_loads();
-            if (blade.nodes.back()->get_position().y() < pos0 && pos_y > pos0) {
+            if (blade.nodes.back()->get_position().z() < pos0 && pos_y > pos0) {
                 if (start_time == 0.0) {
                     start_time = time;
                 } else {
@@ -182,7 +190,7 @@ TEST(test_blade, natural_period_dynamic_edge) {
                 }
             }
         }
-        pos_y = blade.nodes.back()->get_position().y();
+        pos_y = blade.nodes.back()->get_position().z();
         system_elasto.step(dt);
         time += dt;
         step += 1;
@@ -193,10 +201,10 @@ TEST(test_blade, natural_period_dynamic_edge) {
     ASSERT_NEAR(natural_period_ref, natural_period, 0.01);
 }
 
-TEST(test_blade, natural_period_dynamic_flap) {
+TEST(test_blade, flapwise) {
     // system
     auto system_elasto = SystemElastoChrono();
-    system_elasto.set_gravitational_acceleration(Vector3d(0.0, -9.81, 0.0));
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
 
     // blade
     auto blade = seahowl::elasto::BladeElastoFEA();
@@ -210,13 +218,22 @@ TEST(test_blade, natural_period_dynamic_flap) {
     blade.assemble(system_elasto);
     blade.nodes.front()->set_fixed(true);
 
-    // rotate blade for flap
-    blade.rotate(-PI / 2.0, Vector3d(0.0, 0.0, 1.0));
+    // rotate blade (flat along x axis)
+    blade.rotate(PI / 2.0, Vector3d(0.0, 1.0, 0.0));
+    ASSERT_NEAR(blade.reference_points.back().coordinates.x(), -blade.nodes.back()->get_position().z(), 1e-4);
 
-    system_elasto.do_statics(true, 0);
+    // test deflection
+    system_elasto.do_statics(true, 10);
+    double deflection_flap = 1.676042;
+    ASSERT_NEAR(deflection_flap, blade.nodes.back()->get_position().z(), 1e-4);
+    // flip blade
+    blade.rotate(PI, Vector3d(1.0, 0.0, 0.0));
+    system_elasto.do_statics(true, 10);
+    double deflection_flap2 = -6.012171;
+    ASSERT_NEAR(deflection_flap2, blade.nodes.back()->get_position().z(), 1e-4);
 
     // static position of blade tip
-    double pos0 = blade.nodes.back()->get_position().y();
+    double pos0 = blade.nodes.back()->get_position().z();
 
     // check zero-crossings (static position of blade tip)
     int step = 0;
@@ -227,11 +244,11 @@ TEST(test_blade, natural_period_dynamic_flap) {
     double time = 0.0;
     double end_time = 10.0;
     double start_time = 0.0;
-    blade.nodes.back()->set_force(Vector3d(0.0, 1000.0, 0.0), false);
+    blade.nodes.back()->set_force(Vector3d(0.0, 0.0, 1000.0), false);
     while (time < end_time) {
         if (time > 0.5) {
             blade.nodes.back()->reset_loads();
-            if (blade.nodes.back()->get_position().y() < pos0 && pos_y > pos0) {
+            if (blade.nodes.back()->get_position().z() < pos0 && pos_y > pos0) {
                 if (start_time == 0.0) {
                     start_time = time;
                 } else {
@@ -240,7 +257,7 @@ TEST(test_blade, natural_period_dynamic_flap) {
                 }
             }
         }
-        pos_y = blade.nodes.back()->get_position().y();
+        pos_y = blade.nodes.back()->get_position().z();
         system_elasto.step(dt);
         time += dt;
         step += 1;
@@ -278,7 +295,7 @@ TEST(test_tower, tower_shadow_check) {
     auto position1 = Vector3d(-14.0, -5.0, 50.0);
     Vector3d wind_velocity1 = wind_velocity;
     seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity1, position1, tower_aero);
-    ASSERT_NEAR(wind_velocity1.x(), 9.223643, 0.001);
+    ASSERT_NEAR(wind_velocity1.x(), 9.216867, 0.001);
 
     // position 2
     auto position2 = Vector3d(-15.0, 0.0, 45.0);
@@ -290,7 +307,7 @@ TEST(test_tower, tower_shadow_check) {
     auto position3 = Vector3d(-16.0, 2.0, 20.0);
     Vector3d wind_velocity3 = wind_velocity;
     seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity3, position3, tower_aero);
-    ASSERT_NEAR(wind_velocity3.x(), 9.056021, 0.001);
+    ASSERT_NEAR(wind_velocity3.x(), 9.068192, 0.001);
 }
 
 TEST(test_turbine, rpm_initial_pitch) {
@@ -349,7 +366,7 @@ TEST(test_turbine, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.8025926, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.779032, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
@@ -408,7 +425,7 @@ TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.810848, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.791585, 1e-4);
 }
 
 TEST(test_turbine, controller_target_rpm) {
@@ -487,7 +504,7 @@ TEST(test_turbine, actuator_disk) {
     // turbine
     double initial_pitch = 0.0 * seahowl::PI / 1000.0;
     // power target
-    auto reference_power = 15.4e6;
+    auto reference_power = 15.5e6;
 
     // system
     auto system_elasto = SystemElastoChrono();
@@ -621,7 +638,7 @@ TEST(test_aerodyn, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.744, 0.02);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.750755, 1e-4);
 }
 #endif
 
@@ -693,7 +710,7 @@ TEST(test_turbine, multiturbines) {
     }
 
     for (auto& turbine : system_core.turbines) {
-        ASSERT_NEAR(turbine->rna.elasto.get_rpm(), 2.829, 0.02);
+        ASSERT_NEAR(turbine->rna.elasto.get_rpm(), 2.791585, 0.02);
     }
 }
 
@@ -756,6 +773,6 @@ TEST(test_inflowwind, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.829, 0.02);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.765498, 1e-4);
 }
 #endif


### PR DESCRIPTION
This PR ensures that System is instantiated by dependency injection (like other core components such Turbine, Blade, etc).
It also sets gravity to (0.0, 0.0, -9.81) by default and updates tests accordingly (and increases their precision for stricter assertions). PR #94 should be merged before this one.