### PR TITLE
Auto-compute mass+inertia of rigid blade

### DIFF
--- a/data/IEA15MW/turbine_nocontrol_rigid.json
+++ b/data/IEA15MW/turbine_nocontrol_rigid.json
@@ -9,10 +9,6 @@
   },
   "rotor": {
     "type": "rigid",
-    "options": {
-      "inertia_blades": 3.5148698e8,
-      "mass_blades": 195e3
-    },
     "discretization": {
       "elasto": [49],
       "aero": [49]

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -187,8 +187,33 @@ BladeElastoRigid::BladeElastoRigid() {}
 
 void BladeElastoRigid::build() {
     body_root = std::make_unique<BodyElastoChrono>();
-    // body_root->set_mass(0.0);
     length = reference_points.back().coordinates.z();
+
+    // calculate mass
+    double mass_total = 0.0;
+    double inertia_total = 0.0;
+    for (int ii = 0; ii < reference_points.size() - 1; ii++) {
+        auto& point1 = reference_points[ii];
+        auto& point2 = reference_points[ii + 1];
+        auto rho1 = point1.mass_matrix(2, 2);
+        auto rho2 = point2.mass_matrix(2, 2);
+        auto l1 = point1.coordinates.z();
+        auto l2 = point2.coordinates.z();
+        auto length_segment = abs(l2 - l1);
+
+        // mass of blade segment
+        mass_total += 0.5 * (rho1 + rho2) * length_segment;
+
+        // inertia assuming rod element with non-uniform linear density
+        inertia_total += ((pow(l2, 4) - pow(l1, 4)) / 4.0 * (rho2 - rho1) +
+                          (pow(l2, 3) - pow(l1, 3)) / 3.0 * (rho1 * l2 - rho2 * l1)) /
+                         length_segment;
+    };
+
+    // set mass and inertia at root
+    body_root->set_mass(mass_total);
+    // inertia of blade calculated from body root for rotation along local x and y
+    body_root->set_inertia_diagonal(Vector3d(inertia_total, inertia_total, 0.0));
 }
 
 void BladeElastoRigid::assemble(SystemElasto& system) {
@@ -211,7 +236,7 @@ void BladeElastoRigid::translate(const Vector3d& translation_vector) const {
 }
 
 double BladeElastoRigid::get_mass() const {
-    return mass;
+    return body_root->get_mass();
 }
 
 void BladeElastoRigid::apply_pitch_increment(double pitch_increment) {

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -518,8 +518,8 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
     }
 
     // check rotor type
-    auto rotor_options = rotor_json.at("options");
     if (rotor_json.at("type") == "fea") {
+        auto rotor_options = rotor_json.at("options");
         if (rotor_options.at("fpm") == true) {
             spdlog::info("Rotor type: finite element blades (FPM).");
         } else {
@@ -547,6 +547,7 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
                 blade_elasto = std::make_shared<seahowl::elasto::BladeElastoFEA>();
                 auto& blade_elasto_fea = dynamic_cast<seahowl::elasto::BladeElastoFEA&>(*blade_elasto);
                 rotor_json.at("discretization").at("elasto").get_to(blade_elasto_fea.discretization_fractions);
+                auto rotor_options = rotor_json.at("options");
                 rotor_options.at("fpm").get_to(blade_elasto_fea.fpm_mode);
             } else if (rotor_json.at("type").get<std::string>() == "rigid") {
                 blade_elasto = std::make_shared<seahowl::elasto::BladeElastoRigid>();
@@ -575,8 +576,9 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
     populate_rna_from_json(filepath_rna, turbine.rna);
     rna_json.at("initial_pitch_collective").get_to(turbine.elasto.rna.rotor->pitch_collective);
 
-    // update info if rotor is rigid
-    if (rotor_json.at("type").get<std::string>() == "rigid" || rotor_json.at("type").get<std::string>() == "disk") {
+    // update info if rotor is disk
+    if (rotor_json.at("type").get<std::string>() == "disk") {
+        auto rotor_options = rotor_json.at("options");
         if (!rotor_options.contains("inertia_blades")) {
             throw std::runtime_error(
                 "The \"inertia_blades\" key (rotor options) must be provided for rigid/disk rotors.");
@@ -588,13 +590,11 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
         turbine.rna.elasto.rotor->hub.inertia += blades_inertia;
         auto blades_mass = rotor_options.at("mass_blades").get<double>();
         turbine.rna.elasto.rotor->hub.mass += blades_mass;
-        if (rotor_json.at("type").get<std::string>() == "disk") {
-            if (!rotor_options.contains("radius")) {
-                throw std::runtime_error(
-                    "The \"radius\" key (rotor options) must be given for rotors using actuator disk theory.");
-            } else {
-                rotor_options.at("radius").get_to(turbine.rna.aero.rotor->radius);
-            }
+        if (!rotor_options.contains("radius")) {
+            throw std::runtime_error(
+                "The \"radius\" key (rotor options) must be given for rotors using actuator disk theory.");
+        } else {
+            rotor_options.at("radius").get_to(turbine.rna.aero.rotor->radius);
         }
     }
 

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -425,7 +425,7 @@ TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.792103, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.797544, 1e-4);
 }
 
 TEST(test_turbine, controller_target_rpm) {
@@ -487,7 +487,7 @@ TEST(test_turbine, controller_target_rpm) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), target_rpm, 1e-3);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), target_rpm, 1e-2);
 }
 
 TEST(test_turbine, actuator_disk) {


### PR DESCRIPTION
- Mass and inertia auto-calculated from blade reference points (in blade.json)
- Tests updated for rigid rotor (slight expected difference in initial pitch test, loosened tolerance for target RPM that uses rigid rotor)
- Assumes blade is a rod with non-uniform density distribution for inertia calculation