### PR TITLE
Updates for blade torsion (BEMT + aero->elasto loads)

### DIFF
--- a/data/IEA15MW/turbine_nocontrol_fpm.json
+++ b/data/IEA15MW/turbine_nocontrol_fpm.json
@@ -1,0 +1,51 @@
+﻿{
+  "aero": {
+    "solver": "BEMT",
+    "options": {
+      "hub_loss": true,
+      "tip_loss": true,
+      "tower_shadow": true
+    }
+  },
+  "rotor": {
+    "type": "fea",
+    "options": {
+      "fpm": true
+    },
+    "discretization": {
+      "elasto": [49],
+      "aero": [49]
+    },
+    "blades": [
+      {
+        "file": "./blade.json",
+        "initial_pitch": 0,
+        "precone": -4.0
+      },
+      {
+        "file": "./blade.json",
+        "initial_pitch": 0,
+        "precone": -4.0
+      },
+      {
+        "file": "./blade.json",
+        "initial_pitch": 0,
+        "precone": -4.0
+      }
+    ]
+  },
+  "rna": {
+    "initial_pitch_collective": 0,
+    "file": "./rna.json"
+  },
+  "tower": {
+    "discretization": {
+      "elasto": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+      "aero": [19]
+    },
+    "file": "./tower.json"
+  },
+  "controller": {
+    "type": ""
+  }
+}

--- a/include/seahowl/aero/airfoil.h
+++ b/include/seahowl/aero/airfoil.h
@@ -17,8 +17,8 @@ struct AirfoilCoefficients {
     double lift = 0.0;
     /** @brief Drag coefficient (Cd). */
     double drag = 0.0;
-    /** @brief Added mass coefficient. */
-    double added_mass = 0.0;
+    /** @brief Moment coefficient. */
+    double moment = 0.0;
 
     /**
      * @brief Constructor.

--- a/include/seahowl/aero/blade_aero.h
+++ b/include/seahowl/aero/blade_aero.h
@@ -22,6 +22,8 @@ namespace aero {
 struct BladeNodeAero : public EntityDynamicEigen {
     /** @brief Load calculated at node. */
     Vector3d load;
+    /** @brief Moment calculated at node. */
+    Vector3d moment;
     /** @brief Uninduced wind velocity at node. */
     Vector3d wind_velocity;
     /** @brief Tower-shadowed wind velocity at node. */
@@ -84,6 +86,11 @@ struct BladeElementAero {
     Vector3d get_load() const;
 
     /**
+     * @brief Returns integrated moment at center of element.
+     */
+    Vector3d get_moment() const;
+
+    /**
      * @brief Get position of center of element.
      */
     Vector3d get_position() const;
@@ -119,6 +126,8 @@ class BladeAero {
     std::vector<BladeElementAero> elements;
     /** @brief Loads at center of blade elements. */
     std::vector<Vector3d> loads;
+    /** @brief Loads at center of blade elements. */
+    std::vector<Vector3d> moments;
     /** @brief Initial azimuth of the blade relative to rotor azimuth (in radians). */
     double azimuth0 = 0.0;
     /** @brief Pitch of the blade (in radians). */

--- a/include/seahowl/aero/rotor_aero.h
+++ b/include/seahowl/aero/rotor_aero.h
@@ -61,24 +61,9 @@ class RotorAeroBEMT : public RotorAero {
     virtual void compute_aero_loads(const env::FluidModel& wind_model, double time) override;
 
     /**
-     * @brief Computes chord solidity on all aero nodes of blades.
+     * @brief Computes radius, distances from tip and hub, and chord solidity on all aero nodes of blades.
      */
-    void compute_chords_solidity();
-
-    /**
-     * @brief Computes distance from hub on all aero nodes of blades.
-     */
-    void compute_distances_from_hub();
-
-    /**
-     * @brief Computes distance from blade tip on all aero nodes of blades.
-     */
-    void compute_distances_from_tip();
-
-    /**
-     * @brief Computes radius on all aero nodes of blades.
-     */
-    void compute_radii();
+    void compute_radii_distances_solidity();
 };
 
 // The structure containing the coefficients for the rotor disk

--- a/include/seahowl/elasto/blade_elasto.h
+++ b/include/seahowl/elasto/blade_elasto.h
@@ -44,6 +44,7 @@ class BladeElasto : public virtual ComponentElasto {
     virtual EntityDynamicEigen get_entity_along_blade(double eta, int element_index = 0) const = 0;
 
     virtual void accumulate_load_along_blade(const Vector3d& load,
+                                             const Vector3d& moment,
                                              int element_index,
                                              double eta,
                                              const Vector3d& offset) = 0;
@@ -90,6 +91,7 @@ class BladeElastoFEA : public BladeElasto, public ComponentElastoFEA {
     virtual Vector3d get_blade_root_moment() const override;
     virtual EntityDynamicEigen get_entity_along_blade(double eta, int element_index = 0) const override;
     virtual void accumulate_load_along_blade(const Vector3d& load,
+                                             const seahowl::Vector3d& moment,
                                              int element_index,
                                              double eta,
                                              const Vector3d& offset) override;
@@ -137,6 +139,7 @@ class BladeElastoRigid : public BladeElasto {
     virtual EntityDynamicEigen get_entity_along_blade(double eta, int element_index = 0) const override;
     virtual void reset_loads() override;
     virtual void accumulate_load_along_blade(const Vector3d& load,
+                                             const seahowl::Vector3d& moment,
                                              int element_index,
                                              double eta,
                                              const Vector3d& offset) override;

--- a/include/seahowl/elasto/component_elasto.h
+++ b/include/seahowl/elasto/component_elasto.h
@@ -122,11 +122,16 @@ class ComponentElastoFEA : public virtual ComponentElasto {
      * @brief Accumulates load on a given FEA element.
      *
      * @param[in] load Load vector to accumulate.
+     * @param[in] load Moment vector to accumulate.
      * @param[in] element_index Index of the element on which the load is accumulated.
      * @param[in] eta Abscissa of the element within the range [-1, +1], with -1 at node1 and +1 at node2.
      * @param[in] offset Offset from given abscissa along longitudinal axis of element.
      */
-    void accumulate_element_load(const Vector3d& load, int element_index, double eta, const Vector3d& offset);
+    void accumulate_element_load(const Vector3d& load,
+                                 const Vector3d& moment,
+                                 int element_index,
+                                 double eta,
+                                 const Vector3d& offset);
 
     /**
      * @brief Returns all nodes positions (global frame of reference).

--- a/src/aero/aerodyn_adapter.cpp
+++ b/src/aero/aerodyn_adapter.cpp
@@ -454,10 +454,12 @@ void seahowl::aero::RotorAeroDyn::compute_aero_loads(const seahowl::env::FluidMo
             // store load in global frame
             int pp = (count_blade * (blade->elements.size() + 1) + count_node) * 6;
             node.load = Vector3d(loads_aerodyn[pp], loads_aerodyn[pp + 1], loads_aerodyn[pp + 2]);
+            node.moment = Vector3d(loads_aerodyn[pp + 3], loads_aerodyn[pp + 4], loads_aerodyn[pp + 5]);
         }
         // update loads of blade
         for (int ii = 0; ii < blade->elements.size(); ii++) {
             blade->loads[ii] = blade->elements[ii].get_load();
+            blade->moments[ii] = blade->elements[ii].get_moment();
         }
     }
 }

--- a/src/aero/airfoil.cpp
+++ b/src/aero/airfoil.cpp
@@ -14,7 +14,7 @@ AirfoilCoefficients AirfoilCoefficients::operator*(const double factor) const {
     // (and angles of attack should be the same for both airfoils)
     new_point.lift *= factor;
     new_point.drag *= factor;
-    new_point.added_mass *= factor;
+    new_point.moment *= factor;
     return new_point;
 }
 
@@ -24,7 +24,7 @@ AirfoilCoefficients AirfoilCoefficients::operator+(const AirfoilCoefficients& ot
     // (and angles of attack should be the same for both airfoils)
     new_point.lift += other.lift;
     new_point.drag += other.drag;
-    new_point.added_mass += other.added_mass;
+    new_point.moment += other.moment;
     return new_point;
 };
 
@@ -101,8 +101,7 @@ AirfoilCoefficients AirfoilProperties::find_coefficients(double alpha) {
             coefficients.alpha = coefficients_list[ii].alpha * weight1 + coefficients_list[ii + 1].alpha * weight2;
             coefficients.lift = coefficients_list[ii].lift * weight1 + coefficients_list[ii + 1].lift * weight2;
             coefficients.drag = coefficients_list[ii].drag * weight1 + coefficients_list[ii + 1].drag * weight2;
-            coefficients.added_mass =
-                coefficients_list[ii].added_mass * weight1 + coefficients_list[ii + 1].added_mass * weight2;
+            coefficients.moment = coefficients_list[ii].moment * weight1 + coefficients_list[ii + 1].moment * weight2;
             return coefficients;
         }
     }

--- a/src/aero/bemt.cpp
+++ b/src/aero/bemt.cpp
@@ -12,7 +12,7 @@ using seahowl::Vector3d;
 using seahowl::PI;
 
 double seahowl::aero::get_phi(const Vector2d& fluid_velocity) {
-    double phi = atan2(fluid_velocity.y(), -fluid_velocity.x());
+    double phi = atan2(fluid_velocity.y(), fluid_velocity.x());
     return phi;
 }
 
@@ -90,7 +90,7 @@ Vector2d seahowl::aero::get_induced_velocity(seahowl::aero::BladeNodeAero& node,
         double cos_phi = cos(phi);
         double sin_phi = sin(phi);
         double cn = cl * cos_phi + cd * sin_phi;
-        double ct = cl * sin_phi - cd * cos_phi;
+        double ct = -cl * sin_phi + cd * cos_phi;
 
         double tol_induction = 1e-6;  // tolerance for induction variables to avoid singularities
 
@@ -149,7 +149,7 @@ Vector2d seahowl::aero::get_induced_velocity(seahowl::aero::BladeNodeAero& node,
         } else if (fabs(sin_phi) < tol_induction) {
             ap = ap_max;
         } else {
-            double kp = node.chord_solidity * ct / (4.0 * loss_factor * sin_phi * cos_phi);
+            double kp = -node.chord_solidity * ct / (4.0 * loss_factor * sin_phi * cos_phi);
             if (local_velocity_rotor.y() < 0.0) {
                 kp = -kp;
             }

--- a/src/aero/blade_aero.cpp
+++ b/src/aero/blade_aero.cpp
@@ -29,8 +29,6 @@ BladeNodeAero::BladeNodeAero(BladeReferencePointAero& point) {
 Vector3d BladeNodeAero::get_offset_aero_absolute() const {
     auto& offset = properties.offset_aero;
     auto offset3D = Vector3d(offset.x(), offset.y(), 0.0);
-    // remove structural twist (offset aero is expressed with twist already applied
-    offset3D = AngleAxisd(properties.structural_twist, Vector3d(0.0, 0.0, 1.0)) * offset3D;
     // apply rotation of node (includes twist + pitch)
     auto offset_absolute = rotation * offset3D;
     return offset_absolute;
@@ -44,6 +42,10 @@ BladeElementAero::BladeElementAero(const BladeNodeAero& node1, const BladeNodeAe
 
 Vector3d BladeElementAero::get_load() const {
     return 0.5 * (node1.load + node2.load) * length;
+}
+
+Vector3d BladeElementAero::get_moment() const {
+    return 0.5 * (node1.moment + node2.moment) * length;
 }
 
 Vector3d BladeElementAero::get_position() const {
@@ -96,6 +98,7 @@ void BladeAero::build() {
     for (int ii = 0; ii < discretized_points.size() - 1; ii++) {
         elements.push_back(BladeElementAero(nodes[ii], nodes[ii + 1]));
         loads.push_back(Vector3d(0.0, 0.0, 0.0));
+        moments.push_back(Vector3d(0.0, 0.0, 0.0));
     }
 
     // get distance from tip

--- a/src/aero/blade_aero.cpp
+++ b/src/aero/blade_aero.cpp
@@ -28,7 +28,10 @@ BladeNodeAero::BladeNodeAero(BladeReferencePointAero& point) {
 
 Vector3d BladeNodeAero::get_offset_aero_absolute() const {
     auto& offset = properties.offset_aero;
-    auto offset3D = Vector3d(0.0, offset.y(), -offset.x());  // assumes offset in IEC coords
+    auto offset3D = Vector3d(offset.x(), offset.y(), 0.0);
+    // remove structural twist (offset aero is expressed with twist already applied
+    offset3D = AngleAxisd(properties.structural_twist, Vector3d(0.0, 0.0, 1.0)) * offset3D;
+    // apply rotation of node (includes twist + pitch)
     auto offset_absolute = rotation * offset3D;
     return offset_absolute;
 }

--- a/src/aero/reference_point_aero.cpp
+++ b/src/aero/reference_point_aero.cpp
@@ -12,6 +12,7 @@ BladeReferencePointAero BladeReferencePointAero::operator*(const double factor) 
     BladeReferencePointAero new_point = *this;
     new_point.fraction *= factor;
     new_point.coordinates *= factor;
+    new_point.offset_aero *= factor;
     new_point.chord *= factor;
     new_point.structural_twist *= factor;
     for (int ii = 0; ii < airfoil_properties.size(); ii++) {
@@ -24,6 +25,7 @@ BladeReferencePointAero BladeReferencePointAero::operator+(const BladeReferenceP
     BladeReferencePointAero new_point = *this;
     new_point.fraction += other.fraction;
     new_point.coordinates += other.coordinates;
+    new_point.offset_aero += other.offset_aero;
     new_point.chord += other.chord;
     new_point.structural_twist += other.structural_twist;
     for (int ii = 0; ii < airfoil_properties.size(); ii++) {

--- a/src/aero/rotor_aero.cpp
+++ b/src/aero/rotor_aero.cpp
@@ -16,6 +16,11 @@ using seahowl::Vector3d;
 using seahowl::Vector2d;
 using seahowl::PI;
 
+Vector3d project_vector_to_plane(const Vector3d& vec, const Vector3d& plane_normal) {
+    auto vec_projected = (vec - (vec.dot(plane_normal)) * plane_normal);
+    return vec_projected;
+}
+
 double get_vector_angle_from_plane(const Vector3d& vec, const Vector3d& plane_normal, const Vector3d& plane_tangent) {
     double angle = acos(vec.dot(plane_normal)) - seahowl::PI / 2;
     if ((plane_normal.cross(vec)).dot(plane_tangent) < 0) {
@@ -127,7 +132,7 @@ void RotorAeroBEMT::compute_aero_loads(const FluidModel& wind_model, double time
         }
         // tangent from root, to use if sweep is assumed to be through shear
         auto root_axis = blade->nodes.front().get_rotation() * Vector3d(0.0, 0.0, 1.0);
-        auto disk_axis = (root_axis - (root_axis.dot(disk_normal)) * disk_normal).normalized();
+        auto disk_axis = project_vector_to_plane(root_axis, disk_normal).normalized();
         auto disk_tangent = disk_axis.cross(disk_normal).normalized();
 
         int count = -1;
@@ -160,6 +165,10 @@ void RotorAeroBEMT::compute_aero_loads(const FluidModel& wind_model, double time
             // assume shear along blade for sweep
             auto angle_z = get_vector_angle_from_plane(node_axis, disk_normal, disk_tangent);
             auto blade_normal_sheared = AngleAxisd(angle_z, disk_tangent) * disk_normal;
+            // unsheared
+            auto node_axis_projected = project_vector_to_plane(node_axis, disk_normal).normalized();
+            auto blade_tangent = node_axis_projected.cross(disk_normal);
+            auto blade_normal = node_axis.cross(blade_tangent);
 
             // make coordinate system to use for BEMT
             auto global_normal = blade_normal_sheared;
@@ -179,8 +188,9 @@ void RotorAeroBEMT::compute_aero_loads(const FluidModel& wind_model, double time
                 (node.distance_from_hub < tol && has_hub_loss)) {
                 node.load = Vector3d(0.0, 0.0, 0.0);
             } else {
-                // get angle of airfoil to disk plane
-                auto angle_airfoil = get_vector_angle_from_plane(node_tangent, global_normal, -global_axis);
+                // get angle of airfoil (pitch + twist + torsion) from plane of bent blade
+                auto angle_airfoil = get_vector_angle_from_plane(node_normal, blade_tangent, -node_axis_projected);
+
                 // get induced velocity
                 auto local_velocity = get_induced_velocity(node, local_velocity0, angle_airfoil, blades.size(),
                                                            has_tip_loss, has_hub_loss);

--- a/src/aero/rotor_aero.cpp
+++ b/src/aero/rotor_aero.cpp
@@ -200,7 +200,7 @@ void RotorAeroBEMT::compute_aero_loads(const FluidModel& wind_model, double time
                 node.wind_velocity_shadowed = wind_velocity;
                 node.relative_velocity_induced =
                     global_direction_normal * local_velocity.y() + global_direction_tangent * local_velocity.x();
-                // store moment in local frame
+                // store moment in global frame
                 node.moment = moment_global;
             }
         }

--- a/src/aero/rotor_aero.cpp
+++ b/src/aero/rotor_aero.cpp
@@ -174,6 +174,7 @@ void RotorAeroBEMT::compute_aero_loads(const FluidModel& wind_model, double time
                 // get drag and lift coefficients
                 auto cl = coefficients.lift;
                 auto cd = coefficients.drag;
+                auto cm = coefficients.moment;
                 // projected to rotor local frame
                 double cos_phi = cos(phi);
                 double sin_phi = sin(phi);
@@ -185,11 +186,13 @@ void RotorAeroBEMT::compute_aero_loads(const FluidModel& wind_model, double time
                 auto chord = node.properties.chord;
                 auto load_n = 0.5 * density * vel * vel * chord * cn;
                 auto load_t = 0.5 * density * vel * vel * chord * ct;
+                auto moment = 0.5 * density * vel * vel * chord * chord * cm;
 
                 // transform from local to global load
                 auto load_n_global = global_direction_normal * load_n;
                 auto load_t_global = global_direction_tangent * load_t;
                 auto load_global = load_n_global + load_t_global;
+                auto moment_global = global_direction_hub2node * moment;
 
                 // store load in global frame
                 node.load = load_global;
@@ -197,11 +200,14 @@ void RotorAeroBEMT::compute_aero_loads(const FluidModel& wind_model, double time
                 node.wind_velocity_shadowed = wind_velocity;
                 node.relative_velocity_induced =
                     global_direction_normal * local_velocity.y() + global_direction_tangent * local_velocity.x();
+                // store moment in local frame
+                node.moment = moment_global;
             }
         }
         // update loads of blade
         for (int ii = 0; ii < blade->elements.size(); ii++) {
             blade->loads[ii] = blade->elements[ii].get_load();
+            blade->moments[ii] = blade->elements[ii].get_moment();
         }
     }
 }

--- a/src/aero/rotor_aero.cpp
+++ b/src/aero/rotor_aero.cpp
@@ -126,8 +126,9 @@ void RotorAeroBEMT::compute_aero_loads(const FluidModel& wind_model, double time
             blade_azimuth = abs(std::fmod((blade_azimuth + 3 * PI), 2 * PI)) - PI;
         }
         // tangent from root, to use if sweep is assumed to be through shear
-        auto root_tangent =
-            disk_normal.cross(blade->nodes.front().get_rotation() * Vector3d(0.0, 0.0, 1.0)).normalized();
+        auto root_axis = blade->nodes.front().get_rotation() * Vector3d(0.0, 0.0, 1.0);
+        auto disk_axis = (root_axis - (root_axis.dot(disk_normal)) * disk_normal).normalized();
+        auto disk_tangent = disk_axis.cross(disk_normal).normalized();
 
         int count = -1;
         // iterate over blade nodes
@@ -139,7 +140,7 @@ void RotorAeroBEMT::compute_aero_loads(const FluidModel& wind_model, double time
             auto node_rotation = node.get_rotation();
             auto node_velocity = node.get_velocity();
             auto node_normal = node_rotation * Vector3d(1.0, 0.0, 0.0);
-            auto node_tangent = node_rotation * Vector3d(0.0, -1.0, 0.0);
+            auto node_tangent = node_rotation * Vector3d(0.0, 1.0, 0.0);
             auto node_axis = node_rotation * Vector3d(0.0, 0.0, 1.0);
 
             // fluid density
@@ -155,24 +156,20 @@ void RotorAeroBEMT::compute_aero_loads(const FluidModel& wind_model, double time
             // relative velocity
             auto global_velocity = Vector3d(wind_velocity - node_velocity);
 
-            auto direction_hub2node = (node_position - body_hub.get_position()).normalized();
-            auto disk_tangent = disk_normal.cross(direction_hub2node).normalized();
-            auto disk_axis = disk_tangent.cross(disk_normal).normalized();
-
             // get normal vector of bent blade
             // assume shear along blade for sweep
-            auto angle_z = get_vector_angle_from_plane(node_axis, disk_normal, root_tangent);
-            auto blade_normal_sheared = AngleAxisd(angle_z, root_tangent) * disk_normal;
+            auto angle_z = get_vector_angle_from_plane(node_axis, disk_normal, disk_tangent);
+            auto blade_normal_sheared = AngleAxisd(angle_z, disk_tangent) * disk_normal;
 
             // make coordinate system to use for BEMT
             auto global_normal = blade_normal_sheared;
-            auto global_tangent = root_tangent;
-            auto global_axis = global_tangent.cross(global_normal);
+            auto global_tangent = disk_tangent;
+            auto global_axis = global_normal.cross(global_tangent);
 
             // uninduced local velocity (2D)
             // frame perpendicular to rotor disc
-            // x: tangential velocity (coplanar with rotor disc)
-            // y: normal velocity (normal to rotor disc, pointing from hub to nacelle)
+            // x airfoil: tangential velocity (tangential to chord, pointing towards tail of airfoil) --> y IEC
+            // y airfoil: normal velocity (normal to chord, pointing up) --> x IEC
             double local_velocity_normal0 = global_velocity.dot(global_normal);
             double local_velocity_tangent0 = global_velocity.dot(global_tangent);
             auto local_velocity0 = Vector2d(local_velocity_tangent0, local_velocity_normal0);
@@ -202,7 +199,7 @@ void RotorAeroBEMT::compute_aero_loads(const FluidModel& wind_model, double time
                 double cos_phi = cos(phi);
                 double sin_phi = sin(phi);
                 double cn = cl * cos_phi + cd * sin_phi;
-                double ct = cl * sin_phi - cd * cos_phi;
+                double ct = -cl * sin_phi + cd * cos_phi;
 
                 // calculate drag and lift force
                 auto vel = local_velocity.norm();

--- a/src/aero/rotor_aero.cpp
+++ b/src/aero/rotor_aero.cpp
@@ -16,6 +16,24 @@ using seahowl::Vector3d;
 using seahowl::Vector2d;
 using seahowl::PI;
 
+double get_vector_angle_from_plane(const Vector3d& vec, const Vector3d& plane_normal, const Vector3d& plane_tangent) {
+    double angle = acos(vec.dot(plane_normal)) - seahowl::PI / 2;
+    if ((plane_normal.cross(vec)).dot(plane_tangent) < 0) {
+        angle = -angle;
+    }
+    return angle;
+}
+
+double acos_safe(double val) {
+    auto tol = 1e-6;
+    if (-1.0 > val && val < -(1.0 + tol)) {
+        val = -1.0;
+    } else if (1.0 < val && val < 1.0 + tol) {
+        val = 1.0;
+    }
+    return acos(val);
+}
+
 seahowl::Vector2d DiskCoefficients::get_disk_coefficients_from_table(double TSR, double pitch) {
     // interpolate rotor performance for the current TSR and pitch
     double Cp = bilinear_interpolation(power_coeff, pitch_list, tsr_list, pitch, TSR);
@@ -62,112 +80,117 @@ void RotorAeroBEMT::build() {
 
 void RotorAeroBEMT::initialize() {
     // compute blade elements related values
-    compute_distances_from_tip();
-    compute_distances_from_hub();
-    compute_radii();
-    compute_chords_solidity();
+    compute_radii_distances_solidity();
 }
 
-void RotorAeroBEMT::compute_chords_solidity() {
-    auto nblades = blades.size();
+void RotorAeroBEMT::compute_radii_distances_solidity() {
+    auto disk_normal = body_hub.get_rotation() * Vector3d(1.0, 0.0, 0.0);
+    int nblades = blades.size();
+
+    // compute radii and distances
+    radius = 0.0;
+    for (auto& blade : blades) {
+        auto tip_position = blade->nodes.back().get_position();
+        for (auto& node : blade->nodes) {
+            node.radius = (node.get_position() - body_hub.get_position()).norm();
+            node.distance_from_tip = (tip_position - node.get_position()).norm();
+            node.distance_from_hub = node.radius - hub_radius;
+        }
+        if (blade->nodes.back().radius > radius) {
+            radius = blade->nodes.back().radius;
+        }
+    }
+
+    // compute chord solidities (to compute after blade radius is set)
     for (auto& blade : blades) {
         for (auto& node : blade->nodes) {
-            auto radius = (node.get_position() - body_hub.get_position()).norm();
-            node.chord_solidity = nblades * node.properties.chord / (2 * PI * radius);
+            node.chord_solidity = nblades * node.properties.chord / (2 * PI * node.radius);
         }
     }
 }
 
-void RotorAeroBEMT::compute_distances_from_hub() {
-    for (int ii = 0; ii < blades.size(); ii++) {
-        auto& blade = blades[ii];
-        blade->compute_distances_from_hub(body_hub.get_position(), hub_radius);
-    }
-}
-
-void RotorAeroBEMT::compute_distances_from_tip() {
-    for (int ii = 0; ii < blades.size(); ii++) {
-        auto& blade = blades[ii];
-        blade->compute_distances_from_tip();
-    }
-}
-
-void RotorAeroBEMT::compute_radii() {
-    for (int ii = 0; ii < blades.size(); ii++) {
-        auto& blade = blades[ii];
-        blade->compute_radii(body_hub.get_position());
-    }
-}
-
 void RotorAeroBEMT::compute_aero_loads(const FluidModel& wind_model, double time) {
+    compute_radii_distances_solidity();
+
+    auto hub_position = body_hub.get_position();
+    auto hub_rotation = body_hub.get_rotation();
+    // get normal to disk
+    // pointing from hub towards nacelle
+    auto disk_normal = hub_rotation * Vector3d(1.0, 0.0, 0.0);
+
+    // iterate over blades
     for (auto& blade : blades) {
         auto blade_azimuth = azimuth + blade->azimuth0;
         // check that blade_azimuth is between pi and -pi
         if (blade_azimuth < -PI || blade_azimuth > PI) {
             blade_azimuth = abs(std::fmod((blade_azimuth + 3 * PI), 2 * PI)) - PI;
         }
+        // tangent from root, to use if sweep is assumed to be through shear
+        auto root_tangent =
+            disk_normal.cross(blade->nodes.front().get_rotation() * Vector3d(0.0, 0.0, 1.0)).normalized();
+
         int count = -1;
+        // iterate over blade nodes
         for (auto& node : blade->nodes) {
             count += 1;
-            auto position = node.get_position();
-            auto rotation = node.get_rotation();
-            auto velocity = node.get_velocity();
 
-            double density = wind_model.get_fluid_density(position, time);
+            // node info
+            auto node_position = node.get_position();
+            auto node_rotation = node.get_rotation();
+            auto node_velocity = node.get_velocity();
+            auto node_normal = node_rotation * Vector3d(1.0, 0.0, 0.0);
+            auto node_tangent = node_rotation * Vector3d(0.0, -1.0, 0.0);
+            auto node_axis = node_rotation * Vector3d(0.0, 0.0, 1.0);
 
-            // get fluid relative velocity
-            auto wind_velocity0 = wind_model.get_fluid_velocity(position, time);
-            Vector3d wind_velocity = wind_velocity0;
-
+            // fluid density
+            double density = wind_model.get_fluid_density(node_position, time);
+            // fluid velocity
+            auto wind_velocity = wind_model.get_fluid_velocity(node_position, time);
             // correct wind velocity with tower shadow (if activated)
             if (has_tower_shadow) {
                 if (blade_azimuth > PI / 2.0 || blade_azimuth < -PI / 2.0) {
-                    seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity, position, tower_ref);
+                    seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity, node_position, tower_ref);
                 }
             }
+            // relative velocity
+            auto global_velocity = Vector3d(wind_velocity - node_velocity);
 
-            auto global_velocity = Vector3d(wind_velocity - velocity);
-            // project in disc frame
-            auto local_velocity_disc = body_hub.get_rotation().inverse() * global_velocity;
+            auto direction_hub2node = (node_position - body_hub.get_position()).normalized();
+            auto disk_tangent = disk_normal.cross(direction_hub2node).normalized();
+            auto disk_axis = disk_tangent.cross(disk_normal).normalized();
 
-            // get global/local directions
-            // pointing from hub towards nacelle
-            auto local_direction_normal = Vector3d(1.0, 0.0, 0.0);
-            auto global_direction_normal = body_hub.get_rotation() * local_direction_normal;
+            // get normal vector of bent blade
+            // assume shear along blade for sweep
+            auto angle_z = get_vector_angle_from_plane(node_axis, disk_normal, root_tangent);
+            auto blade_normal_sheared = AngleAxisd(angle_z, root_tangent) * disk_normal;
 
-            // pointing from hub to node position
-            auto global_direction_hub2node = (position - body_hub.get_position()).normalized();
-            // pointing in tangential direction
-            auto global_direction_tangent = global_direction_normal.cross(global_direction_hub2node).normalized();
+            // make coordinate system to use for BEMT
+            auto global_normal = blade_normal_sheared;
+            auto global_tangent = root_tangent;
+            auto global_axis = global_tangent.cross(global_normal);
 
             // uninduced local velocity (2D)
             // frame perpendicular to rotor disc
             // x: tangential velocity (coplanar with rotor disc)
             // y: normal velocity (normal to rotor disc, pointing from hub to nacelle)
-            double local_velocity_normal = global_velocity.dot(global_direction_normal);
-            double local_velocity_tangent = global_velocity.dot(global_direction_tangent);
-            auto local_velocity0 = Vector2d(local_velocity_tangent, local_velocity_normal);
+            double local_velocity_normal0 = global_velocity.dot(global_normal);
+            double local_velocity_tangent0 = global_velocity.dot(global_tangent);
+            auto local_velocity0 = Vector2d(local_velocity_tangent0, local_velocity_normal0);
 
             double tol = 1e-6;
             if (local_velocity0.norm() < tol || (node.distance_from_tip < tol && has_tip_loss) ||
                 (node.distance_from_hub < tol && has_hub_loss)) {
                 node.load = Vector3d(0.0, 0.0, 0.0);
             } else {
-                // get airfoil angle with rotor plane
-                auto airfoil_direction = node.get_rotation() * Vector3d(0.0, -1.0, 0.0);
-                double airfoil_angle = acos(airfoil_direction.dot(global_direction_normal)) - seahowl::PI / 2;
-                // check direction of airfoil axis
-                if (airfoil_direction.dot(global_direction_tangent) < 0) {
-                    airfoil_angle = seahowl::PI - airfoil_angle;
-                }
-
+                // get angle of airfoil to disk plane
+                auto angle_airfoil = get_vector_angle_from_plane(node_tangent, global_normal, -global_axis);
                 // get induced velocity
-                auto local_velocity = get_induced_velocity(node, local_velocity0, airfoil_angle, blades.size(),
+                auto local_velocity = get_induced_velocity(node, local_velocity0, angle_airfoil, blades.size(),
                                                            has_tip_loss, has_hub_loss);
 
                 // get coefficients from angle of attack
                 double phi = seahowl::aero::get_phi(local_velocity);
-                double alpha = seahowl::aero::get_alpha_from_phi(phi, airfoil_angle);
+                double alpha = seahowl::aero::get_alpha_from_phi(phi, angle_airfoil);
                 auto coefficients =
                     seahowl::aero::get_aero_coefficients_from_alpha(alpha, node.properties.airfoil_properties);
 
@@ -189,19 +212,14 @@ void RotorAeroBEMT::compute_aero_loads(const FluidModel& wind_model, double time
                 auto moment = 0.5 * density * vel * vel * chord * chord * cm;
 
                 // transform from local to global load
-                auto load_n_global = global_direction_normal * load_n;
-                auto load_t_global = global_direction_tangent * load_t;
-                auto load_global = load_n_global + load_t_global;
-                auto moment_global = global_direction_hub2node * moment;
+                node.load = global_normal * load_n + global_tangent * load_t;
+                node.moment = global_axis * moment;
 
-                // store load in global frame
-                node.load = load_global;
-                node.wind_velocity = wind_velocity0;
+                // store info about fluid velocity
+                node.wind_velocity = wind_velocity;
                 node.wind_velocity_shadowed = wind_velocity;
                 node.relative_velocity_induced =
-                    global_direction_normal * local_velocity.y() + global_direction_tangent * local_velocity.x();
-                // store moment in global frame
-                node.moment = moment_global;
+                    global_normal * local_velocity.y() + global_tangent * local_velocity.x();
             }
         }
         // update loads of blade

--- a/src/core/blade.cpp
+++ b/src/core/blade.cpp
@@ -97,7 +97,7 @@ void Blade::update_loads_elasto() {
                                  std::to_string(mapping_aero2elasto_elements.size()) + ") do not match.");
     }
     for (int ii = 0; ii < aero.loads.size(); ii++) {
-        elasto.accumulate_load_along_blade(aero.loads[ii], mapping_aero2elasto_elements[ii].index,
+        elasto.accumulate_load_along_blade(aero.loads[ii], aero.moments[ii], mapping_aero2elasto_elements[ii].index,
                                            mapping_aero2elasto_elements[ii].eta,
                                            aero.elements[ii].get_offset_aero_absolute());
     }

--- a/src/core/blade.cpp
+++ b/src/core/blade.cpp
@@ -77,8 +77,8 @@ void Blade::update_positions_aero() {
         int elasto_element_index = mapping_aero2elasto_nodes[ii].index;
         double eta = mapping_aero2elasto_nodes[ii].eta;
         auto entity = elasto.get_entity_along_blade(eta, elasto_element_index);
-        node_aero.set_position(entity.get_position());
         node_aero.set_rotation(entity.get_rotation());
+        node_aero.set_position(entity.get_position() + node_aero.get_offset_aero_absolute());
         node_aero.set_velocity(entity.get_velocity());
         node_aero.set_rotational_velocity(entity.get_rotational_velocity());
         node_aero.set_acceleration(entity.get_acceleration());

--- a/src/core/tower.cpp
+++ b/src/core/tower.cpp
@@ -85,7 +85,7 @@ void Tower::update_loads_elasto() {
     }
     auto offset = Vector3d(0.0, 0.0, 0.0);
     for (int ii = 0; ii < aero.loads.size(); ii++) {
-        elasto.accumulate_element_load(aero.loads[ii], mapping_aero2elasto[ii].index, mapping_aero2elasto[ii].eta,
-                                       offset);
+        elasto.accumulate_element_load(aero.loads[ii], Vector3d(0.0, 0.0, 0.0), mapping_aero2elasto[ii].index,
+                                       mapping_aero2elasto[ii].eta, offset);
     }
 }

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -172,10 +172,11 @@ seahowl::EntityDynamicEigen BladeElastoFEA::get_entity_along_blade(double eta, i
 }
 
 void BladeElastoFEA::accumulate_load_along_blade(const seahowl::Vector3d& load,
+                                                 const seahowl::Vector3d& moment,
                                                  int element_index,
                                                  double eta,
                                                  const seahowl::Vector3d& offset) {
-    accumulate_element_load(load, element_index, eta, offset);
+    accumulate_element_load(load, moment, element_index, eta, offset);
 }
 
 void BladeElastoFEA::attach_root_to_body(const BodyElasto& body) {
@@ -295,6 +296,7 @@ void BladeElastoRigid::reset_loads() {
 }
 
 void BladeElastoRigid::accumulate_load_along_blade(const seahowl::Vector3d& load,
+                                                   const seahowl::Vector3d& moment,
                                                    int element_index,
                                                    double eta,
                                                    const seahowl::Vector3d& offset) {
@@ -304,8 +306,7 @@ void BladeElastoRigid::accumulate_load_along_blade(const seahowl::Vector3d& load
     // apply moment on root
     auto entity = get_entity_along_blade(eta, element_index);
     auto distance = (entity.get_position() + offset - body_root->get_position());
-    auto moment = distance.cross(load);
-    body_root->accumulate_torque(moment, false);
+    body_root->accumulate_torque(moment + distance.cross(load), false);
 }
 
 void BladeElastoRigid::attach_root_to_body(const BodyElasto& body) {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -313,8 +313,6 @@ bool NodeElastoChrono::is_fixed() const {
 }
 
 void NodeElastoChrono::set_properties(const BladeReferencePointElasto& ref, bool fpm) {
-    Eigen::Matrix<double, 6, 6> mm = ref.mass_matrix.replicate(1, 1);
-    Eigen::Matrix<double, 6, 6> sm = ref.stiffness_matrix.replicate(1, 1);
     // Convert from IEC convention to Chrono convention.
     // IEC standard:
     // x-axis: flapwise pointing towards nacelle,
@@ -324,31 +322,17 @@ void NodeElastoChrono::set_properties(const BladeReferencePointElasto& ref, bool
     // x-axis: longitudinal pointing towards blade tip,
     // y-axis : edgewise pointing towards trailing edge,
     // z-axis : flapwise pointing away from nacelle.
-    int jjo, kko;
-    for (int jj = 0; jj < 6; jj++) {
-        if (jj == 2 || jj == 5) {
-            jjo = -2;
-        }
-        if (jj == 1 || jj == 4) {
-            jjo = +0;
-        }
-        if (jj == 0 || jj == 3) {
-            jjo = +2;
-        }
-        for (int kk = 0; kk < 6; kk++) {
-            if (kk == 2 || kk == 5) {
-                kko = -2;
-            }
-            if (kk == 1 || kk == 4) {
-                kko = +0;
-            }
-            if (kk == 0 || kk == 3) {
-                kko = +2;
-            }
-            mm(jj + jjo, kk + kko) = ref.mass_matrix(jj, kk);
-            sm(jj + jjo, kk + kko) = ref.stiffness_matrix(jj, kk);
+    Eigen::Matrix<double, 3, 3> rot33 = AngleAxisd(PI / 2, Vector3d(0.0, 1.0, 0.0)).toRotationMatrix();
+    Eigen::Matrix<double, 6, 6> rot66 = Eigen::Matrix<double, 6, 6>::Zero();
+    for (int ii = 0; ii < 3; ii++) {
+        for (int jj = 0; jj < 3; jj++) {
+            rot66(ii, jj) = rot33(ii, jj);
+            rot66(ii + 3, jj + 3) = rot33(ii, jj);
         }
     }
+    auto mm = rot66 * ref.mass_matrix * rot66.transpose();
+    auto sm = rot66 * ref.stiffness_matrix * rot66.transpose();
+
     if (fpm == true) {
         auto sectionFPM = chrono_types::make_shared<chrono::fea::ChBeamSectionTimoshenkoAdvancedGenericFPM>();
         section = sectionFPM;

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -291,6 +291,7 @@ void NodeElastoChrono::set_torque(const Vector3d& torque, bool is_local) {
     if (is_local) {
         chobj->SetTorque(vec_iec2ch(torque));
     } else {
+        // chobj->SetTorque(chobj->TransformDirectionParentToLocal(vec2ch(torque)));
         chobj->SetTorque(vec_iec2ch(get_rotation().inverse() * torque));
     }
 }

--- a/src/elasto/component_elasto.cpp
+++ b/src/elasto/component_elasto.cpp
@@ -111,21 +111,17 @@ void ComponentElastoFEA::accumulate_element_load(const Vector3d& load,
     auto load0 = load * weight0;
     auto node0 = element->nodes[0];
     // load in global reference
-    node0->set_force(node0->get_force() + load0, false);
-    // torque in node reference
-    node0->set_torque(node0->get_torque() +
-                          node0->get_rotation().inverse() * ((position + offset - node0->get_position()).cross(load0)),
-                      true);
+    node0->accumulate_force(load0, false);
+    // torque in global reference
+    node0->accumulate_torque((position + offset - node0->get_position()).cross(load0), false);
     // load on second node
     double weight1 = 0.5 * abs(eta + 1);
     auto load1 = load * weight1;
     auto node1 = element->nodes[1];
     // load in global reference
-    node1->set_force(node1->get_force() + load1, false);
-    // torque in node reference
-    node1->set_torque(node1->get_torque() +
-                          node1->get_rotation().inverse() * ((position + offset - node1->get_position()).cross(load1)),
-                      true);
+    node1->accumulate_force(load1, false);
+    // torque in global reference
+    node1->accumulate_torque((position + offset - node1->get_position()).cross(load1), false);
 }
 
 std::vector<Vector3d> ComponentElastoFEA::get_nodes_positions() const {

--- a/src/elasto/component_elasto.cpp
+++ b/src/elasto/component_elasto.cpp
@@ -90,6 +90,7 @@ void ComponentElastoFEA::evaluate_position_rotation(Vector3d& position,
 }
 
 void ComponentElastoFEA::accumulate_element_load(const Vector3d& load,
+                                                 const Vector3d& moment,
                                                  int element_index,
                                                  double eta,
                                                  const Vector3d& offset) {
@@ -109,19 +110,19 @@ void ComponentElastoFEA::accumulate_element_load(const Vector3d& load,
     // load on first node
     double weight0 = 0.5 * abs(eta - 1);
     auto load0 = load * weight0;
+    auto moment0 = moment * weight0;
     auto node0 = element->nodes[0];
     // load in global reference
     node0->accumulate_force(load0, false);
-    // torque in global reference
-    node0->accumulate_torque((position + offset - node0->get_position()).cross(load0), false);
+    node0->accumulate_torque(moment0 + (position + offset - node0->get_position()).cross(load0), false);
     // load on second node
     double weight1 = 0.5 * abs(eta + 1);
     auto load1 = load * weight1;
+    auto moment1 = moment * weight1;
     auto node1 = element->nodes[1];
     // load in global reference
     node1->accumulate_force(load1, false);
-    // torque in global reference
-    node1->accumulate_torque((position + offset - node1->get_position()).cross(load1), false);
+    node1->accumulate_torque(moment1 + (position + offset - node1->get_position()).cross(load1), false);
 }
 
 std::vector<Vector3d> ComponentElastoFEA::get_nodes_positions() const {

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -143,11 +143,14 @@ std::vector<seahowl::aero::BladeReferencePointAero> get_blade_aero_reference_poi
         }
         reference_point.fraction = coords[2] / blade_length;
         reference_point.coordinates = Vector3d(coords[0], coords[1], coords[2]);
+        reference_point.structural_twist = point.at("twist").get<double>() * PI / 180.0;
         if (point.contains("offset_aero")) {
             auto oa = point.at("offset_aero").get<std::vector<double>>();
-            reference_point.offset_aero = Vector2d(oa[0], oa[1]);
+            // remove structural twist (offset aero is expressed with twist already applied)
+            auto offset3D = seahowl::AngleAxisd(reference_point.structural_twist, Vector3d(0.0, 0.0, 1.0)) *
+                            Vector3d(oa[0], oa[1], 0.0);
+            reference_point.offset_aero = Vector2d(offset3D[0], offset3D[1]);
         }
-        reference_point.structural_twist = point.at("twist").get<double>() * PI / 180.0;
 
         if (point.contains("chord")) {
             reference_point.chord = point["chord"];
@@ -176,7 +179,7 @@ std::vector<seahowl::aero::BladeReferencePointAero> get_blade_aero_reference_poi
                     coefficients.alpha = coeffs[kk][0];
                     coefficients.lift = coeffs[kk][1];
                     coefficients.drag = coeffs[kk][2];
-                    coefficients.added_mass = coeffs[kk][3];
+                    coefficients.moment = coeffs[kk][3];
                     coefficients_list.push_back(coefficients);
                 }
                 seahowl::aero::AirfoilProperties airfoil;

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -369,6 +369,65 @@ TEST(test_turbine, rpm_initial_pitch) {
     ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.746750, 1e-4);
 }
 
+TEST(test_turbine, rpm_initial_pitch_fpm) {
+    // general options
+    bool visualization_on = true;
+    bool statics_prestep = true;
+    // solver
+    auto verbose = false;
+    // timestepping
+    double dt = 0.1;
+    // wind
+    auto wind_model = seahowl::env::ConstantWind();
+    wind_model.set_wind_velocity(Vector3d(8.0, 0.0, 0.0));
+    // turbine
+    double initial_pitch = seahowl::PI / 8.0;
+
+    // system
+    auto system_elasto = SystemElastoChrono();
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
+    auto system_chrono = system_elasto.chobj;
+
+    // turbine
+    auto turbine_elasto = seahowl::elasto::TurbineElasto();
+    auto turbine_aero = seahowl::aero::TurbineAero();
+    auto turbine = seahowl::core::Turbine(turbine_elasto, turbine_aero);
+    populate_turbine_from_json((DATADIR / "turbine_nocontrol_fpm.json").generic_string(), turbine);
+
+    // remove controller
+    turbine.controller = std::make_shared<seahowl::servo::Controller>();
+    turbine.build();
+    turbine.elasto.assemble(system_elasto);
+    turbine.tower.elasto.nodes.front()->set_fixed(true);
+
+    // statics
+    if (statics_prestep) {
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
+        system_elasto.do_statics(true, 10);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
+    }
+
+    double time = 0.0;
+    turbine.rna.elasto.rotor->apply_collective_pitch_increment(initial_pitch);
+    turbine.initialize(time, dt);
+    // while (application.GetDevice()->run()) {
+    while (time < 50) {
+        // prestep
+        // compute forces
+        turbine.aero.compute_aero_loads(wind_model, time);
+        // prestep (accumulates loads from aero to elasto)
+        turbine.prestep(time, dt);
+
+        system_elasto.step(dt);
+        time += dt;
+
+        // poststep
+        turbine.poststep(time, dt);
+    }
+
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.750031, 1e-4);
+}
+
 TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
     // general options
     bool visualization_on = true;

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -366,7 +366,7 @@ TEST(test_turbine, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.746750, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.695730, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_fpm) {
@@ -425,7 +425,7 @@ TEST(test_turbine, rpm_initial_pitch_fpm) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.750031, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.699299, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
@@ -697,7 +697,7 @@ TEST(test_aerodyn, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.750620, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.718761, 1e-4);
 }
 #endif
 
@@ -831,6 +831,6 @@ TEST(test_inflowwind, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.733759, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.685642, 1e-4);
 }
 #endif

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -366,7 +366,7 @@ TEST(test_turbine, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.780339, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.746750, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
@@ -425,7 +425,7 @@ TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.797544, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.797311, 1e-4);
 }
 
 TEST(test_turbine, controller_target_rpm) {
@@ -638,7 +638,7 @@ TEST(test_aerodyn, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.750998, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.750620, 1e-4);
 }
 #endif
 
@@ -772,6 +772,6 @@ TEST(test_inflowwind, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.766250, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.733759, 1e-4);
 }
 #endif


### PR DESCRIPTION
 Updated in this PR:
- Aerodynamic moment calculated during BEMT
- Fix for aero offset: remove twist from offset read in json (AeroDyn uses offsets with twist included)
- Update of tests: biggest differences (~1%) in tests that use flexible blades, other differences are minimal
- Use IEC coordinate system for BEMT
- Use same coordinate system as AeroDyn along blade: sheared in-plane and take blade out-of-plane bending into account
- Calculate pitch+twist+torsion from actual value along node axis (and not sheared axis)