### PR TITLE
Simplify tower input files (cylinder)

### DIFF
--- a/data/IEA15MW/tower.json
+++ b/data/IEA15MW/tower.json
@@ -1,151 +1,112 @@
 {
-  "height": 144.366,
+  "type": "cylinder",
+  "damping_coefficients": [0.02, 0.02, 0.02, 0.02],
+  "height": 144.386,
   "base_height": 15.0,
-  "damping_coefficients": [
-    0.02,
-    0.02,
-    0.02,
-    0.02
-  ],
+  "options": {
+    "density": 7850,
+    "young_modulus": 210000000000.0,
+    "poisson_ratio": 0.3
+  },
   "reference_points": [{
     "fraction": 0.0,
-    "density": 10517.98696043843,
-    "stiffness_foreaft": 3125329984894.722,
-    "stiffness_sideside": 3125329984894.722,
-    "diameter": 10.0,
+    "diameter": 9.471527860538082,
+    "thickness": 0.04436722280099126,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.05276273814258928,
-    "density": 10314.84441173361,
-    "stiffness_foreaft": 3065446681730.708,
-    "stiffness_sideside": 3065446681730.708,
-    "diameter": 10.0,
+    "fraction": 0.100474549023851,
+    "diameter": 9.471527860538082,
+    "thickness": 0.04436722280099126,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.1055254762851786,
-    "density": 9919.392049524873,
-    "stiffness_foreaft": 2948819312643.065,
-    "stiffness_sideside": 2948819312643.065,
-    "diameter": 9.996279967205929,
+    "fraction": 0.100482277835314,
+    "diameter": 9.470994625090677,
+    "thickness": 0.04095226611546465,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.1582882144277679,
-    "density": 9488.451468448127,
-    "stiffness_foreaft": 2800650854266.825,
-    "stiffness_sideside": 2800650854266.825,
-    "diameter": 9.957419950808895,
+    "fraction": 0.200949098047702,
+    "diameter": 9.400956599433346,
+    "thickness": 0.0409522677984171,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.2110509525703571,
-    "density": 9107.242207297397,
-    "stiffness_foreaft": 2668849444810.565,
-    "stiffness_sideside": 2668849444810.565,
-    "diameter": 9.877438490823343,
+    "fraction": 0.200956826859166,
+    "diameter": 9.400486768179315,
+    "thickness": 0.0379450874682119,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.2638136907129464,
-    "density": 8547.41522389624,
-    "stiffness_foreaft": 2384631473929.271,
-    "stiffness_sideside": 2384631473929.271,
-    "diameter": 9.623798113529176,
+    "fraction": 0.301423647071553,
+    "diameter": 8.943346795172339,
+    "thickness": 0.03794509698884152,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.3165764288555357,
-    "density": 8138.448456295994,
-    "stiffness_foreaft": 2158684470523.123,
-    "stiffness_sideside": 2158684470523.123,
-    "diameter": 9.35100459441689,
+    "fraction": 0.301431375883017,
+    "diameter": 8.943068238692485,
+    "thickness": 0.036162357266052325,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.369339166998125,
-    "density": 7685.899491316733,
-    "stiffness_foreaft": 1908968379611.055,
-    "stiffness_sideside": 1908968379611.055,
-    "diameter": 9.030672026819705,
+    "fraction": 0.401898196095404,
+    "diameter": 8.365727870543015,
+    "thickness": 0.036162369668488736,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.4221019051407142,
-    "density": 7257.851254111201,
-    "stiffness_foreaft": 1684199591110.688,
-    "stiffness_sideside": 1684199591110.688,
-    "diameter": 8.695861493753704,
+    "fraction": 0.401905924906868,
+    "diameter": 8.365467431637724,
+    "thickness": 0.03449533341731037,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.4748646432833035,
-    "density": 6812.656121445571,
-    "stiffness_foreaft": 1461023434770.46,
-    "stiffness_sideside": 1461023434770.46,
-    "diameter": 8.337719180472915,
-    "drag_coefficient": 0.49999999999999994
-  }, {
-    "fraction": 0.5276273814258928,
-    "density": 6367.653399866696,
-    "stiffness_foreaft": 1257987044218.262,
-    "stiffness_sideside": 1257987044218.262,
-    "diameter": 7.959719935385938,
+    "fraction": 0.502372745119256,
+    "diameter": 7.719981882276564,
+    "thickness": 0.03449534843335744,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.5803901195684821,
-    "density": 5906.845588207135,
-    "stiffness_foreaft": 1060381854661.747,
-    "stiffness_sideside": 1060381854661.747,
-    "diameter": 7.560091928924532,
+    "fraction": 0.502380473930719,
+    "diameter": 7.7196999243113975,
+    "thickness": 0.03269014050761809,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.6331528577110713,
-    "density": 5435.020484499056,
-    "stiffness_foreaft": 882352802318.5538,
-    "stiffness_sideside": 882352802318.5538,
-    "diameter": 7.244918721031226,
+    "fraction": 0.602847294143107,
+    "diameter": 6.999443913448144,
+    "thickness": 0.03269015915711959,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.6859155958536606,
-    "density": 5081.876946716433,
-    "stiffness_foreaft": 772202233150.6515,
-    "stiffness_sideside": 772202233150.6515,
-    "diameter": 6.9923286144504955,
+    "fraction": 0.60285502295457,
+    "diameter": 6.9991127553155215,
+    "thickness": 0.030569291197838133,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.7386783339962499,
-    "density": 4622.289077026658,
-    "stiffness_foreaft": 656038565138.3677,
-    "stiffness_sideside": 656038565138.3677,
-    "diameter": 6.852344905960566,
+    "fraction": 0.703321843166958,
+    "diameter": 6.543865485064136,
+    "thickness": 0.030569303543766857,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.7914410721388392,
-    "density": 4283.492084231731,
-    "stiffness_foreaft": 594095539561.9287,
-    "stiffness_sideside": 594095539561.9287,
-    "diameter": 6.767798113529177,
+    "fraction": 0.703329571978421,
+    "diameter": 6.543303370798586,
+    "thickness": 0.026970120433160716,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.8442038102814284,
-    "density": 3953.168588780436,
-    "stiffness_foreaft": 535638269036.4203,
-    "stiffness_sideside": 535638269036.4203,
-    "diameter": 6.6772188354857835,
+    "fraction": 0.803796392190809,
+    "diameter": 6.390923373871678,
+    "thickness": 0.02697012368101337,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.8969665484240177,
-    "density": 3625.335201113426,
-    "stiffness_foreaft": 478676570896.8642,
-    "stiffness_sideside": 478676570896.8642,
-    "diameter": 6.584795012703644,
+    "fraction": 0.803804121002272,
+    "diameter": 6.390364471031785,
+    "thickness": 0.02339453673393388,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.949729286566607,
-    "density": 3848.777885790216,
-    "stiffness_foreaft": 494558334851.6254,
-    "stiffness_sideside": 494558334851.6254,
-    "diameter": 6.537809745683601,
+    "fraction": 0.90427094121466,
+    "diameter": 6.223787667772417,
+    "thickness": 0.023394539228819067,
+    "drag_coefficient": 0.5
+  }, {
+    "fraction": 0.904278670026123,
+    "diameter": 6.224344531196612,
+    "thickness": 0.02695777076634176,
     "drag_coefficient": 0.5
   }, {
     "fraction": 1.0,
-    "density": 4097.489292297825,
-    "stiffness_foreaft": 520492413909.5013,
-    "stiffness_sideside": 520492413909.5013,
-    "diameter": 6.5,
+    "diameter": 6.1561994238725255,
+    "thickness": 0.026957772420800552,
     "drag_coefficient": 0.5
   }]
 }

--- a/data/IEA15MW/tower_floating.json
+++ b/data/IEA15MW/tower_floating.json
@@ -1,139 +1,62 @@
 {
+  "type": "cylinder",
   "damping_coefficients": [0.02, 0.02, 0.02, 0.02],
   "height": 144.386,
   "base_height": 15.0,
+  "options": {
+    "density": 7850,
+    "young_modulus": 210000000000.0,
+    "poisson_ratio": 0.3
+  },
   "reference_points": [{
     "fraction": 0.0,
-    "density": 23006.4213107425,
-    "stiffness_foreaft": 6770513741893.661,
-    "stiffness_sideside": 6770513741893.661,
-    "diameter": 10.0,
+    "diameter": 9.480079230031128,
+    "thickness": 0.0994483291996131,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.100475,
-    "density": 20645.995757369445,
-    "stiffness_foreaft": 6086865344926.777,
-    "stiffness_sideside": 6086865344926.777,
-    "diameter": 10.0,
+    "fraction": 0.1114034260838268,
+    "diameter": 9.478316467844387,
+    "thickness": 0.08804484805328805,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.111403,
-    "density": 20389.26791017103,
-    "stiffness_foreaft": 6012509438660.999,
-    "stiffness_sideside": 6012509438660.999,
-    "diameter": 10.0,
+    "fraction": 0.2228068521676536,
+    "diameter": 9.476535792205395,
+    "thickness": 0.07655157582340255,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.200949,
-    "density": 18264.632102127107,
-    "stiffness_foreaft": 5394598975094.711,
-    "stiffness_sideside": 5394598975094.711,
-    "diameter": 10.0,
+    "fraction": 0.3342102782514804,
+    "diameter": 9.474727858234289,
+    "thickness": 0.06490901317256892,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.222807,
-    "density": 17746.01273898164,
-    "stiffness_foreaft": 5243768263364.071,
-    "stiffness_sideside": 5243768263364.071,
-    "diameter": 10.0,
+    "fraction": 0.4456137043353072,
+    "diameter": 9.472894516493918,
+    "thickness": 0.053130061449685684,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.301424,
-    "density": 15852.47402271775,
-    "stiffness_foreaft": 4690763553700.438,
-    "stiffness_sideside": 4690763553700.438,
-    "diameter": 10.0,
+    "fraction": 0.557017130419134,
+    "diameter": 9.47106829369864,
+    "thickness": 0.041423919767386685,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.33421,
-    "density": 15062.80308193614,
-    "stiffness_foreaft": 4460141520157.67,
-    "stiffness_sideside": 4460141520157.67,
-    "diameter": 10.0,
+    "fraction": 0.6684205565029608,
+    "diameter": 9.46931128637315,
+    "thickness": 0.03018678026618815,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.401898,
-    "density": 13409.917033573116,
-    "stiffness_foreaft": 3975378255922.296,
-    "stiffness_sideside": 3975378255922.296,
-    "diameter": 10.0,
+    "fraction": 0.7798239825867876,
+    "diameter": 9.467705445545128,
+    "thickness": 0.01993802820237356,
     "drag_coefficient": 0.5
   }, {
-    "fraction": 0.445614,
-    "density": 12342.4077780147,
-    "stiffness_foreaft": 3662296012994.249,
-    "stiffness_sideside": 3662296012994.249,
-    "diameter": 10.0,
-    "drag_coefficient": 0.5
-  }, {
-    "fraction": 0.502373,
-    "density": 10962.035240316254,
-    "stiffness_foreaft": 3255743789131.6416,
-    "stiffness_sideside": 3255743789131.6416,
-    "diameter": 10.0,
-    "drag_coefficient": 0.5
-  }, {
-    "fraction": 0.557017,
-    "density": 9633.099266285813,
-    "stiffness_foreaft": 2864340844739.592,
-    "stiffness_sideside": 2864340844739.592,
-    "diameter": 10.0,
-    "drag_coefficient": 0.49999999999999994
-  }, {
-    "fraction": 0.602847,
-    "density": 8560.974835035016,
-    "stiffness_foreaft": 2547272838273.76,
-    "stiffness_sideside": 2547272838273.76,
-    "diameter": 10.0,
-    "drag_coefficient": 0.5
-  }, {
-    "fraction": 0.668421,
-    "density": 7026.968999232271,
-    "stiffness_foreaft": 2093608918221.6,
-    "stiffness_sideside": 2093608918221.6,
-    "diameter": 10.0,
-    "drag_coefficient": 0.5
-  }, {
-    "fraction": 0.703322,
-    "density": 6280.882961858169,
-    "stiffness_foreaft": 1872112628693.3577,
-    "stiffness_sideside": 1872112628693.3577,
-    "diameter": 10.0,
-    "drag_coefficient": 0.5
-  }, {
-    "fraction": 0.779824,
-    "density": 4645.483574127345,
-    "stiffness_foreaft": 1386599057692.824,
-    "stiffness_sideside": 1386599057692.824,
-    "diameter": 10.0,
-    "drag_coefficient": 0.5
-  }, {
-    "fraction": 0.803796,
-    "density": 4204.49025030578,
-    "stiffness_foreaft": 1255231521750.8687,
-    "stiffness_sideside": 1255231521750.8687,
-    "diameter": 10.0,
-    "drag_coefficient": 0.5
-  }, {
-    "fraction": 0.891227,
-    "density": 2596.09348345098,
-    "stiffness_foreaft": 776106082282.2759,
-    "stiffness_sideside": 776106082282.2759,
-    "diameter": 10.0,
-    "drag_coefficient": 0.5
-  }, {
-    "fraction": 0.904271,
-    "density": 2490.436982678561,
-    "stiffness_foreaft": 724885881564.0813,
-    "stiffness_sideside": 724885881564.0813,
-    "diameter": 10.0,
+    "fraction": 0.8912274086706145,
+    "diameter": 9.466323319248843,
+    "thickness": 0.011133470025252556,
     "drag_coefficient": 0.5
   }, {
     "fraction": 1.0,
-    "density": 1715.031343116859,
-    "stiffness_foreaft": 348984425373.3395,
-    "stiffness_sideside": 348984425373.3395,
-    "diameter": 6.5,
+    "diameter": 7.809674280299108,
+    "thickness": 0.008914883024937037,
     "drag_coefficient": 0.5
   }]
 }

--- a/data/IEA15MW/turbine.json
+++ b/data/IEA15MW/turbine.json
@@ -40,7 +40,7 @@
   },
   "tower": {
     "discretization": {
-      "elasto": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+      "elasto": [],
       "aero": [19]
     },
     "file": "./tower.json"

--- a/data/IEA15MW/turbine_floating.json
+++ b/data/IEA15MW/turbine_floating.json
@@ -40,7 +40,7 @@
   },
   "tower": {
     "discretization": {
-      "elasto": [10],
+      "elasto": [],
       "aero": [19]
     },
     "file": "./tower_floating.json"

--- a/scripts/converters.py
+++ b/scripts/converters.py
@@ -477,6 +477,7 @@ def convert_elastodyn_tower_file(
     filename_elastodyn, filename_elastodyn_tower, save_directory=None
 ):
     elastodyn_json = dict()
+    elastodyn_json["type"] = "cylinder"
     elastodyn_json["damping_coefficients"] = [0.02, 0.02, 0.02, 0.02]
 
     # elastodyn (general info)
@@ -512,22 +513,46 @@ def convert_elastodyn_tower_file(
     assert npoints != 0, "Could not find tower ElastoDyn info in given file."
     start_idx = 19
     fractions = list()
+
+    # assume basic steel properties and cylinder shape
+    young_modulus = 210e9
+    density = 7850
+    poisson_ratio = 0.3
+    options = {}
+    options["density"] = density
+    options["young_modulus"] = young_modulus
+    options["poisson_ratio"] = poisson_ratio
+    elastodyn_json["options"] = options
     for line in lines[start_idx : start_idx + npoints]:
         point = dict()
         words = line.split()
         point["fraction"] = float(words[0])
         fractions.append(point["fraction"])
-        point["density"] = float(words[1])
-        point["stiffness_foreaft"] = float(words[2])
-        point["stiffness_sideside"] = float(words[3])
+        density_linear = float(words[1])
+        inertia = float(words[2]) / young_modulus  # area moment of inertia
+        # inner
+        area_inner = (
+            (4 * np.pi * inertia - (density_linear / density) ** 2)
+            * (density / density_linear)
+            * 0.5
+        )
+        diameter_inner = np.sqrt(4 * area_inner / np.pi)
+        # outer
+        area_outer = density_linear / density + area_inner
+        diameter_outer = np.sqrt(4 * area_outer / np.pi)
+        point["diameter"] = diameter_outer
+        # thickness
+        thickness = 0.5 * (diameter_outer - diameter_inner)
+        point["thickness"] = thickness
+
+        point["drag_coefficient"] = 0.5  # cylinders
         points.append(point)
 
-    elastodyn_json["discretization_elasto"] = fractions
     elastodyn_json["reference_points"] = points
 
     # save to file
     if save_directory is not None:
-        fullpath = Path(save_directory) / filepath.with_suffix(".json")
+        fullpath = Path(save_directory) / "tower.json"
         save_json(elastodyn_json, fullpath)
 
     return elastodyn_json
@@ -780,7 +805,7 @@ def convert_openfast_fst(filename, save_directory=None, use_beamdyn=True):
                     tower_elasto_json = convert_elastodyn_tower_file(
                         filename_elastodyn=path_ED,
                         filename_elastodyn_tower=path_ED_tower,
-                        save_directory=None,
+                        save_directory=save_directory,
                     )
                     if blade_elasto_json is None:
                         blade_elasto_json = convert_elastodyn_blade_file(
@@ -825,13 +850,6 @@ def convert_openfast_fst(filename, save_directory=None, use_beamdyn=True):
                 # ServoDyn
                 elif words[1] == "ServoFile":
                     path_servo = filedir / words[0].replace('"', "")
-
-        # tower
-        tower_json = merge_elastodyn2aerodyn_tower(
-            elastodyn_json=tower_elasto_json,
-            aerodyn_json=tower_aero_json,
-            save_directory=save_directory,
-        )
 
         # rna
         rna_json = convert_elastodyn_rna_file(
@@ -926,8 +944,8 @@ def convert_openfast_fst(filename, save_directory=None, use_beamdyn=True):
             },
             "tower": {
                 "discretization": {
-                    "elasto": tower_elasto_json["discretization_elasto"],
-                    "aero": tower_aero_json["discretization_aero"],
+                    "elasto": [],
+                    "aero": [],
                 },
                 "file": str(Path("./tower.json")),
             },

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -245,6 +245,8 @@ std::vector<seahowl::elasto::TowerReferencePointElasto> get_tower_elasto_referen
     const std::string& filepath) {
     auto json_obj = get_json_from_file(filepath);
 
+    auto tower_type = json_obj.at("type").get<std::string>();
+
     // EXTRACT INFO
     double height = json_obj.at("height").get<double>();
     double base_height = json_obj.at("base_height").get<double>();
@@ -259,19 +261,56 @@ std::vector<seahowl::elasto::TowerReferencePointElasto> get_tower_elasto_referen
         point.at("fraction").get_to(reference_point.fraction);
         reference_point.coordinates =
             Vector3d(0.0, 0.0, (height - base_height) * reference_point.fraction + base_height);
-        point.at("stiffness_sideside").get_to(reference_point.stiffness_sideside);
-        point.at("stiffness_foreaft").get_to(reference_point.stiffness_foreaft);
-        point.at("density").get_to(reference_point.density);
         reference_point.damping_coefficients[0] = damping_coefficients[0];
         reference_point.damping_coefficients[1] = damping_coefficients[1];
         reference_point.damping_coefficients[2] = damping_coefficients[2];
         reference_point.damping_coefficients[3] = damping_coefficients[3];
+        if (tower_type == "cylinder") {
+            // general properties
+            auto tower_options = json_obj.at("options");
+            auto density = tower_options.at("density").get<double>();
+            auto young_modulus = tower_options.at("young_modulus").get<double>();
+            auto poisson_ratio = tower_options.at("poisson_ratio").get<double>();
+            auto shear_modulus = 0.5 * young_modulus / (1.0 + poisson_ratio);
 
-        ///@todo change to actual values
-        reference_point.stiffness_axial = 210e9;
-        reference_point.stiffness_torsion = 1e11;
+            // point-specific properties
+            auto diameter = point.at("diameter").get<double>();
+            auto thickness = point.at("thickness").get<double>();
 
-        reference_points.push_back(reference_point);
+            // geometry info
+            auto d1 = diameter;
+            auto d2 = diameter - 2.0 * thickness;
+            auto area = PI * (pow(d1, 2) - pow(d2, 2)) / 4.0;
+            // linear density
+            auto density_linear = density * area;
+            // stiffnesses
+            auto EI = young_modulus * PI * (pow(d1, 4) - pow(d2, 4)) / 64.;  // bending
+            auto EA = young_modulus * area;                                  // axial
+            auto kt = shear_modulus * PI * (pow(d1, 4) - pow(d2, 4)) / 32.;  // torsion
+
+            // populate reference point
+            reference_point.stiffness_foreaft = EI;
+            reference_point.stiffness_sideside = EI;
+            reference_point.stiffness_axial = EA;
+            reference_point.stiffness_torsion = kt;
+            reference_point.density = density_linear;
+
+            reference_points.push_back(reference_point);
+        } else if (tower_type == "anisotropic") {
+            for (int ii = 0; ii < points.size(); ii++) {
+                // populate reference point
+                point.at("stiffness_sideside").get_to(reference_point.stiffness_sideside);
+                point.at("stiffness_foreaft").get_to(reference_point.stiffness_foreaft);
+                point.at("stiffness_axial").get_to(reference_point.stiffness_axial);
+                point.at("stiffness_torsion").get_to(reference_point.stiffness_torsion);
+                point.at("density").get_to(reference_point.density);
+
+                reference_points.push_back(reference_point);
+            }
+        } else {
+            throw std::runtime_error("Tower type \"" + tower_type +
+                                     "\" not recognised (try \"cylinder\" or \"anisotropic\").");
+        }
     }
 
     return reference_points;

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -130,7 +130,7 @@ TEST(test_tower, mass) {
     system_elasto.do_statics(true, 0);
 
     // check mass
-    double tower_mass = 870391.59776;
+    double tower_mass = 853463.237;
     ASSERT_NEAR(tower_mass, tower.get_mass(), 1.0);
 }
 
@@ -295,19 +295,19 @@ TEST(test_tower, tower_shadow_check) {
     auto position1 = Vector3d(-14.0, -5.0, 50.0);
     Vector3d wind_velocity1 = wind_velocity;
     seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity1, position1, tower_aero);
-    ASSERT_NEAR(wind_velocity1.x(), 9.216867, 0.001);
+    ASSERT_NEAR(wind_velocity1.x(), 9.315126, 1e-4);
 
     // position 2
     auto position2 = Vector3d(-15.0, 0.0, 45.0);
     Vector3d wind_velocity2 = wind_velocity;
     seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity2, position2, tower_aero);
-    ASSERT_NEAR(wind_velocity2.x(), 8.964047, 0.001);
+    ASSERT_NEAR(wind_velocity2.x(), 9.091580, 1e-4);
 
     // position 3
     auto position3 = Vector3d(-16.0, 2.0, 20.0);
     Vector3d wind_velocity3 = wind_velocity;
     seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity3, position3, tower_aero);
-    ASSERT_NEAR(wind_velocity3.x(), 9.068192, 0.001);
+    ASSERT_NEAR(wind_velocity3.x(), 9.163947, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch) {
@@ -366,7 +366,7 @@ TEST(test_turbine, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.779032, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.780339, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
@@ -425,7 +425,7 @@ TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.791585, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.792103, 1e-4);
 }
 
 TEST(test_turbine, controller_target_rpm) {
@@ -638,7 +638,7 @@ TEST(test_aerodyn, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.750755, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.750998, 1e-4);
 }
 #endif
 
@@ -773,6 +773,6 @@ TEST(test_inflowwind, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.765498, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.766250, 1e-4);
 }
 #endif


### PR DESCRIPTION
In this PR:
- Simplify tower definition with steel properties and diameter, thickness along tower
- Make 2 modes for tower definition: "cylinder" (diameter, thickness), and "anisotropic" (linear density, stiffnesses)
- Change tower properties to align to latest version of [IEAWindTask37](https://github.com/IEAWindTask37/IEA-15-240-RWT)
- Fix tests affected by mass and diameter change of tower