### PR TITLE
Make InflowWind simpler to link

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ It is a JSON dictionary containing:
   "type": "inflowwind",
   "options": {
      "file_inflowwind": "./aerodyn/IEA-15-240-RWT_InflowWind.dat",
-     "file_windwnd": "./aerodyn/long_step_wind.wnd"
   }
 }
 ```

--- a/cmake/FindAERODYN.cmake
+++ b/cmake/FindAERODYN.cmake
@@ -6,9 +6,6 @@ find_library(AERODYN_LIBRARY
   PATHS ${PC_AERODYN_LIBRARY_DIRS}
 )
 
-include(SelectLibraryConfigurations)
-select_library_configurations(AERODYN)
-
 set(PC_AERODYN_VERSION "1.0.0") #${PC_AERODYN_VERSION})
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/FindINFLOWWIND.cmake
+++ b/cmake/FindINFLOWWIND.cmake
@@ -6,9 +6,6 @@ find_library(INFLOWWIND_LIBRARY
   PATHS ${PC_INFLOWWIND_LIBRARY_DIRS}
 )
 
-include(SelectLibraryConfigurations)
-select_library_configurations(INFLOWWIND)
-
 set(PC_INFLOWWIND_VERSION "0.1.0")
 
 include(FindPackageHandleStandardArgs)

--- a/data/IEA15MW/environment_inflowwind.json
+++ b/data/IEA15MW/environment_inflowwind.json
@@ -1,0 +1,28 @@
+﻿{
+  "gravity": [0.0, 0.0, -9.81],
+  "wind": {
+    "type": "inflowwind",
+    "options": {
+       "file_inflowwind": "./aerodyn/IEA-15-240-RWT_InflowWind.dat"
+    }
+  },
+  "sea": {
+    "type": "current",
+    "water_density": 1025,
+    "mean_water_level": 0.0,
+    "water_depth": 200.0,
+    "options": {
+      "direction": [1.0, 0.0],
+      "velocity_surface": 0.0,
+      "velocity_seabed": 0.0
+    }
+  },
+  "soil": {
+    "type": "linear",
+    "options": {
+      "stiffness_normal": 1e5,
+      "stiffness_shear": 0.0,
+      "soil_position": -200.0
+    }
+  }
+}

--- a/include/seahowl/env/inflowwind_adapter.h
+++ b/include/seahowl/env/inflowwind_adapter.h
@@ -49,7 +49,6 @@ struct InflowWindLib {
     float* Velocity;
 
     void SetIFWINFILE(std::string name);
-    void SetWNDINFILE(std::string name);
     void CheckError();
 
     void SetTimeStep(double dt);
@@ -93,7 +92,7 @@ class InflowWindAdapter : public WindModel {
   public:
     std::unique_ptr<InflowWindLib> pImpl;
 
-    InflowWindAdapter(std::string InflowInfile, std::string WindWndfile);
+    InflowWindAdapter(std::string InflowInfile);
     ~InflowWindAdapter();
 
     void end();

--- a/include/seahowl/env/inflowwind_adapter.h
+++ b/include/seahowl/env/inflowwind_adapter.h
@@ -49,6 +49,7 @@ struct InflowWindLib {
     float* Velocity;
 
     void SetIFWINFILE(std::string name);
+    void SetWNDINFILE(std::string name);
     void CheckError();
 
     void SetTimeStep(double dt);

--- a/src/bindings/pyseahowl_env.cpp
+++ b/src/bindings/pyseahowl_env.cpp
@@ -3,7 +3,9 @@
 #include <pybind11/eigen.h>
 
 #include <seahowl/env/wind_models.h>
-#include <seahowl/env/inflowwind_adapter.h>
+#ifdef HAVE_INFLOWWIND
+    #include <seahowl/env/inflowwind_adapter.h>
+#endif
 
 namespace py = pybind11;
 
@@ -40,8 +42,10 @@ void initialize_pyseahowl_env(py::module& m) {
         .def_readwrite("wind_velocity_start", &seahowl::env::WindRamp::wind_velocity_start)
         .def_readwrite("wind_velocity_end", &seahowl::env::WindRamp::wind_velocity_end);
 
+#ifdef HAVE_INFLOWWIND
     // env/infflowwind_adapter.h
     py::class_<seahowl::env::InflowWindAdapter, std::shared_ptr<seahowl::env::InflowWindAdapter>,
                seahowl::env::FluidModel>(m_aero, "InflowWindAdapter")
         .def(py::init<std::string&>());
+#endif
 }

--- a/src/bindings/pyseahowl_env.cpp
+++ b/src/bindings/pyseahowl_env.cpp
@@ -3,6 +3,7 @@
 #include <pybind11/eigen.h>
 
 #include <seahowl/env/wind_models.h>
+#include <seahowl/env/inflowwind_adapter.h>
 
 namespace py = pybind11;
 
@@ -38,4 +39,9 @@ void initialize_pyseahowl_env(py::module& m) {
         .def_readwrite("time_end", &seahowl::env::WindRamp::time_end)
         .def_readwrite("wind_velocity_start", &seahowl::env::WindRamp::wind_velocity_start)
         .def_readwrite("wind_velocity_end", &seahowl::env::WindRamp::wind_velocity_end);
+
+    // env/infflowwind_adapter.h
+    py::class_<seahowl::env::InflowWindAdapter, std::shared_ptr<seahowl::env::InflowWindAdapter>,
+               seahowl::env::FluidModel>(m_aero, "InflowWindAdapter")
+        .def(py::init<std::string&>());
 }

--- a/src/env/inflowwind_adapter.cpp
+++ b/src/env/inflowwind_adapter.cpp
@@ -75,11 +75,34 @@ void InflowWindLib::SetIFWINFILE(std::string name) {
                 spdlog::trace("InflowWind: modified path to file to be relative:");
                 spdlog::trace("    from: {}", line_before);
                 spdlog::trace("    to: {}", line);
+                if (type_lowercase == "filename_uni") {
+                    // add wnd file if filename_uni
+                    if (insertoffset == 1) {
+                        // remove quotes
+                        words[0].erase(words[0].length() - 1, 1);
+                        words[0].erase(0, 1);
+                    }
+                    SetWNDINFILE((DATADIR / words[0]).string());
+                }
             };
         }
         IfWinputFileString += line + '\0';
     }
     IfWinputFileStringLength = IfWinputFileString.length();
+    file.close();
+}
+
+void InflowWindLib::SetWNDINFILE(std::string name) {
+    spdlog::info("Set wind.wnd INFILE: {}.", name);
+    std::ifstream file(name);
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open wind.wnd input file.");
+    }
+    std::string line;
+    while (std::getline(file, line)) {
+        InputUniformString += line + '\0';
+    }
+    InputUniformStringLength = InputUniformString.length();
     file.close();
 }
 

--- a/src/env/inflowwind_adapter.cpp
+++ b/src/env/inflowwind_adapter.cpp
@@ -5,14 +5,27 @@
 #include <string>
 #include <fstream>
 #include <spdlog/spdlog.h>
+#include <filesystem>
 
 using namespace seahowl::env;
+namespace fs = std::filesystem;
 
-InflowWindAdapter::InflowWindAdapter(std::string InflowInfile, std::string WindWndfile) {
+std::vector<std::string> splitString(const std::string& str) {
+    std::istringstream iss(str);
+    std::vector<std::string> tokens;
+    std::string token;
+    while (iss >> token) {
+        if (!token.empty()) {
+            tokens.push_back(token);
+        }
+    }
+    return tokens;
+}
+
+InflowWindAdapter::InflowWindAdapter(std::string InflowInfile) {
     spdlog::info("Using InflowWind.");
     pImpl.reset(new InflowWindLib);
     pImpl->SetIFWINFILE(InflowInfile);
-    pImpl->SetWNDINFILE(WindWndfile);
     pImpl->SetTimeStep(0.01);  // time step should not matter (not used in InflowWind)
     pImpl->Init();
 }
@@ -45,23 +58,28 @@ void InflowWindLib::SetIFWINFILE(std::string name) {
     }
     std::string line;
     while (std::getline(file, line)) {
+        std::vector<std::string> words = splitString(line);
+        if (words.size() > 1) {
+            std::string type_lowercase = words[1];
+            std::transform(type_lowercase.begin(), type_lowercase.end(), type_lowercase.begin(), ::tolower);
+
+            if (type_lowercase.find("filename") != std::string::npos) {
+                size_t insertoffset = 0;
+                if (words[0].front() == '"') {
+                    insertoffset = 1;
+                }
+                auto pos = line.find(words[0].front());
+                std::string line_before = line;
+                auto DATADIR = fs::absolute(fs::path(name)).parent_path();
+                line.insert(pos + insertoffset, (DATADIR).string() + "/");
+                spdlog::trace("InflowWind: modified path to file to be relative:");
+                spdlog::trace("    from: {}", line_before);
+                spdlog::trace("    to: {}", line);
+            };
+        }
         IfWinputFileString += line + '\0';
     }
     IfWinputFileStringLength = IfWinputFileString.length();
-    file.close();
-}
-
-void InflowWindLib::SetWNDINFILE(std::string name) {
-    spdlog::info("Set wind.wnd INFILE: {}.", name);
-    std::ifstream file(name);
-    if (!file.is_open()) {
-        throw std::runtime_error("Failed to open wind.wnd input file.");
-    }
-    std::string line;
-    while (std::getline(file, line)) {
-        InputUniformString += line + '\0';
-    }
-    InputUniformStringLength = InputUniformString.length();
     file.close();
 }
 

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -835,19 +835,13 @@ void populate_environmental_conditions_from_json(const std::string& filepath, se
         spdlog::info("Inflow model: InflowWind.");
 #ifdef HAVE_INFLOWWIND
         std::string inflowwind_filepath;
-        std::string windwnd_filepath;
         auto wind_options = wind_json.at("options");
         if (wind_options.contains("file_inflowwind")) {
             inflowwind_filepath = (DATADIR / wind_options.at("file_inflowwind")).generic_string();
         } else {
             throw std::runtime_error("InflowWind file not defined.");
         }
-        if (wind_options.contains("file_windwnd")) {
-            windwnd_filepath = (DATADIR / wind_options.at("file_windwnd")).generic_string();
-        } else {
-            throw std::runtime_error("InflowWind input file (.wnd) not defined.");
-        }
-        wind_model_ptr = std::make_shared<seahowl::env::InflowWindAdapter>(inflowwind_filepath, windwnd_filepath);
+        wind_model_ptr = std::make_shared<seahowl::env::InflowWindAdapter>(inflowwind_filepath);
 #else
         throw std::runtime_error(
             "InflowWind module in CMAKE options should be enabled if wind type 'inflowwind' selected.");

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -19,7 +19,9 @@
 #include "seahowl/env/wave_models.h"
 #include "seahowl/env/soil_models.h"
 #include "seahowl/env/combined_models.h"
-#include "seahowl/env/inflowwind_adapter.h"
+#ifdef HAVE_INFLOWWIND
+    #include "seahowl/env/inflowwind_adapter.h"
+#endif
 #include "seahowl/aero/airfoil.h"
 #include "seahowl/aero/blade_aero.h"
 #include "seahowl/aero/rotor_aero.h"

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -725,8 +725,7 @@ TEST(test_inflowwind, rpm_initial_pitch) {
     double dt = 0.1;
     // wind
     auto wind_model =
-        seahowl::env::InflowWindAdapter((DATADIR / "aerodyn/IEA-15-240-RWT_InflowWind.dat").generic_string(),
-                                        (DATADIR / "aerodyn/long_step_wind.wnd").generic_string());
+        seahowl::env::InflowWindAdapter((DATADIR / "aerodyn/IEA-15-240-RWT_InflowWind.dat").generic_string());
     // turbine
     double initial_pitch = seahowl::PI / 8.0;
 


### PR DESCRIPTION
In this PR:
- Make paths automatically relative from InflowWind.dat file (will not work if path are already defined in absolute in .dat file!)
- Remove library configuration in cmake (Debug, Release), and link only once to InflowWind/AeroDyn libs

To do (not in this PR):
- Dynamic loading of AeroDyn/InflowWind