### PR TITLE
Add more python bindings for elasto and io

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,6 +445,7 @@ if (SEAHOWL_ENABLE_PYTHON)
         ${PYSEAHOWL_DIR}/pyseahowl_aero.cpp
         ${PYSEAHOWL_DIR}/pyseahowl_servo.cpp
         ${PYSEAHOWL_DIR}/pyseahowl_core.cpp
+        ${PYSEAHOWL_DIR}/pyseahowl_io.cpp
     )
 	target_compile_features(pyseahowl PRIVATE cxx_std_17)
     target_link_libraries(pyseahowl PRIVATE seahowl_core)

--- a/examples/python/ex_system.py
+++ b/examples/python/ex_system.py
@@ -11,7 +11,7 @@ t_output_next = 0.0
 system_elasto = pyseahowl.elasto.SystemElastoChrono()
 system_aero = pyseahowl.aero.SystemAero()
 system_core = pyseahowl.core.System(system_elasto, system_aero)
-pyseahowl.populate_system_from_json(filepath, system_core)
+pyseahowl.io.populate_system_from_json(filepath, system_core)
 
 # fix tower bottom nodes
 for turbine in system_core.turbines:

--- a/include/seahowl/commons/entities.h
+++ b/include/seahowl/commons/entities.h
@@ -35,6 +35,18 @@ class Entity {
      * @brief Returns rotation of entity.
      */
     virtual Quaternion get_rotation() const = 0;
+
+    /**
+     * @brief Returns rotation matrix of entity.
+     */
+    Eigen::Matrix<double, 3, 3> get_rotation_matrix() const { return get_rotation().toRotationMatrix(); };
+
+    /**
+     * @brief Sets rotation matrix of entity.
+     *
+     * @param[in] rotation Rotation matrix of entity.
+     */
+    void set_rotation_matrix(Eigen::Matrix<double, 3, 3> rotation) { set_rotation(Quaternion(rotation)); };
 };
 
 /**

--- a/include/seahowl/core/system.h
+++ b/include/seahowl/core/system.h
@@ -11,6 +11,9 @@ namespace env {
 class FluidModel;
 class SoilModel;
 }  // namespace env
+namespace servo {
+class Controller;
+}  // namespace servo
 namespace aero {
 class SystemAero;
 }  // namespace aero
@@ -93,7 +96,7 @@ class System : public ComponentDynamic {
     /**
      * @brief Returns time of simulation.
      */
-    double get_time();
+    double get_time() const;
 
     /**
      * @brief Sets time of simulation.

--- a/include/seahowl/elasto/mooring_elasto.h
+++ b/include/seahowl/elasto/mooring_elasto.h
@@ -50,9 +50,9 @@ class MooringElasto : public virtual ComponentElasto {
 struct MooringSystem : public ComponentElasto {
   public:
     /** @brief List of mooring lines. */
-    std::deque<std::unique_ptr<MooringElasto>> moorings;
+    std::deque<std::shared_ptr<MooringElasto>> moorings;
     /** @brief List of anchors. */
-    std::deque<std::unique_ptr<BodyElasto>> anchors;
+    std::deque<std::shared_ptr<BodyElasto>> anchors;
 
     /**
      * @brief Constructor.

--- a/include/seahowl/elasto/turbine_floating_elasto.h
+++ b/include/seahowl/elasto/turbine_floating_elasto.h
@@ -28,7 +28,7 @@ class TurbineFloatingElasto : public TurbineElasto {
     // components
     //
     /** @brief Floater of the turbine. */
-    std::unique_ptr<seahowl::elasto::FloaterElasto> floater;
+    std::shared_ptr<seahowl::elasto::FloaterElasto> floater;
     /** @brief Link between floater and tower of the turbine. */
     std::unique_ptr<seahowl::elasto::Link> link_floater_tower;
     /** @brief Floater of the turbine. */

--- a/include/seahowl/io/write_csv.h
+++ b/include/seahowl/io/write_csv.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <string>
 
 // forward declarations
@@ -14,4 +16,4 @@ class System;
  * @param[in] ssystem System to output.
  * @param[in] time Time of simulation.
  */
-void write_turbine_info_to_csv(std::string fileprefix, const seahowl::core::System& ssystem, double time);
+void write_turbine_info_to_csv(std::string fileprefix, const seahowl::core::System& ssystem);

--- a/src/bindings/pyseahowl.cpp
+++ b/src/bindings/pyseahowl.cpp
@@ -3,17 +3,6 @@
 #include <pybind11/eigen.h>
 
 #include <seahowl/commons/entities.h>
-#include <seahowl/io/read_json.h>
-#include <seahowl/core/blade.h>
-#include <seahowl/core/rotor.h>
-#include <seahowl/core/turbine.h>
-#include <seahowl/core/system.h>
-#include <seahowl/elasto/blade_elasto.h>
-#include <seahowl/elasto/tower_elasto.h>
-#include <seahowl/elasto/rotor_elasto.h>
-#include <seahowl/aero/blade_aero.h>
-#include <seahowl/aero/tower_aero.h>
-#include <seahowl/aero/rotor_aero.h>
 
 namespace py = pybind11;
 
@@ -22,6 +11,7 @@ void initialize_pyseahowl_elasto(py::module& m);
 void initialize_pyseahowl_aero(py::module& m);
 void initialize_pyseahowl_servo(py::module& m);
 void initialize_pyseahowl_core(py::module& m);
+void initialize_pyseahowl_io(py::module& m);
 
 PYBIND11_MODULE(pyseahowl, m) {
     // commons.h
@@ -58,14 +48,6 @@ PYBIND11_MODULE(pyseahowl, m) {
     // core
     initialize_pyseahowl_core(m);
 
-    // io/read_json.h
-    m.def("populate_blade_from_json", &populate_blade_from_json);
-    m.def("populate_blade_elasto_from_json", &populate_blade_elasto_from_json);
-    m.def("populate_blade_aero_from_json", &populate_blade_aero_from_json);
-    m.def("populate_tower_from_json", &populate_tower_from_json);
-    m.def("populate_tower_elasto_from_json", &populate_tower_elasto_from_json);
-    m.def("populate_tower_aero_from_json", &populate_tower_aero_from_json);
-    m.def("populate_rna_from_json", &populate_rna_from_json);
-    m.def("populate_turbine_from_json", &populate_turbine_from_json);
-    m.def("populate_system_from_json", &populate_system_from_json);
+    // io
+    initialize_pyseahowl_io(m);
 }

--- a/src/bindings/pyseahowl.cpp
+++ b/src/bindings/pyseahowl.cpp
@@ -18,8 +18,10 @@ PYBIND11_MODULE(pyseahowl, m) {
     py::class_<seahowl::Entity, std::shared_ptr<seahowl::Entity>>(m, "Entity")
         .def("get_position", &seahowl::Entity::get_position)
         .def("set_position", &seahowl::Entity::set_position)
-        .def("get_rotation", &seahowl::Entity::get_rotation)
-        .def("set_rotation", &seahowl::Entity::set_rotation);
+        //.def("get_rotation", &seahowl::Entity::get_rotation)
+        .def("get_rotation_matrix", &seahowl::Entity::get_rotation_matrix)
+        //.def("set_rotation", &seahowl::Entity::set_rotation)
+        .def("set_rotation_matrix", &seahowl::Entity::set_rotation_matrix);
     py::class_<seahowl::EntityDynamic, std::shared_ptr<seahowl::EntityDynamic>, seahowl::Entity>(m, "EntityDynamic")
         .def("get_velocity", &seahowl::EntityDynamic::get_velocity)
         .def("set_velocity", &seahowl::EntityDynamic::set_velocity)

--- a/src/bindings/pyseahowl_core.cpp
+++ b/src/bindings/pyseahowl_core.cpp
@@ -4,6 +4,7 @@
 
 #include <seahowl/core/component.h>
 #include <seahowl/core/turbine.h>
+#include <seahowl/core/turbine_floating.h>
 #include <seahowl/elasto/turbine_elasto.h>
 #include <seahowl/aero/turbine_aero.h>
 #include <seahowl/core/rotor.h>
@@ -44,6 +45,23 @@ void initialize_pyseahowl_core(py::module& m) {
         .def_readonly("tower", &seahowl::core::Turbine::tower)
         .def_readonly("rna", &seahowl::core::Turbine::rna);
 
+    // core/turbine_floating.h
+    py::class_<seahowl::core::TurbineFloating, std::shared_ptr<seahowl::core::TurbineFloating>, seahowl::core::Turbine>(
+        m_core, "TurbineFloating")
+        .def(py::init<seahowl::elasto::TurbineFloatingElasto&, seahowl::aero::TurbineAero&>())
+        .def_property_readonly("elasto", [](seahowl::core::Turbine& turbine) { return &turbine.elasto; })
+        .def_property_readonly("aero", [](seahowl::core::Turbine& turbine) { return &turbine.aero; });
+    m_core.def(
+        "get_turbine_floating_reference",
+        [](seahowl::core::Turbine& turbine) {
+            try {
+                return dynamic_cast<seahowl::core::TurbineFloating&>(turbine);
+            } catch (const std::bad_cast& e) {
+                throw std::runtime_error("Cannot convert Turbine reference to TurbineFloating reference.");
+            }
+        },
+        py::return_value_policy::reference_internal);
+
     // core/tower.h
     py::class_<seahowl::core::Tower, std::shared_ptr<seahowl::core::Tower>, seahowl::core::ComponentDynamic>(m_core,
                                                                                                              "Tower")
@@ -69,6 +87,9 @@ void initialize_pyseahowl_core(py::module& m) {
         .def(py::init<seahowl::elasto::SystemElasto&, seahowl::aero::SystemAero&>())
         .def("step", &seahowl::core::System::step)
         .def("get_time", &seahowl::core::System::get_time)
+        .def("set_time", &seahowl::core::System::set_time)
+        .def("run_presetup", &seahowl::core::System::run_presetup)
+        .def("run_presimulation", &seahowl::core::System::run_presimulation)
         .def_readonly("turbines", &seahowl::core::System::turbines)
         .def_readwrite("fluid_model", &seahowl::core::System::fluid_model)
         .def_property_readonly("elasto", [](seahowl::core::System& system) { return &system.elasto; })

--- a/src/bindings/pyseahowl_elasto.cpp
+++ b/src/bindings/pyseahowl_elasto.cpp
@@ -8,7 +8,10 @@
 #include <seahowl/elasto/blade_elasto.h>
 #include <seahowl/elasto/rotor_elasto.h>
 #include <seahowl/elasto/tower_elasto.h>
+#include <seahowl/elasto/mooring_elasto.h>
+#include <seahowl/elasto/floater_elasto.h>
 #include <seahowl/elasto/turbine_elasto.h>
+#include <seahowl/elasto/turbine_floating_elasto.h>
 #include <seahowl/elasto/system_elasto.h>
 #include <seahowl/elasto/chrono_adapters.h>
 
@@ -228,5 +231,52 @@ void initialize_pyseahowl_elasto(py::module& m) {
                                                                                                 "TurbineElasto")
         .def_readonly("rna", &seahowl::elasto::TurbineElasto::rna)
         .def_readonly("tower", &seahowl::elasto::TurbineElasto::tower)
+        .def(py::init<>());
+
+    // elasto/floater_elasto.h
+    py::class_<seahowl::elasto::FloaterElasto, std::shared_ptr<seahowl::elasto::FloaterElasto>,
+               seahowl::elasto::ComponentElasto>(m_elasto, "FloaterElasto")
+        .def("add_body", &seahowl::elasto::FloaterElasto::add_body)
+        .def("get_body", &seahowl::elasto::FloaterElasto::get_body, py::return_value_policy::reference_internal)
+        .def("add_fairlead", &seahowl::elasto::FloaterElasto::add_fairlead)
+        .def("get_fairlead_link", &seahowl::elasto::FloaterElasto::get_fairlead_link,
+             py::return_value_policy::reference_internal)
+        .def("get_fairlead_body", &seahowl::elasto::FloaterElasto::get_fairlead_body,
+             py::return_value_policy::reference_internal)
+        .def("set_tower_connection_body_name", &seahowl::elasto::FloaterElasto::set_tower_connection_body_name)
+        .def("get_tower_connection_body", &seahowl::elasto::FloaterElasto::get_tower_connection_body,
+             py::return_value_policy::reference_internal);
+
+    // elasto/mooring_elasto.h
+    py::class_<seahowl::elasto::MooringSystem, std::shared_ptr<seahowl::elasto::MooringSystem>,
+               seahowl::elasto::ComponentElasto>(m_elasto, "MooringSystem")
+        .def(py::init<>())
+        .def_readwrite("moorings", &seahowl::elasto::MooringSystem::moorings)
+        .def_readwrite("anchors", &seahowl::elasto::MooringSystem::anchors);
+    py::class_<seahowl::elasto::MooringElasto, std::shared_ptr<seahowl::elasto::MooringElasto>,
+               seahowl::elasto::ComponentElasto>(m_elasto, "MooringElasto")
+        .def_property_readonly("fairlead", [](seahowl::elasto::MooringElasto& mooring) { return &mooring.fairlead; })
+        .def_property_readonly("anchor", [](seahowl::elasto::MooringElasto& mooring) { return &mooring.anchor; })
+        .def("get_tension_fairlead", &seahowl::elasto::MooringElasto::get_tension_fairlead)
+        .def("get_tension_anchor", &seahowl::elasto::MooringElasto::get_tension_anchor);
+    py::class_<seahowl::elasto::MooringElastoFEA, std::shared_ptr<seahowl::elasto::MooringElastoFEA>,
+               seahowl::elasto::MooringElasto, seahowl::elasto::ComponentElastoFEA>(m_elasto, "MooringElastoFEA")
+        .def(py::init<seahowl::elasto::BodyElasto&, seahowl::elasto::BodyElasto&>());
+
+    // elasto/turbine_floating_elasto.h
+    py::class_<seahowl::elasto::TurbineFloatingElasto, std::shared_ptr<seahowl::elasto::TurbineFloatingElasto>,
+               seahowl::elasto::TurbineElasto>(m_elasto, "TurbineFloatingElasto")
+        //.def_property_readonly(
+        //    "floater", [](seahowl::elasto::TurbineFloatingElasto& turbine) { return turbine.floater.get(); },
+        //    py::return_value_policy::reference_internal)
+        .def_readwrite("floater", &seahowl::elasto::TurbineFloatingElasto::floater)
+        .def_property_readonly(
+            "link_floater_tower",
+            [](seahowl::elasto::TurbineFloatingElasto& turbine) { return turbine.link_floater_tower.get(); },
+            py::return_value_policy::reference_internal)
+        .def_property_readonly(
+            "mooring_system",
+            [](seahowl::elasto::TurbineFloatingElasto& turbine) { return turbine.mooring_system.get(); },
+            py::return_value_policy::reference_internal)
         .def(py::init<>());
 }

--- a/src/bindings/pyseahowl_elasto.cpp
+++ b/src/bindings/pyseahowl_elasto.cpp
@@ -56,6 +56,8 @@ void initialize_pyseahowl_elasto(py::module& m) {
     py::class_<seahowl::elasto::SystemElasto, std::shared_ptr<seahowl::elasto::SystemElasto>>(m_elasto, "SystemElasto")
         .def("step", &seahowl::elasto::SystemElasto::step)
         .def("get_time", &seahowl::elasto::SystemElasto::get_time)
+        .def("set_gravitational_acceleration", &seahowl::elasto::SystemElasto::set_gravitational_acceleration)
+        .def("get_gravitational_acceleration", &seahowl::elasto::SystemElasto::get_gravitational_acceleration)
         .def("do_statics", &seahowl::elasto::SystemElasto::do_statics);
 
     // elasto/chrono_adapters.h

--- a/src/bindings/pyseahowl_elasto.cpp
+++ b/src/bindings/pyseahowl_elasto.cpp
@@ -4,6 +4,7 @@
 
 #include <seahowl/elasto/entities_elasto.h>
 #include <seahowl/elasto/component_elasto.h>
+#include <seahowl/elasto/reference_point_elasto.h>
 #include <seahowl/elasto/blade_elasto.h>
 #include <seahowl/elasto/rotor_elasto.h>
 #include <seahowl/elasto/tower_elasto.h>
@@ -42,14 +43,22 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("set_fixed", &seahowl::elasto::NodeElasto::set_fixed);
     py::class_<seahowl::elasto::ElementElasto, std::shared_ptr<seahowl::elasto::ElementElasto>>(m_elasto,
                                                                                                 "ElementElasto")
+        .def("set_nodes", &seahowl::elasto::ElementElasto::set_nodes)
         .def("evaluate_position_rotation", &seahowl::elasto::ElementElasto::evaluate_position_rotation)
         .def("evaluate_force_torque", &seahowl::elasto::ElementElasto::evaluate_force_torque)
         .def("get_force", &seahowl::elasto::ElementElasto::get_force)
         .def("get_torque", &seahowl::elasto::ElementElasto::get_torque)
         .def("get_mass", &seahowl::elasto::ElementElasto::get_mass);
     py::class_<seahowl::elasto::ElementBladeElasto, std::shared_ptr<seahowl::elasto::ElementBladeElasto>,
-               seahowl::elasto::ElementElasto>(m_elasto, "ElementBladeElasto");
+               seahowl::elasto::ElementElasto>(m_elasto, "ElementBladeElasto")
+        .def("set_prebend", &seahowl::elasto::ElementBladeElasto::set_prebend);
+    py::class_<seahowl::elasto::ElementMooringElasto, std::shared_ptr<seahowl::elasto::ElementMooringElasto>,
+               seahowl::elasto::ElementElasto>(m_elasto, "ElementMooringElasto")
+        .def("set_properties", &seahowl::elasto::ElementMooringElasto::set_properties)
+        .def("set_rest_length", &seahowl::elasto::ElementMooringElasto::set_rest_length)
+        .def("get_rest_length", &seahowl::elasto::ElementMooringElasto::get_rest_length);
     py::class_<seahowl::elasto::Link, std::shared_ptr<seahowl::elasto::Link>>(m_elasto, "Link")
+        .def("set_constraints", &seahowl::elasto::Link::set_constraints)
         .def("get_reaction_force", &seahowl::elasto::Link::get_reaction_force)
         .def("get_reaction_torque", &seahowl::elasto::Link::get_reaction_torque);
     py::class_<seahowl::elasto::MeshElasto, std::shared_ptr<seahowl::elasto::MeshElasto>>(m_elasto, "MeshElasto");
@@ -61,6 +70,32 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("do_statics", &seahowl::elasto::SystemElasto::do_statics);
 
     // elasto/chrono_adapters.h
+    py::class_<seahowl::elasto::BodyElastoChrono, std::shared_ptr<seahowl::elasto::BodyElastoChrono>,
+               seahowl::elasto::BodyElasto>(m_elasto, "BodyElastoChrono")
+        .def(py::init<>());
+    py::class_<seahowl::elasto::NodeElastoChrono, std::shared_ptr<seahowl::elasto::NodeElastoChrono>,
+               seahowl::elasto::NodeElasto>(m_elasto, "NodeElastoChrono")
+        .def(py::init<seahowl::Vector3d&, seahowl::Quaternion&>());
+    py::class_<seahowl::elasto::NodeElastoChronoD, std::shared_ptr<seahowl::elasto::NodeElastoChronoD>,
+               seahowl::elasto::NodeElasto>(m_elasto, "NodeElastoChronoD")
+        .def(py::init<seahowl::Vector3d&, seahowl::Vector3d&>());
+    py::class_<seahowl::elasto::ElementBladeElastoChrono, std::shared_ptr<seahowl::elasto::ElementBladeElastoChrono>,
+               seahowl::elasto::ElementBladeElasto>(m_elasto, "ElementBladeElastoChrono")
+        .def(py::init<>());
+    py::class_<seahowl::elasto::ElementBladeElastoChronoFPM,
+               std::shared_ptr<seahowl::elasto::ElementBladeElastoChronoFPM>, seahowl::elasto::ElementBladeElasto>(
+        m_elasto, "ElementBladeElastoChronoFPM")
+        .def(py::init<>());
+    py::class_<seahowl::elasto::ElementMooringElastoChrono,
+               std::shared_ptr<seahowl::elasto::ElementMooringElastoChrono>, seahowl::elasto::ElementMooringElasto>(
+        m_elasto, "ElementMooringElastoChrono")
+        .def(py::init<>());
+    py::class_<seahowl::elasto::LinkChrono, std::shared_ptr<seahowl::elasto::LinkChrono>, seahowl::elasto::Link>(
+        m_elasto, "LinkChrono")
+        .def(py::init<>());
+    py::class_<seahowl::elasto::LinkChronoCable, std::shared_ptr<seahowl::elasto::LinkChronoCable>,
+               seahowl::elasto::Link>(m_elasto, "LinkChronoCable")
+        .def(py::init<>());
     py::class_<seahowl::elasto::MeshElastoChrono, std::shared_ptr<seahowl::elasto::MeshElastoChrono>,
                seahowl::elasto::MeshElasto>(m_elasto, "MeshElastoChrono")
         .def(py::init<>());
@@ -68,22 +103,73 @@ void initialize_pyseahowl_elasto(py::module& m) {
                seahowl::elasto::SystemElasto>(m_elasto, "SystemElastoChrono")
         .def(py::init<>());
 
+    // elasto/reference_point_elasto.h
+    py::class_<seahowl::elasto::ReferencePointElasto, std::shared_ptr<seahowl::elasto::ReferencePointElasto>>(
+        m_elasto, "ReferencePointElasto")
+        .def_readwrite("coordinates", &seahowl::elasto::ReferencePointElasto::coordinates)
+        .def_readwrite("fraction", &seahowl::elasto::ReferencePointElasto::fraction)
+        .def(py::init<>());
+    py::class_<seahowl::elasto::BladeReferencePointElasto, std::shared_ptr<seahowl::elasto::BladeReferencePointElasto>,
+               seahowl::elasto::ReferencePointElasto>(m_elasto, "BladeReferencePointElasto")
+        .def_readwrite("offset_elastic", &seahowl::elasto::BladeReferencePointElasto::offset_elastic)
+        .def_readwrite("offset_gravity", &seahowl::elasto::BladeReferencePointElasto::offset_gravity)
+        .def_readwrite("stiffness_matrix", &seahowl::elasto::BladeReferencePointElasto::stiffness_matrix)
+        .def_readwrite("mass_matrix", &seahowl::elasto::BladeReferencePointElasto::mass_matrix)
+        .def_readwrite("structural_twist", &seahowl::elasto::BladeReferencePointElasto::structural_twist)
+        .def_readwrite("damping_coefficients", &seahowl::elasto::BladeReferencePointElasto::damping_coefficients)
+        .def(py::init<>());
+    py::class_<seahowl::elasto::TowerReferencePointElasto, std::shared_ptr<seahowl::elasto::TowerReferencePointElasto>,
+               seahowl::elasto::ReferencePointElasto>(m_elasto, "TowerReferencePointElasto")
+        .def_readwrite("density", &seahowl::elasto::TowerReferencePointElasto::density)
+        .def_readwrite("stiffness_axial", &seahowl::elasto::TowerReferencePointElasto::stiffness_axial)
+        .def_readwrite("stiffness_foreaft", &seahowl::elasto::TowerReferencePointElasto::stiffness_foreaft)
+        .def_readwrite("stiffness_sideside", &seahowl::elasto::TowerReferencePointElasto::stiffness_sideside)
+        .def_readwrite("stiffness_torsion", &seahowl::elasto::TowerReferencePointElasto::stiffness_torsion)
+        .def_readwrite("damping_coefficients", &seahowl::elasto::TowerReferencePointElasto::damping_coefficients)
+        .def(py::init<>());
+
     // elasto/component_elasto.h
     py::class_<seahowl::elasto::ComponentElasto, std::shared_ptr<seahowl::elasto::ComponentElasto>>(m_elasto,
                                                                                                     "ComponentElasto")
+        .def("assemble", &seahowl::elasto::ComponentElasto::assemble)
+        .def("reset_loads", &seahowl::elasto::ComponentElasto::reset_loads)
         .def("rotate", &seahowl::elasto::ComponentElasto::rotate)
-        .def("translate", &seahowl::elasto::ComponentElasto::translate);
+        .def("translate", &seahowl::elasto::ComponentElasto::translate)
+        .def("get_mass", &seahowl::elasto::ComponentElasto::get_mass);
     py::class_<seahowl::elasto::ComponentElastoFEA, std::shared_ptr<seahowl::elasto::ComponentElastoFEA>,
                seahowl::elasto::ComponentElasto>(m_elasto, "ComponentElastoFEA")
         .def_readonly("nodes", &seahowl::elasto::ComponentElastoFEA::nodes)
-        .def_readonly("elements", &seahowl::elasto::ComponentElastoFEA::elements);
+        .def_readonly("elements", &seahowl::elasto::ComponentElastoFEA::elements)
+        .def_readwrite("discretization_fractions", &seahowl::elasto::ComponentElastoFEA::discretization_fractions)
+        .def("evaluate_position_rotation", &seahowl::elasto::ComponentElastoFEA::evaluate_position_rotation)
+        .def("accumulate_element_load", &seahowl::elasto::ComponentElastoFEA::accumulate_element_load);
 
     // elasto/blade_elasto.h
-    py::class_<seahowl::elasto::BladeElasto, std::shared_ptr<seahowl::elasto::BladeElasto>>(m_elasto, "BladeElasto")
+    py::class_<seahowl::elasto::BladeElasto, std::shared_ptr<seahowl::elasto::BladeElasto>,
+               seahowl::elasto::ComponentElasto>(m_elasto, "BladeElasto")
+        .def_readonly("pitch", &seahowl::elasto::BladeElasto::pitch)
+        .def_readonly("azimuth0", &seahowl::elasto::BladeElasto::azimuth0)
+        .def_readonly("precone", &seahowl::elasto::BladeElasto::precone)
+        .def_readwrite("reference_points", &seahowl::elasto::BladeElasto::reference_points)
+        .def_readwrite("discretization_fractions", &seahowl::elasto::BladeElasto::discretization_fractions)
         .def("apply_pitch_increment", &seahowl::elasto::BladeElasto::apply_pitch_increment)
         .def("get_blade_root_moment", &seahowl::elasto::BladeElasto::get_blade_root_moment)
-        .def_readonly("pitch", &seahowl::elasto::BladeElasto::pitch)
-        .def_readonly("azimuth0", &seahowl::elasto::BladeElasto::azimuth0);
+        .def("get_entity_along_blade", &seahowl::elasto::BladeElasto::get_entity_along_blade)
+        .def("accumulate_load_along_blade", &seahowl::elasto::BladeElasto::accumulate_load_along_blade)
+        .def("attach_root_to_body", &seahowl::elasto::BladeElasto::attach_root_to_body);
+    py::class_<seahowl::elasto::BladeElastoFEA, std::shared_ptr<seahowl::elasto::BladeElastoFEA>,
+               seahowl::elasto::BladeElasto, seahowl::elasto::ComponentElastoFEA>(m_elasto, "BladeElastoFEA")
+        .def_readonly("discretized_points", &seahowl::elasto::BladeElastoFEA::discretized_points)
+        .def_readwrite("fpm_mode", &seahowl::elasto::BladeElastoFEA::fpm_mode)
+        .def(py::init<>());
+    py::class_<seahowl::elasto::BladeElastoRigid, std::shared_ptr<seahowl::elasto::BladeElastoRigid>,
+               seahowl::elasto::BladeElasto>(m_elasto, "BladeElastoRigid")
+        .def_property_readonly(
+            "body_root", [](seahowl::elasto::BladeElastoRigid& blade) { return blade.body_root.get(); },
+            py::return_value_policy::reference_internal)
+        .def_readwrite("length", &seahowl::elasto::BladeElastoRigid::length)
+        .def_readwrite("mass", &seahowl::elasto::BladeElastoRigid::mass)
+        .def(py::init<>());
 
     // elasto/rotor_elasto.h
     py::class_<seahowl::elasto::RotorElasto, std::shared_ptr<seahowl::elasto::RotorElasto>>(m_elasto, "RotorElasto")
@@ -131,9 +217,10 @@ void initialize_pyseahowl_elasto(py::module& m) {
     // elasto/tower_elasto.h
     py::class_<seahowl::elasto::TowerElasto, std::shared_ptr<seahowl::elasto::TowerElasto>,
                seahowl::elasto::ComponentElastoFEA>(m_elasto, "TowerElasto")
+        .def_readwrite("reference_points", &seahowl::elasto::TowerElasto::reference_points)
+        .def_readonly("discretized_points", &seahowl::elasto::TowerElasto::discretized_points)
         .def(py::init<>())
         .def("build", &seahowl::elasto::TowerElasto::build)
-        .def("assemble", &seahowl::elasto::TowerElasto::assemble)
         .def("get_tower_base_moment", &seahowl::elasto::TowerElasto::get_tower_base_moment);
 
     // elasto/turbine_elasto.h

--- a/src/bindings/pyseahowl_io.cpp
+++ b/src/bindings/pyseahowl_io.cpp
@@ -1,0 +1,37 @@
+#include <pybind11/pybind11.h>
+
+#include <seahowl/io/read_json.h>
+#include <seahowl/core/blade.h>
+#include <seahowl/core/tower.h>
+#include <seahowl/core/rotor.h>
+#include <seahowl/core/turbine.h>
+#include <seahowl/core/system.h>
+#include <seahowl/elasto/blade_elasto.h>
+#include <seahowl/elasto/tower_elasto.h>
+#include <seahowl/elasto/rotor_elasto.h>
+#include <seahowl/aero/blade_aero.h>
+#include <seahowl/aero/tower_aero.h>
+#include <seahowl/aero/rotor_aero.h>
+#include <seahowl/io/write_csv.h>
+
+namespace py = pybind11;
+
+void initialize_pyseahowl_io(py::module& m) {
+    // submodule
+    auto m_io = m.def_submodule("io", "Inpout/output submodule.");
+
+    // io/read_json.h
+    m_io.def("populate_blade_from_json", &populate_blade_from_json);
+    m_io.def("populate_blade_elasto_from_json", &populate_blade_elasto_from_json);
+    m_io.def("populate_blade_aero_from_json", &populate_blade_aero_from_json);
+    m_io.def("populate_tower_from_json", &populate_tower_from_json);
+    m_io.def("populate_tower_elasto_from_json", &populate_tower_elasto_from_json);
+    m_io.def("populate_tower_aero_from_json", &populate_tower_aero_from_json);
+    m_io.def("populate_rna_from_json", &populate_rna_from_json);
+    m_io.def("populate_turbine_from_json", &populate_turbine_from_json);
+    m_io.def("populate_system_from_json", &populate_system_from_json);
+    m_io.def("initialize_system_from_json", &initialize_system_from_json);
+
+    // io/write_csv.h
+    m_io.def("write_turbine_info_to_csv", &write_turbine_info_to_csv);
+}

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -65,7 +65,7 @@ void System::assemble() {
     }
 }
 
-double System::get_time() {
+double System::get_time() const {
     return elasto.get_time();
 }
 

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -657,7 +657,7 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
             spdlog::info("Hydrodynamic model: HydroChrono.");
 #ifdef HAVE_HYDROCHRONO
             // make floater
-            turbine_floating.floater = std::make_unique<seahowl::hydro::FloaterHydroChrono>();
+            turbine_floating.floater = std::make_shared<seahowl::hydro::FloaterHydroChrono>();
             auto& floater = dynamic_cast<seahowl::hydro::FloaterHydroChrono&>(*turbine_floating.floater);
             auto floater_options = json_obj_floater.at("options");
             // add h5file path
@@ -736,7 +736,7 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
                     anchor_position += floater.get_body(body_name).get_position();
                 }
                 turbine_floating.mooring_system->anchors.push_back(
-                    std::make_unique<seahowl::elasto::BodyElastoChrono>());
+                    std::make_shared<seahowl::elasto::BodyElastoChrono>());
                 auto& anchor_body = *turbine_floating.mooring_system->anchors.back();
                 anchor_body.set_position(anchor_position);
                 anchor_body.set_fixed(true);
@@ -744,7 +744,7 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
                 auto mooring_properties_json = get_json_from_file(
                     (DATADIR / mooring_json.at("line_properties").get<std::string>()).generic_string());
                 turbine_floating.mooring_system->moorings.push_back(
-                    std::make_unique<seahowl::elasto::MooringElastoFEA>(fairlead_body, anchor_body));
+                    std::make_shared<seahowl::elasto::MooringElastoFEA>(fairlead_body, anchor_body));
                 auto& mooring =
                     dynamic_cast<seahowl::elasto::MooringElastoFEA&>(*turbine_floating.mooring_system->moorings.back());
 

--- a/src/io/write_csv.cpp
+++ b/src/io/write_csv.cpp
@@ -14,7 +14,8 @@
 
 using seahowl::PI;
 
-void write_turbine_info_to_csv(std::string fileprefix, const seahowl::core::System& ssystem, double time) {
+void write_turbine_info_to_csv(std::string fileprefix, const seahowl::core::System& ssystem) {
+    auto time = ssystem.get_time();
     for (int idx_turbine = 0; idx_turbine < ssystem.turbines.size(); idx_turbine++) {
         auto& turbine = *ssystem.turbines[idx_turbine];
         std::string filename;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ void output_results(seahowl::core::System& system_core) {
     spdlog::info(output_sstring.str());
 
     // output info in file
-    write_turbine_info_to_csv("./output/output", system_core, system_core.get_time());
+    write_turbine_info_to_csv("./output/output", system_core);
 }
 
 void run_simulation(int argc, char* argv[]) {


### PR DESCRIPTION
More python bindings for elasto and io modules.
Some `unique_ptr` were converted to `shared_ptr` as it integrates better with pybind11 when they are in a vector/deque.
It also adds a function `core.get_turbine_floating_reference` to convert a turbine object into a floating turbine object in python, if possible.