### PR TITLE
Add wave options + hydro ref point in config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,7 +363,7 @@ target_link_libraries(seahowl_core
 )
 
 if (SEAHOWL_ENABLE_HYDROCHRONO)
-    target_link_libraries(seahowl_core PUBLIC HydroChrono::HydroChrono)
+    target_link_libraries(seahowl_core PRIVATE HydroChrono::HydroChrono)
 endif (SEAHOWL_ENABLE_HYDROCHRONO)
 
 if(SEAHOWL_ENABLE_VTK)

--- a/data/IEA15MW/environment_hydrochrono.json
+++ b/data/IEA15MW/environment_hydrochrono.json
@@ -1,0 +1,43 @@
+﻿{
+  "gravity": [0.0, 0.0, -9.81],
+  "wind": {
+    "type": "ramp",
+    "air_density": 1.225,
+    "options": {
+      "reference_height": 150,
+      "shear_coefficient": 0.12,
+      "velocity_start": [12, 0, 0],
+      "velocity_end": [25, 0, 0],
+      "time_start": 500,
+      "time_end": 1700
+    }
+  },
+  "sea": {
+    "type": "HydroChrono",
+    "water_density": 1025,
+    "mean_water_level": 0.0,
+    "water_depth": 200.0,
+    "options": {
+      "type": "irregular",
+      "wave_height": 7.0,
+      "wave_period": 12.0,
+      "frequency_min": 0.01175,
+      "frequency_max": 0.50930,
+      "nfrequencies": 0,
+      "duration": 4200,
+      "dt": 0.025,
+      "peak_enhancement_factor": 3.3,
+      "is_normalized": true,
+      "seed": 42,
+      "num_bodies": 1
+    }
+  },
+  "soil": {
+    "type": "linear",
+    "options": {
+      "stiffness_normal": 1e5,
+      "stiffness_shear": 0.0,
+      "soil_position": -200.0
+    }
+  }
+}

--- a/data/IEA15MW/floater.json
+++ b/data/IEA15MW/floater.json
@@ -1,6 +1,10 @@
 ﻿{
+  "type": "HydroChrono",
+  "options": {
+    "file": "./VolturnUS.h5"
+  },
+  "position": [0.0, 0.0, -14.94],
   "mass": 17839e3,
-  "cog": [0.0, 0.0, -14.94],
   "inertia": [
     [1.251e10, 0.0, 0.0],
     [0.0, 1.251e10, 0.0],
@@ -14,11 +18,18 @@
     [-8.918e6, 0.0, 0.0, 0.0, 1.676e10, 0.0],
     [0.0, 0.0, 0.0, 0.0, 0.0, 4.798e10]
   ],
-  "type": "HydroChrono",
-  "options": {
-    "file": "./VolturnUS.h5",
-    "name": "body1"
-  },
+  "bodies": [
+    {
+      "name": "body1",
+      "position": [0.0, 0.0, -14.94],
+      "mass": 0.0,
+      "inertia": [
+        [0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0]
+      ]
+    }
+  ],
   "moorings": [
     {
       "connected_body_name": "body1",

--- a/data/IEA15MW/main_floating.json
+++ b/data/IEA15MW/main_floating.json
@@ -23,7 +23,7 @@
     "log_level": "info"
   },
   "environment": {
-    "file": "./environment.json"
+    "file": "./environment_hydrochrono.json"
   },
   "turbines": [
     {

--- a/include/seahowl/elasto/floater_elasto.h
+++ b/include/seahowl/elasto/floater_elasto.h
@@ -14,6 +14,7 @@ class FloaterElasto : public ComponentElasto {
   public:
     /* @brief Damping matrix of floater.*/
     Eigen::Matrix<double, 6, 6> damping_matrix;
+    std::unique_ptr<seahowl::elasto::BodyElasto> body_main;
 
     /**
      * @brief Constructor.
@@ -73,18 +74,6 @@ class FloaterElasto : public ComponentElasto {
      * @param[in] index Index of fairlead.
      */
     virtual seahowl::elasto::Link& get_fairlead_link(const std::string& body_name, int index);
-
-    /**
-     * @brief Sets name of body that will be used for tower connection.
-     *
-     * @param[in] connected_body_name Name of the body to connect to the tower.
-     */
-    virtual void set_tower_connection_body_name(const std::string& connected_body_name);
-
-    /**
-     * @brief Returns body to connect to tower.
-     */
-    virtual seahowl::elasto::BodyElasto& get_tower_connection_body() const;
 
     /**
      * @brief Translates the floater.

--- a/include/seahowl/elasto/rotor_elasto.h
+++ b/include/seahowl/elasto/rotor_elasto.h
@@ -56,8 +56,6 @@ struct ShaftProperties {
     double tilt = 0.0;
     /** @brief Distance of shaft axis from towertop. */
     double distance_from_towertop = 0.0;
-    /** @brief Inertia of the hub. */
-    double generator_inertia = 0.0;
 };
 
 class RotorElasto : public ComponentElasto {
@@ -97,7 +95,7 @@ class RotorElasto : public ComponentElasto {
     virtual double get_mass() const override;
 
     /**
-     * @brief Resets all loads.
+     * @brief Resets accumulated loads.
      */
     void reset_loads();
 
@@ -113,7 +111,7 @@ class RotorElasto : public ComponentElasto {
     void apply_collective_pitch_increment(double pitch_increment);
 
     /**
-     * @brief Accumulates torque on the hub.
+     * @brief Accumulates torque on the rotor.
      *
      * @param[in] torque Torque to accumulate on axial axis of hub.
      */
@@ -134,8 +132,6 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
     std::unique_ptr<seahowl::elasto::RotorElasto> rotor;
     /** @brief Shaft rigid body. */
     std::unique_ptr<seahowl::elasto::BodyElasto> body_shaft;
-    /** @brief Bedplate rigid body (to fix shaft). */
-    std::unique_ptr<seahowl::elasto::BodyElasto> body_bedplate;
     /** @brief Nacelle rigid body. */
     std::unique_ptr<seahowl::elasto::BodyElasto> body_nacelle;
     /** @brief Yaw bearing rigid body. */
@@ -143,14 +139,12 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
 
     // links
     //
-    /** @brief Link between shaft and hub (fixed). */
+    /** @brief Link between shaft and hub (revolute). */
     std::unique_ptr<Link> link_shaft_hub;
-    /** @brief Link between shaft and bedplate (revolute). */
-    std::unique_ptr<Link> link_shaft_bedplate;
-    /** @brief Link between bedplate and nacelle (fixed). */
-    std::unique_ptr<Link> link_bedplate_nacelle;
-    /** @brief Link between nacelle and yaw bearing (fixed). */
-    std::unique_ptr<Link> link_nacelle_yaw_bearing;
+    /** @brief Link between shaft and nacelle (fixed). */
+    std::unique_ptr<Link> link_shaft_nacelle;
+    /** @brief Link between shaft and yaw bearing (fixed). */
+    std::unique_ptr<Link> link_shaft_yaw_bearing;
     /** @brief Link between towertop (if any) and yaw bearing (fixed). */
     std::unique_ptr<Link> link_towertop_yaw_bearing;
     ///@}
@@ -184,14 +178,9 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
     double get_mass() const override;                                   ///< @see ElastoComponent::get_mass
 
     /**
-     * @brief Resets all loads.
+     * @brief Resets accumulated loads.
      */
     void reset_loads();
-
-    /**
-     * @brief Locks shaft if true, unlocks it if false.
-     */
-    void lock_shaft(bool locked);
 
     /**
      * @brief Returns the RPM of the rotor.
@@ -214,9 +203,9 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
     double get_azimuth() const;
 
     /**
-     * @brief Accumulates electrical torque on the rotor.
+     * @brief Accumulates torque on the rotor.
      *
-     * @param[in] torque Torque to accumulate on axial axis of rotor.
+     * @param[in] torque Torque to accumulate on axial axis of hub.
      */
     void accumulate_electrical_torque(double torque);
 };

--- a/include/seahowl/hydro/hydrochrono_adapter.h
+++ b/include/seahowl/hydro/hydrochrono_adapter.h
@@ -4,6 +4,7 @@
 #include "seahowl/elasto/entities_elasto.h"
 #include "seahowl/elasto/chrono_adapters.h"
 #include "seahowl/elasto/floater_elasto.h"
+#include "seahowl/env/wave_models.h"
 
 #include <string>
 
@@ -12,11 +13,11 @@
 namespace seahowl {
 namespace hydro {
 
+/**
+ * @brief HydroChrono adapter for floater class.
+ */
 class FloaterHydroChrono : public elasto::FloaterElasto {
   public:
-    /** @brief Waves (HydroChrono). */
-    std::shared_ptr<WaveBase> waves;
-
     /**
      * @brief Constructor.
      */
@@ -37,7 +38,16 @@ class FloaterHydroChrono : public elasto::FloaterElasto {
      */
     void set_h5_filepath(std::string filepath);
 
+    /**
+     * @brief Sets waves used to compute hydro loads on floater.
+     *
+     * @param[in] waves Waves to attach to floater.
+     */
+    void set_waves(std::shared_ptr<WaveBase> waves);
+
   private:
+    /** @brief Waves (HydroChrono). */
+    std::shared_ptr<WaveBase> waves;
     /** @brief HydroChrono logic class. */
     std::unique_ptr<TestHydro> hydrochrono_setter;
     /** @brief Path to potential flow frequency data file (HDF5 format). */
@@ -45,4 +55,27 @@ class FloaterHydroChrono : public elasto::FloaterElasto {
 };
 
 }  // namespace hydro
+
+namespace env {
+
+/**
+ * @brief Class for HydroChrono waves.
+ */
+class WaveModelHydroChrono : public WaveModel {
+  public:
+    /** @brief Waves (HydroChrono). */
+    std::shared_ptr<WaveBase> waves;
+
+    /**
+     * @brief Constructor.
+     */
+    WaveModelHydroChrono();
+
+    virtual Vector3d get_fluid_velocity(const Vector3d& position, double time) const override;
+    virtual double get_fluid_density(const Vector3d& position, double time) const override;
+    virtual bool is_in_water(const Vector3d& position, double time) const override;
+};
+
+}  // namespace env
+
 }  // namespace seahowl

--- a/src/bindings/pyseahowl_elasto.cpp
+++ b/src/bindings/pyseahowl_elasto.cpp
@@ -61,19 +61,11 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("set_rest_length", &seahowl::elasto::ElementMooringElasto::set_rest_length)
         .def("get_rest_length", &seahowl::elasto::ElementMooringElasto::get_rest_length);
     py::class_<seahowl::elasto::Link, std::shared_ptr<seahowl::elasto::Link>>(m_elasto, "Link")
-        .def("initialize", [](seahowl::elasto::Link& link, seahowl::elasto::BodyElasto& body,
-                              seahowl::elasto::BodyElasto& body2) { link.initialize(body, body2); })
-        .def("initialize", [](seahowl::elasto::Link& link, seahowl::elasto::BodyElasto& body,
-                              seahowl::elasto::NodeElasto& node) { link.initialize(body, node); })
-        .def("initialize", [](seahowl::elasto::Link& link, seahowl::elasto::NodeElasto& node,
-                              seahowl::elasto::BodyElasto& body) { link.initialize(node, body); })
         .def("set_constraints", &seahowl::elasto::Link::set_constraints)
         .def("get_reaction_force", &seahowl::elasto::Link::get_reaction_force)
         .def("get_reaction_torque", &seahowl::elasto::Link::get_reaction_torque);
     py::class_<seahowl::elasto::MeshElasto, std::shared_ptr<seahowl::elasto::MeshElasto>>(m_elasto, "MeshElasto");
     py::class_<seahowl::elasto::SystemElasto, std::shared_ptr<seahowl::elasto::SystemElasto>>(m_elasto, "SystemElasto")
-        .def("add", [](seahowl::elasto::SystemElasto& system, seahowl::elasto::BodyElasto& body) { system.add(body); })
-        .def("add", [](seahowl::elasto::SystemElasto& system, seahowl::elasto::Link& link) { system.add(link); })
         .def("step", &seahowl::elasto::SystemElasto::step)
         .def("get_time", &seahowl::elasto::SystemElasto::get_time)
         .def("set_gravitational_acceleration", &seahowl::elasto::SystemElasto::set_gravitational_acceleration)
@@ -199,9 +191,6 @@ void initialize_pyseahowl_elasto(py::module& m) {
             "body_shaft", [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.body_shaft.get(); },
             py::return_value_policy::reference_internal)
         .def_property_readonly(
-            "body_bedplate", [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.body_bedplate.get(); },
-            py::return_value_policy::reference_internal)
-        .def_property_readonly(
             "body_nacelle", [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.body_nacelle.get(); },
             py::return_value_policy::reference_internal)
         .def_property_readonly(
@@ -212,19 +201,15 @@ void initialize_pyseahowl_elasto(py::module& m) {
             "link_shaft_hub", [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_shaft_hub.get(); },
             py::return_value_policy::reference_internal)
         .def_property_readonly(
-            "link_shaft_bedplate",
-            [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_shaft_bedplate.get(); },
-            py::return_value_policy::reference_internal)
-        .def_property_readonly(
             "link_shaft_nacelle",
-            [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_bedplate_nacelle.get(); },
+            [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_shaft_nacelle.get(); },
             py::return_value_policy::reference_internal)
         .def_property_readonly(
-            "link_nacelle_yaw_bearing",
-            [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_nacelle_yaw_bearing.get(); },
+            "link_shaft_yaw_bearing",
+            [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_shaft_yaw_bearing.get(); },
             py::return_value_policy::reference_internal)
         .def_property_readonly(
-            "link_nacelle_yaw_bearing",
+            "link_shaft_yaw_bearing",
             [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_towertop_yaw_bearing.get(); },
             py::return_value_policy::reference_internal);
 

--- a/src/bindings/pyseahowl_elasto.cpp
+++ b/src/bindings/pyseahowl_elasto.cpp
@@ -238,9 +238,6 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("get_fairlead_link", &seahowl::elasto::FloaterElasto::get_fairlead_link,
              py::return_value_policy::reference_internal)
         .def("get_fairlead_body", &seahowl::elasto::FloaterElasto::get_fairlead_body,
-             py::return_value_policy::reference_internal)
-        .def("set_tower_connection_body_name", &seahowl::elasto::FloaterElasto::set_tower_connection_body_name)
-        .def("get_tower_connection_body", &seahowl::elasto::FloaterElasto::get_tower_connection_body,
              py::return_value_policy::reference_internal);
 
     // elasto/mooring_elasto.h

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -34,18 +34,16 @@ void Turbine::prestep(double time, double dt) {
 
 void Turbine::poststep(double time, double dt) {
     // hub loads
-    // reset external loads applied on rotor hub
+    // reset external loads applied on RNA
     rna.elasto.reset_loads();
 
-    if (gearbox_ratio != 1.0) {
-        // apply aero torque losses from gearbox efficiency for next step
-        auto aero_torque = rna.elasto.get_axial_torque();
-        if (controller->has_torque_control) {
-            // remove previously applied electrical torque from total rotor torque
-            aero_torque += controller->get_torque_elec() * gearbox_ratio * gearbox_efficiency;
-        }
-        rna.elasto.rotor->accumulate_axial_torque(-aero_torque * (1.0 - gearbox_efficiency));
+    // apply aero torque losses from gearbox efficiency for next step
+    auto aero_torque = rna.elasto.get_axial_torque();
+    if (controller->has_torque_control) {
+        // remove previously applied electrical torque from total rotor torque
+        aero_torque += controller->get_torque_elec() * gearbox_ratio * gearbox_efficiency;
     }
+    rna.elasto.rotor->accumulate_axial_torque(-aero_torque * (1.0 - gearbox_efficiency));
 
     // controller step
     controller->step(time, dt, *this);
@@ -53,7 +51,7 @@ void Turbine::poststep(double time, double dt) {
     if (controller->has_torque_control) {
         auto torque_elec = controller->get_torque_elec() * gearbox_ratio * gearbox_efficiency;
         // torque elec is applied on hub body (locally)
-        rna.elasto.accumulate_electrical_torque(-torque_elec);
+        rna.elasto.accumulate_electrical_torque(torque_elec);
     }
     // apply pitch from controller
     if (controller->has_pitch_control) {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -752,7 +752,7 @@ void SystemElastoChrono::do_statics(bool linear, int nonlinear_steps) {
     std::vector<bool> tower_fixed;
     for (auto& turbine : turbines) {
         // rotor
-        turbine->rna.lock_shaft(true);
+        turbine->rna.link_shaft_hub->set_constraints(true, true, true, true, true, true);
         // tower
         tower_fixed.push_back(turbine->tower.nodes.front()->is_fixed());
         turbine->tower.nodes.front()->set_fixed(true);
@@ -771,7 +771,7 @@ void SystemElastoChrono::do_statics(bool linear, int nonlinear_steps) {
     int idx_turbine = 0;
     for (auto& turbine : turbines) {
         // rotor
-        turbine->rna.lock_shaft(false);
+        turbine->rna.link_shaft_hub->set_constraints(true, true, true, false, true, true);
         // tower
         turbine->tower.nodes.front()->set_fixed(tower_fixed[idx_turbine]);
     }

--- a/src/elasto/floater_elasto.cpp
+++ b/src/elasto/floater_elasto.cpp
@@ -6,10 +6,12 @@
 
 using namespace seahowl::elasto;
 
-FloaterElasto::FloaterElasto(){};
+FloaterElasto::FloaterElasto() {
+    body_main = std::make_unique<seahowl::elasto::BodyElastoChrono>();
+};
 
 void FloaterElasto::prestep(double time, double dt) {
-    auto& floater_body = get_tower_connection_body();
+    auto& floater_body = *body_main;
     floater_body.reset_loads();
 
     // apply viscous damping
@@ -99,6 +101,15 @@ void FloaterElasto::assemble(seahowl::elasto::SystemElasto& system) {
         auto& body = *bodymap.second;
         system.add(body);
     }
+    // link hydro bodies to body_main
+    // needs to happen after adding hydro bodies to system (HydroChrono requirement)
+    system.add(*body_main);
+    for (auto& bodymap : floater_bodies) {
+        auto& body = *bodymap.second;
+        auto link_cog = std::make_unique<seahowl::elasto::LinkChrono>();
+        link_cog->initialize(*body_main, body);
+        system.add(*link_cog);
+    }
     for (auto& fairleadmap : fairlead_bodies) {
         for (auto& fairlead : fairleadmap.second) {
             system.add(*fairlead);
@@ -107,24 +118,6 @@ void FloaterElasto::assemble(seahowl::elasto::SystemElasto& system) {
     for (auto& linkmap : fairlead_links) {
         for (auto& link : linkmap.second) {
             system.add(*link);
-        }
-    }
-}
-
-void FloaterElasto::set_tower_connection_body_name(const std::string& connected_body_name) {
-    tower_connection_name = connected_body_name;
-}
-
-seahowl::elasto::BodyElasto& FloaterElasto::get_tower_connection_body() const {
-    if (floater_bodies.size() < 1) {
-        throw std::runtime_error("Need to add at least one body to floater before connecting to tower.");
-    } else if (floater_bodies.size() == 1) {
-        return *(floater_bodies.begin()->second);
-    } else {
-        if (tower_connection_name == "") {
-            throw std::runtime_error("Need to set name of floater body that connects to tower.");
-        } else {
-            return *floater_bodies.at(tower_connection_name);
         }
     }
 }

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -8,9 +8,7 @@ using seahowl::elasto::BladeElasto;
 using seahowl::elasto::RotorElasto;
 using seahowl::elasto::RotorNacelleAssemblyElasto;
 
-RotorElasto::RotorElasto() {
-    body_hub = std::make_unique<BodyElastoChrono>();
-}
+RotorElasto::RotorElasto() {}
 
 void RotorElasto::assemble(SystemElasto& system) {
     for (auto& blade : blades) {
@@ -28,6 +26,7 @@ void RotorElasto::build() {
     auto rotation0 = Quaternion(1.0, 0.0, 0.0, 0.0);
 
     // hub
+    body_hub = std::make_unique<BodyElastoChrono>();
     // mass and inertia
     body_hub->set_mass(hub.mass);
     body_hub->set_inertia_diagonal(Vector3d(hub.inertia, 0., 0.));
@@ -77,11 +76,6 @@ void RotorElasto::apply_collective_pitch_increment(double pitch_increment) {
     }
     pitch_collective += pitch_increment;
 }
-
-void RotorElasto::accumulate_axial_torque(double torque) {
-    body_hub->accumulate_torque(Vector3d(torque, 0.0, 0.0), true);
-}
-
 void RotorElasto::rotate(double angle, const Vector3d& axis) const {
     // blades
     for (auto& blade : blades) {
@@ -103,6 +97,7 @@ void RotorElasto::translate(const Vector3d& translation_vector) const {
     // hub
     body_hub->set_position(body_hub->get_position() + translation_vector);
 }
+
 double RotorElasto::get_mass() const {
     double total_mass = 0.0;
     // blades
@@ -118,37 +113,22 @@ void RotorElasto::reset_loads() {
     body_hub->reset_loads();
 }
 
+void RotorElasto::accumulate_axial_torque(double torque) {
+    body_hub->accumulate_torque(Vector3d(torque, 0.0, 0.0), true);
+}
+
 RotorNacelleAssemblyElasto::RotorNacelleAssemblyElasto() {
-    // rotor
     rotor = std::make_unique<RotorElasto>();
-
-    // shaft
-    body_shaft = std::make_unique<BodyElastoChrono>();
-    link_shaft_hub = std::make_unique<LinkChrono>();
-
-    // bedplate
-    body_bedplate = std::make_unique<BodyElastoChrono>();
-    link_shaft_bedplate = std::make_unique<LinkChrono>();
-
-    // nacelle
-    body_nacelle = std::make_unique<BodyElastoChrono>();
-    link_bedplate_nacelle = std::make_unique<LinkChrono>();
-
-    // yaw bearing
-    body_yaw_bearing = std::make_unique<BodyElastoChrono>();
-    link_nacelle_yaw_bearing = std::make_unique<LinkChrono>();
 }
 
 void RotorNacelleAssemblyElasto::assemble(SystemElasto& system) {
     rotor->assemble(system);
     system.add(*(body_shaft.get()));
-    system.add(*(body_bedplate.get()));
-    system.add(*(link_shaft_bedplate.get()));
     system.add(*(link_shaft_hub.get()));
     system.add(*(body_nacelle.get()));
-    system.add(*(link_bedplate_nacelle.get()));
+    system.add(*(link_shaft_nacelle.get()));
     system.add(*(body_yaw_bearing.get()));
-    system.add(*(link_nacelle_yaw_bearing.get()));
+    system.add(*(link_shaft_yaw_bearing.get()));
 }
 
 void RotorNacelleAssemblyElasto::build() {
@@ -163,29 +143,20 @@ void RotorNacelleAssemblyElasto::build() {
     auto rotation0 = Quaternion(1.0, 0.0, 0.0, 0.0);
 
     // shaft
+    body_shaft = std::make_unique<BodyElastoChrono>();
     // move end of shaft at yaw axis of nacelle
     body_shaft->set_position(Vector3d(0.0, 0.0, shaft.distance_from_towertop));
     // align rotation
     body_shaft->set_rotation(rotor->body_hub->get_rotation());
     // massless body
     body_shaft->set_mass(0.0);
-    body_shaft->set_inertia_diagonal(Vector3d(shaft.generator_inertia, 0.0, 0.0));
     // link hub to shaft
+    link_shaft_hub = std::make_unique<LinkChrono>();
     link_shaft_hub->initialize(*(rotor->body_hub.get()), *(body_shaft.get()));
-    link_shaft_hub->set_constraints(true, true, true, true, true, true);
-
-    // bedplate
-    // move bedplate at yaw axis of nacelle
-    body_bedplate->set_position(Vector3d(0.0, 0.0, shaft.distance_from_towertop));
-    // align rotation
-    body_bedplate->set_rotation(rotor->body_hub->get_rotation());
-    // massless body
-    body_bedplate->set_mass(0.0);
-    // link shaft to bedplate
-    link_shaft_bedplate->initialize(*(body_shaft.get()), *(body_bedplate.get()));
-    link_shaft_bedplate->set_constraints(true, true, true, false, true, true);
+    link_shaft_hub->set_constraints(true, true, true, false, true, true);
 
     // nacelle
+    body_nacelle = std::make_unique<BodyElastoChrono>();
     body_nacelle->set_position(nacelle.center_of_mass);
     body_nacelle->set_rotation(rotation0);
     // mass and inertia
@@ -193,16 +164,19 @@ void RotorNacelleAssemblyElasto::build() {
     ///@todo  change to full 3x3 inertia matrix
     body_nacelle->set_inertia_diagonal(Vector3d(0.0, 0.0, nacelle.inertia));
     // link nacelle body to shaft body
-    link_bedplate_nacelle->initialize(*(body_bedplate.get()), *(body_nacelle.get()));
-    link_bedplate_nacelle->set_constraints(true, true, true, true, true, true);
+    link_shaft_nacelle = std::make_unique<LinkChrono>();
+    link_shaft_nacelle->initialize(*(body_nacelle.get()), *(body_shaft.get()));
+    link_shaft_nacelle->set_constraints(true, true, true, true, true, true);
 
     // yaw bearing
+    body_yaw_bearing = std::make_unique<BodyElastoChrono>();
     body_yaw_bearing->set_position(Vector3d(0.0, 0.0, 0.0));
     body_yaw_bearing->set_rotation(rotation0);
     body_yaw_bearing->set_mass(nacelle.yaw_bearing_mass);
     // link yaw bearing body to shaft body
-    link_nacelle_yaw_bearing->initialize(*(body_bedplate.get()), *(body_yaw_bearing.get()));
-    link_nacelle_yaw_bearing->set_constraints(true, true, true, true, true, true);
+    link_shaft_yaw_bearing = std::make_unique<LinkChrono>();
+    link_shaft_yaw_bearing->initialize(*(body_shaft.get()), *(body_yaw_bearing.get()));
+    link_shaft_yaw_bearing->set_constraints(true, true, true, true, true, true);
 }
 
 void RotorNacelleAssemblyElasto::rotate(double angle, const Vector3d& axis) const {
@@ -214,11 +188,6 @@ void RotorNacelleAssemblyElasto::rotate(double angle, const Vector3d& axis) cons
     auto new_rotation_shaft = (rotation * body_shaft->get_rotation()).normalized();
     body_shaft->set_position(new_position_shaft);
     body_shaft->set_rotation(new_rotation_shaft);
-    // bedplate
-    auto new_position_bedplate = rotation * body_bedplate->get_position();
-    auto new_rotation_bedplate = (rotation * body_bedplate->get_rotation()).normalized();
-    body_bedplate->set_position(new_position_bedplate);
-    body_bedplate->set_rotation(new_rotation_bedplate);
     // nacelle
     auto new_position_nacelle = rotation * body_nacelle->get_position();
     auto new_rotation_nacelle = (rotation * body_nacelle->get_rotation()).normalized();
@@ -236,8 +205,6 @@ void RotorNacelleAssemblyElasto::translate(const Vector3d& translation_vector) c
     rotor->translate(translation_vector);
     // shaft
     body_shaft->set_position(body_shaft->get_position() + translation_vector);
-    // bedplate
-    body_bedplate->set_position(body_bedplate->get_position() + translation_vector);
     // nacelle
     body_nacelle->set_position(body_nacelle->get_position() + translation_vector);
     // yaw_bearing
@@ -250,8 +217,6 @@ double RotorNacelleAssemblyElasto::get_mass() const {
     total_mass += rotor->get_mass();
     // shaft
     total_mass += body_shaft->get_mass();
-    // bedplate
-    total_mass += body_bedplate->get_mass();
     // nacelle
     total_mass += body_nacelle->get_mass();
     // yaw_bearing
@@ -262,23 +227,12 @@ double RotorNacelleAssemblyElasto::get_mass() const {
 void RotorNacelleAssemblyElasto::reset_loads() {
     rotor->reset_loads();
     body_shaft->reset_loads();
-    body_bedplate->reset_loads();
-    body_nacelle->reset_loads();
-    body_yaw_bearing->reset_loads();
-}
-
-void RotorNacelleAssemblyElasto::lock_shaft(bool locked) {
-    if (locked) {
-        link_shaft_bedplate->set_constraints(true, true, true, true, true, true);
-    } else {
-        link_shaft_bedplate->set_constraints(true, true, true, false, true, true);
-    }
 }
 
 double RotorNacelleAssemblyElasto::get_rpm() const {
     // relative rotational velocity between hub and shaft (in local reference frame of the hub)
     auto rotational_velocity =
-        (body_shaft->get_rotational_velocity(true) - body_bedplate->get_rotational_velocity(true));
+        (rotor->body_hub->get_rotational_velocity(true) - body_shaft->get_rotational_velocity(true));
     // convert to rpm
     auto rpm = rotational_velocity.x() * 60 / (2 * PI);
     return rpm;
@@ -286,7 +240,7 @@ double RotorNacelleAssemblyElasto::get_rpm() const {
 
 double RotorNacelleAssemblyElasto::get_azimuth() const {
     // get angle between quaternions
-    auto qq = (body_bedplate->get_rotation().conjugate() * body_shaft->get_rotation()).normalized();
+    auto qq = (body_shaft->get_rotation().conjugate() * rotor->body_hub->get_rotation()).normalized();
     double angle0 = 2 * std::atan2(qq.vec().x(), qq.w());
     // get angle between 0 and 2pi
     double angle1 = fmod(angle0, 2 * PI);
@@ -311,6 +265,6 @@ double RotorNacelleAssemblyElasto::get_axial_torque() const {
 }
 
 void RotorNacelleAssemblyElasto::accumulate_electrical_torque(double torque) {
+    rotor->body_hub->accumulate_torque(Vector3d(-torque, 0.0, 0.0), true);
     body_shaft->accumulate_torque(Vector3d(torque, 0.0, 0.0), true);
-    body_bedplate->accumulate_torque(Vector3d(-torque, 0.0, 0.0), true);
 }

--- a/src/elasto/turbine_floating_elasto.cpp
+++ b/src/elasto/turbine_floating_elasto.cpp
@@ -18,7 +18,7 @@ void TurbineFloatingElasto::assemble(SystemElasto& system) {
         // assemble floater
         floater->assemble(system);
         // make floater-tower connection
-        auto& body_floater = floater->get_tower_connection_body();
+        auto& body_floater = *floater->body_main;
         auto& node_tower = *(tower.nodes.front().get());
         link_floater_tower->initialize(body_floater, node_tower);
         link_floater_tower->set_constraints(true, true, true, true, true, true);

--- a/src/hydro/hydrochrono_adapter.cpp
+++ b/src/hydro/hydrochrono_adapter.cpp
@@ -4,17 +4,22 @@
 
 #include <chrono/physics/ChBody.h>
 
-using namespace seahowl::hydro;
+#include <spdlog/spdlog.h>
 
-FloaterHydroChrono::FloaterHydroChrono() {
-    waves = std::make_shared<NoWave>(1);
-};
+using namespace seahowl::hydro;
+using namespace seahowl::env;
+
+FloaterHydroChrono::FloaterHydroChrono(){};
 
 void FloaterHydroChrono::initialize() {
     if (h5_filepath == "") {
         throw std::runtime_error("Path of h5 file for HydroChrono floater was not defined.");
     } else if (floater_bodies.size() == 0) {
         throw std::runtime_error("Must add bodies to floater before initializing.");
+    }
+
+    if (!waves) {
+        throw std::runtime_error("Need to attach waves to floater before initializing when using HydroChrono.");
     }
 
     // give names to Chrono bodies
@@ -32,4 +37,24 @@ void FloaterHydroChrono::initialize() {
 
 void FloaterHydroChrono::set_h5_filepath(std::string filepath) {
     h5_filepath = filepath;
+}
+
+void FloaterHydroChrono::set_waves(std::shared_ptr<WaveBase> waves) {
+    this->waves = waves;
+}
+
+WaveModelHydroChrono::WaveModelHydroChrono() {
+    waves = std::make_shared<NoWave>();
+}
+
+seahowl::Vector3d WaveModelHydroChrono::get_fluid_velocity(const Vector3d& position, double time) const {
+    return Vector3d(0.0, 0.0, 0.0);
+}
+
+double WaveModelHydroChrono::get_fluid_density(const Vector3d& position, double time) const {
+    return density;
+}
+
+bool WaveModelHydroChrono::is_in_water(const Vector3d& position, double time) const {
+    return false;
 }

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -423,6 +423,30 @@ void add_turbine_to_system_from_json(const std::string& filepath,
     turbine->build();
 }
 
+auto populate_body_from_json(const json& body_json, seahowl::elasto::BodyElasto& body) {
+    body.set_mass(body_json.at("mass").get<double>());
+    auto body_position = body_json.at("position").get<std::vector<double>>();
+    if (body_position.size() != 3) {
+        throw std::runtime_error("Position of body should be a vector of length 3.");
+    }
+    body.set_position(Vector3d(body_position[0], body_position[1], body_position[2]));
+    // inertia body
+    auto body_inertia = body_json.at("inertia").get<std::vector<std::vector<double>>>();
+    if (body_inertia.size() != 3) {
+        throw std::runtime_error("Inertia matrix of body should be 3x3.");
+    }
+    Eigen::Matrix<double, 3, 3> body_inertia_matrix;
+    for (int row = 0; row < 3; row++) {
+        if (body_inertia[row].size() != 3) {
+            throw std::runtime_error("Inertia matrix of body should be 3x3.");
+        }
+        for (int col = 0; col < 3; col++) {
+            body_inertia_matrix(row, col) = body_inertia[row][col];
+        }
+    }
+    body.set_inertia_matrix(body_inertia_matrix);
+}
+
 void populate_turbine_from_json(const std::string& filepath,
                                 seahowl::core::Turbine& turbine,
                                 const std::string& output_folder) {
@@ -642,40 +666,25 @@ void populate_turbine_from_json(const std::string& filepath,
             auto floater_options = json_obj_floater.at("options");
             // add h5file path
             floater.set_h5_filepath((DATADIR / floater_options.at("file").get<std::string>()).generic_string());
-            // make body
-            auto body_name = floater_options.at("name").get<std::string>();
-            floater.add_body(body_name);
-            // position body
-            auto& body = floater.get_body(body_name);
-            body.set_mass(json_obj_floater.at("mass").get<double>());
-            auto body_position = json_obj_floater.at("cog").get<std::vector<double>>();
-            if (body_position.size() != 3) {
-                throw std::runtime_error("COG of floater should be a vector of length 3.");
+            // get main body info
+            auto& body = *floater.body_main;
+            populate_body_from_json(json_obj_floater, body);
+            // get other bodies info
+            auto bodies_json = json_obj_floater.at("bodies");
+            for (auto& body_json : bodies_json) {
+                auto body_name = body_json.at("name").get<std::string>();
+                floater.add_body(body_name);
+                populate_body_from_json(body_json, floater.get_body(body_name));
             }
-            body.set_position(Vector3d(body_position[0], body_position[1], body_position[2]));
-            // inertia body
-            auto body_inertia = json_obj_floater.at("inertia").get<std::vector<std::vector<double>>>();
-            if (body_inertia.size() != 3) {
-                throw std::runtime_error("Inertia matrix of floater should be 3x3.");
-            }
-            Eigen::Matrix<double, 3, 3> body_inertia_matrix;
-            for (int row = 0; row < 3; row++) {
-                if (body_inertia[row].size() != 3) {
-                    throw std::runtime_error("Inertia matrix of floater should be 3x3.");
-                }
-                for (int col = 0; col < 3; col++) {
-                    body_inertia_matrix(row, col) = body_inertia[row][col];
-                }
-            }
-            body.set_inertia_matrix(body_inertia_matrix);
 
             auto dm = json_obj_floater.at("damping_matrix").get<std::vector<std::vector<double>>>();
             if (dm.size() != 6) {
-                throw std::runtime_error("Viscous damping matrix for floater has to be defined as 6x6 matrices.");
+                throw std::runtime_error("Viscous damping matrix for floater body has to be defined as 6x6 matrices.");
             }
             for (int irow = 0; irow < 6; irow++) {
                 if (dm[irow].size() != 6) {
-                    throw std::runtime_error("Viscous damping matrix for floater has to be defined as 6x6 matrices.");
+                    throw std::runtime_error(
+                        "Viscous damping matrix for floater body has to be defined as 6x6 matrices.");
                 }
                 for (int icol = 0; icol < 6; icol++) {
                     floater.damping_matrix(irow, icol) = dm[irow][icol];
@@ -703,7 +712,7 @@ void populate_turbine_from_json(const std::string& filepath,
                 auto fairlead_relative_position = seahowl::Vector3d(fpos[0], fpos[1], fpos[2]);
                 seahowl::Vector3d fairlead_position = rotation * fairlead_relative_position;
                 if (mooring_json.at("relative_fairlead").get<bool>()) {
-                    fairlead_position += floater.get_body(body_name).get_position();
+                    fairlead_position += floater.body_main->get_position();
                 }
                 floater.add_fairlead(fairlead_position, body_name);
                 auto& fairlead_body = floater.get_fairlead_body(body_name, floater.get_fairlead_count(body_name) - 1);
@@ -713,7 +722,7 @@ void populate_turbine_from_json(const std::string& filepath,
                 auto anchor_relative_position = seahowl::Vector3d(apos[0], apos[1], apos[2]);
                 seahowl::Vector3d anchor_position = rotation * anchor_relative_position;
                 if (mooring_json.at("relative_anchor").get<bool>()) {
-                    anchor_position += floater.get_body(body_name).get_position();
+                    anchor_position += floater.body_main->get_position();
                 }
                 turbine_floating.mooring_system->anchors.push_back(
                     std::make_shared<seahowl::elasto::BodyElastoChrono>());

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -770,9 +770,46 @@ void populate_environmental_conditions_from_json(const std::string& filepath, se
         auto& fluid_model = dynamic_cast<seahowl::env::WaveWindModel&>(*system_core.fluid_model);
 
         // specific model options
-        if (sea_json.at("type").get<std::string>() == "still") {
+        auto sea_type = sea_json.at("type").get<std::string>();
+        if (sea_type == "still") {
             fluid_model.wave_model = std::make_unique<seahowl::env::StillWater>();
-        } else if (sea_json.at("type").get<std::string>() == "current") {
+        } else if (sea_type == "HydroChrono" || sea_type == "hydrochrono") {
+#ifdef HAVE_HYDROCHRONO
+            fluid_model.wave_model = std::make_unique<seahowl::env::WaveModelHydroChrono>();
+            auto& wave_model = dynamic_cast<seahowl::env::WaveModelHydroChrono&>(*fluid_model.wave_model);
+            auto sea_options = sea_json.at("options");
+            auto wave_type = sea_options.at("type").get<std::string>();
+            if (wave_type == "still") {
+                wave_model.waves = std::make_shared<NoWave>();
+            } else if (wave_type == "regular") {
+                auto hydrochrono_waves = std::make_shared<RegularWave>();
+                wave_model.waves = hydrochrono_waves;
+                hydrochrono_waves->regular_wave_amplitude_ = sea_options.at("wave_height").get<double>() / 2.0;
+                hydrochrono_waves->regular_wave_omega_ = 2 * PI / sea_options.at("wave_period").get<double>();
+            } else if (wave_type == "irregular") {
+                auto params = IrregularWaveParams();
+                sea_options.at("num_bodies").get_to(params.num_bodies_);
+                sea_options.at("wave_height").get_to(params.wave_height_);
+                sea_options.at("wave_period").get_to(params.wave_period_);
+                sea_options.at("frequency_min").get_to(params.frequency_min_);
+                sea_options.at("frequency_max").get_to(params.frequency_max_);
+                sea_options.at("nfrequencies").get_to(params.nfrequencies_);
+                sea_options.at("wave_period").get_to(params.wave_period_);
+                sea_options.at("peak_enhancement_factor").get_to(params.peak_enhancement_factor_);
+                sea_options.at("is_normalized").get_to(params.is_normalized_);
+                sea_options.at("seed").get_to(params.seed_);
+                sea_options.at("dt").get_to(params.simulation_dt_);
+                sea_options.at("duration").get_to(params.simulation_duration_);
+                params.ramp_duration_ = 0.0;
+                params.num_bodies_ = 1;
+                wave_model.waves = std::make_shared<IrregularWaves>(params);
+            } else {
+                throw std::runtime_error("Unrecognized wave type \"" + wave_type + "\" for HydroChrono.");
+            }
+#else
+            throw std::runtime_error("Must compile and enable HydroChrono dependency to use HydroChrono waves.");
+#endif
+        } else if (sea_type == "current") {
             fluid_model.wave_model = std::make_unique<seahowl::env::CurrentConstant>();
             auto& wave_model = dynamic_cast<seahowl::env::CurrentConstant&>(*fluid_model.wave_model);
             auto sea_options = sea_json.at("options");
@@ -782,7 +819,7 @@ void populate_environmental_conditions_from_json(const std::string& filepath, se
             sea_options.at("velocity_seabed").get_to(wave_model.velocity_seabed);
         } else {
             throw std::runtime_error(
-                "The input sea type is unknown. Please use the existing current types: still, current.");
+                "The input sea type is unknown. Please use the existing current types: still, current, HydroChrono.");
         }
 
         // general wave model options
@@ -887,6 +924,21 @@ void populate_system_from_json(const std::string& filepath, seahowl::core::Syste
 
         // get ref to turbine added last
         auto& turbine = *system_core.turbines.back();
+
+#ifdef HAVE_HYDROCHRONO
+        try {
+            auto& turbine_floating = dynamic_cast<seahowl::core::TurbineFloating&>(turbine);
+            auto& floater = dynamic_cast<seahowl::hydro::FloaterHydroChrono&>(*turbine_floating.elasto.floater);
+            try {
+                auto& fluid_model = dynamic_cast<seahowl::env::WaveWindModel&>(*system_core.fluid_model);
+                auto& waves_model = dynamic_cast<seahowl::env::WaveModelHydroChrono&>(*fluid_model.wave_model);
+                floater.set_waves(waves_model.waves);
+            } catch (const std::bad_cast& e) {
+                throw std::runtime_error("Must use HydroChrono wave model when using HydroChrono floater.");
+            }
+        } catch (const std::bad_cast& e) {
+        }
+#endif
 
 #ifdef HAVE_AERODYN
         try {

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -360,9 +360,6 @@ void populate_rna_elasto_from_json(const std::string& filepath, seahowl::elasto:
     shaft.at("tilt").get_to(rna.shaft.tilt);
     // convert to radians
     rna.shaft.tilt *= PI / 180.0;
-    // drivetrain
-    auto drivetrain = json_obj.at("drivetrain");
-    drivetrain.at("generator_inertia").get_to(rna.shaft.generator_inertia);
 }
 
 void populate_rna_aero_from_json(const std::string& filepath, seahowl::aero::RotorNacelleAssemblyAero& rna) {
@@ -617,6 +614,10 @@ void populate_turbine_from_json(const std::string& filepath,
     // generator
     drivetrain.at("generator_efficiency").get_to(turbine.generator_efficiency);
     turbine.generator_efficiency /= 100.0;
+    // add inertia of generator to hub directly
+    double drivetrain_inertia;
+    drivetrain.at("generator_inertia").get_to(drivetrain_inertia);
+    turbine.rna.elasto.rotor->hub.inertia += drivetrain_inertia;
 
     if (json_obj.contains("floater")) {
         try {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,8 @@ using json = nlohmann::json;
 #include <seahowl/aero/system_aero.h>
 #include <seahowl/core/blade.h>
 #include <seahowl/elasto/blade_elasto.h>
+#include <seahowl/core/turbine_floating.h>
+#include <seahowl/elasto/mooring_elasto.h>
 
 #include <filesystem>  // C++17
 #include <fstream>

--- a/src/servo/controller.cpp
+++ b/src/servo/controller.cpp
@@ -48,6 +48,7 @@ void ControllerVariableTorque::step(double time, double dt, const seahowl::core:
         // @todo Line below is specific to actuator disk (otherwise torque_aero is zero), need to move it
         // inside turbine.rna.elasto.get_axial_torque()
         torque_aero += turbine.rna.aero.rotor->hub_torque_aero;
+
         torque_elec = torque_aero * std::pow(rpm / target_rpm, 2);
         // torque_elec must be the torque at the generator --> scaled by gearbox ratio and efficiency
         torque_elec *= turbine.gearbox_efficiency / turbine.gearbox_ratio;

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -390,9 +390,9 @@ TEST(test_turbine, rpm_initial_pitch) {
 
     // statics
     if (statics_prestep) {
-        turbine.rna.elasto.lock_shaft(true);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
         system_elasto.do_statics(true, 10);
-        turbine.rna.elasto.lock_shaft(false);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
     }
 
     double time = 0.0;
@@ -449,9 +449,9 @@ TEST(test_turbine, rpm_initial_pitch_fpm) {
 
     // statics
     if (statics_prestep) {
-        turbine.rna.elasto.lock_shaft(true);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
         system_elasto.do_statics(true, 10);
-        turbine.rna.elasto.lock_shaft(false);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
     }
 
     double time = 0.0;
@@ -508,9 +508,9 @@ TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
 
     // statics
     if (statics_prestep) {
-        turbine.rna.elasto.lock_shaft(true);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
         system_elasto.do_statics(true, 10);
-        turbine.rna.elasto.lock_shaft(false);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
     }
 
     double time = 0.0;
@@ -570,9 +570,9 @@ TEST(test_turbine, controller_target_rpm) {
 
     // statics
     if (statics_prestep) {
-        turbine.rna.elasto.lock_shaft(true);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
         system_elasto.do_statics(true, 10);
-        turbine.rna.elasto.lock_shaft(false);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
     }
 
     double time = 0.0;
@@ -634,9 +634,9 @@ TEST(test_turbine, actuator_disk) {
 
     // statics
     if (statics_prestep) {
-        turbine.rna.elasto.lock_shaft(true);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
         system_elasto.do_statics(true, 10);
-        turbine.rna.elasto.lock_shaft(false);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
     }
 
     double time = 0.0;
@@ -721,9 +721,9 @@ TEST(test_aerodyn, rpm_initial_pitch) {
 
     // statics
     if (statics_prestep) {
-        turbine.rna.elasto.lock_shaft(true);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
         system_elasto.do_statics(true, 10);
-        turbine.rna.elasto.lock_shaft(false);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
     }
 
     double time = 0.0;
@@ -855,9 +855,9 @@ TEST(test_inflowwind, rpm_initial_pitch) {
 
     // statics
     if (statics_prestep) {
-        turbine.rna.elasto.lock_shaft(true);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
         system_elasto.do_statics(true, 10);
-        turbine.rna.elasto.lock_shaft(false);
+        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
     }
 
     double time = 0.0;


### PR DESCRIPTION
In this PR:
- Add wave options when using HydroChrono as a "sea" type in environment.json options
- Separate floater main body (COG) and reference body for potential flow (the hydro databse can be computed at a point elsewhere than the floater COG)
- Make HydroChrono dependency private
- Had to revert some of the changes of [72ea0f](https://github.com/Total-RD/seahowl/pull/102/commits/0c5ef1d1b448ac8b9a185da45c2e76064206007d), adding extra bodies in RNA caused issue with FOWT