### PR TITLE
Aero: tower shadow and wind ramp updates

### DIFF
--- a/data/IEA15MW/aerodyn/IEA-15-240-RWT_AeroDyn15.dat
+++ b/data/IEA15MW/aerodyn/IEA-15-240-RWT_AeroDyn15.dat
@@ -5,8 +5,8 @@ False                  Echo        - Echo the input to "<rootname>.AD.ech"?  (fl
 default                DTAero      - Time interval for aerodynamic calculations {or "default"} (s)
 1                      WakeMod     - Type of wake/induction model (switch) {0=none, 1=BEMT, 2=DBEMT, 3=OLAF} [WakeMod cannot be 2 or 3 when linearizing]
 1                      AFAeroMod   - Type of blade airfoil aerodynamics model (switch) {1=steady model, 2=Beddoes-Leishman unsteady model} [AFAeroMod must be 1 when linearizing]
-0                      TwrPotent   - Type tower influence on wind based on potential flow around the tower (switch) {0=none, 1=baseline potential flow, 2=potential flow with Bak correction}
-1                      TwrShadow   - Calculate tower influence on wind based on downstream tower shadow (switch) {0=none, 1=Powles model, 2=Eames model}
+1                      TwrPotent   - Type tower influence on wind based on potential flow around the tower (switch) {0=none, 1=baseline potential flow, 2=potential flow with Bak correction}
+0                      TwrShadow   - Calculate tower influence on wind based on downstream tower shadow (switch) {0=none, 1=Powles model, 2=Eames model}
 True                   TwrAero     - Calculate tower aerodynamic loads? (flag)
 False                  FrozenWake  - Assume frozen wake during linearization? (flag) [used only when WakeMod=1 and when linearizing]
 False                  CavitCheck  - Perform cavitation check? (flag) [AFAeroMod must be 1 when CavitCheck=true]
@@ -19,7 +19,7 @@ AeroAcousticsInput.dat AA_InputFile - AeroAcoustics input file [used only when C
 "default"              Patm        - Atmospheric pressure (Pa) [used only when CavitCheck=True]
 "default"              Pvap        - Vapour pressure of fluid (Pa) [used only when CavitCheck=True]
 ======  Blade-Element/Momentum Theory Options  ====================================================== [used only when WakeMod=1]
-2                      SkewMod     - Type of skewed-wake correction model (switch) {1=uncoupled, 2=Pitt/Peters, 3=coupled} [unused when WakeMod=0 or 3]
+1                      SkewMod     - Type of skewed-wake correction model (switch) {1=uncoupled, 2=Pitt/Peters, 3=coupled} [unused when WakeMod=0 or 3]
 default                SkewModFactor - Constant used in Pitt/Peters skewed wake model {or "default" is 15/32*pi} (-) [used only when SkewMod=2; unused when WakeMod=0 or 3]
 True                   TipLoss     - Use the Prandtl tip-loss model? (flag) [unused when WakeMod=0 or 3]
 True                   HubLoss     - Use the Prandtl hub-loss model? (flag) [unused when WakeMod=0 or 3]

--- a/include/seahowl/aero/blade_aero.h
+++ b/include/seahowl/aero/blade_aero.h
@@ -4,13 +4,6 @@
 #include "seahowl/commons/entities.h"
 #include "seahowl/aero/reference_point_aero.h"
 
-// forward declarations
-namespace seahowl {
-namespace aero {
-struct BladeReferencePointAero;
-}  // namespace aero
-}  // namespace seahowl
-
 namespace seahowl {
 
 /**@brief Aerodynamic module */
@@ -21,15 +14,15 @@ namespace aero {
  */
 struct BladeNodeAero : public EntityDynamicEigen {
     /** @brief Load calculated at node. */
-    Vector3d load;
+    Vector3d load{0.0, 0.0, 0.0};
     /** @brief Moment calculated at node. */
-    Vector3d moment;
+    Vector3d moment{0.0, 0.0, 0.0};
     /** @brief Uninduced wind velocity at node. */
-    Vector3d wind_velocity;
+    Vector3d wind_velocity{0.0, 0.0, 0.0};
     /** @brief Tower-shadowed wind velocity at node. */
-    Vector3d wind_velocity_shadowed;
+    Vector3d wind_velocity_shadowed{0.0, 0.0, 0.0};
     /** @brief Induced wind velocity at node. */
-    Vector3d relative_velocity_induced;
+    Vector3d relative_velocity_induced{0.0, 0.0, 0.0};
     /** @brief Reference point associated to node (aerodynamic properties). */
     BladeReferencePointAero properties;
 
@@ -66,11 +59,11 @@ struct BladeElementAero {
     /** @brief Second node of element. */
     const BladeNodeAero& node2;
     /** @brief Fraction (normalized abscissa along longitudinal axis of component) of center of element. */
-    double fraction;
+    double fraction = 0.0;
     /** @brief Length of element. */
-    double length;
+    double length = 0.0;
     /** @brief Offset (x, y) for the aerodynamic center of blade at center of element. */
-    Vector2d offset_aero;
+    Vector2d offset_aero = {0.0, 0.0};
 
     /**
      * @brief Constructor.

--- a/include/seahowl/aero/tower_aero.h
+++ b/include/seahowl/aero/tower_aero.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "seahowl/commons/numerics.h"
+#include "seahowl/commons/entities.h"
 #include "seahowl/aero/reference_point_aero.h"
 
 #include <vector>
@@ -17,15 +19,49 @@ namespace seahowl {
 namespace aero {
 
 /**
+ * @brief Tower aerodynamic node.
+ */
+struct TowerNodeAero : public EntityDynamicEigen {
+    /** @brief Load calculated at node. */
+    Vector3d load{0.0, 0.0, 0.0};
+    /** @brief Reference point associated to node (aerodynamic properties). */
+    TowerReferencePointAero properties;
+
+    /**
+     * @brief Constructor.
+     */
+    TowerNodeAero(TowerReferencePointAero& point);
+};
+
+/**
  * @brief Tower aerodynamic element.
  */
 struct TowerElementAero {
-    /** @brief Reference point associated to element (aerodynamic properties). */
-    TowerReferencePointAero properties;
+    /** @brief Fist node of element. */
+    const TowerNodeAero& node1;
+    /** @brief Second node of element. */
+    const TowerNodeAero& node2;
+    /** @brief Fraction (normalized abscissa along longitudinal axis of component) of center of element. */
+    double fraction = 0.0;
     /** @brief Length of element. */
     double length = 0.0;
 
-    TowerElementAero(const TowerReferencePointAero& point1, const TowerReferencePointAero& point2);
+    TowerElementAero(const TowerNodeAero& point1, const TowerNodeAero& point2);
+
+    /**
+     * @brief Returns integrated load at center of element.
+     */
+    Vector3d get_load() const;
+
+    /**
+     * @brief Get position of center of element.
+     */
+    Vector3d get_position() const;
+
+    /**
+     * @brief Get rotation of center of element.
+     */
+    Quaternion get_rotation() const;
 };
 
 /**
@@ -39,6 +75,8 @@ class TowerAero {
     std::vector<TowerReferencePointAero> reference_points;
     /** @brief List of discretized points (interpolated reference points) describing the tower properties. */
     std::vector<TowerReferencePointAero> discretized_points;
+    /** @brief Aero nodes. */
+    std::vector<TowerNodeAero> nodes;
     /** @brief Aero elements. */
     std::vector<TowerElementAero> elements;
     /** @brief Loads at center of tower elements. */

--- a/include/seahowl/core/tower.h
+++ b/include/seahowl/core/tower.h
@@ -36,8 +36,10 @@ class Tower : public ComponentDynamic {
     seahowl::elasto::TowerElasto& elasto;
     /** @brief Aerodynamic model of the tower. */
     seahowl::aero::TowerAero& aero;
-    /** @brief Mapping of aero elements into elasto domain. */
-    std::vector<seahowl::DiscretizationPoint> mapping_aero2elasto;
+    /** @brief Mapping of aero nodes into elasto domain. */
+    std::vector<seahowl::DiscretizationPoint> mapping_aero2elasto_nodes;
+    /** @brief Mapping of aero elements (central point of elements) into elasto domain. */
+    std::vector<seahowl::DiscretizationPoint> mapping_aero2elasto_elements;
     /** @brief Mapping of elasto nodes into aero domain. */
     std::vector<seahowl::DiscretizationPoint> mapping_elasto2aero;
 

--- a/include/seahowl/elasto/component_elasto.h
+++ b/include/seahowl/elasto/component_elasto.h
@@ -172,6 +172,14 @@ class ComponentElastoFEA : public virtual ComponentElasto {
      * @brief Returns all nodes loads (global frame of reference).
      */
     std::vector<Vector3d> get_nodes_loads() const;
+
+    /**
+     * @brief Returns zntity along component.
+     *
+     * @param[in] eta Normalized abscissa between node1 and node2 of element.
+     * @param[in] element Element index.
+     */
+    seahowl::EntityDynamicEigen get_entity_along_component(double eta, int element_index) const;
 };
 
 }  // namespace elasto

--- a/include/seahowl/env/wind_models.h
+++ b/include/seahowl/env/wind_models.h
@@ -26,8 +26,6 @@ class ShearedWind : public WindModel {
     double shear_coefficient = 0.0;
     /** @brief Reference height (where constant velocity is defined). */
     double reference_height = 150.0;
-    /** @brief Reference length (length of shear). */
-    double reference_length = 240.0;
     /** @brief Direction of gravitational acceleration. */
     Vector3d direction_gravity{0.0, 0.0, -1.0};
 };

--- a/src/aero/bemt.cpp
+++ b/src/aero/bemt.cpp
@@ -196,31 +196,71 @@ void seahowl::aero::apply_tower_shadow_effect_on_wind(Vector3d& wind_velocity,
                                                       const Vector3d& position,
                                                       const seahowl::aero::TowerAero& tower_aero) {
     // get wind velocity in tower reference frame
-    auto& towertop_position = tower_aero.elements.back().properties.coordinates;
-    auto& towertop_rotation = tower_aero.elements.back().properties.rotation;
+    auto& towertop = tower_aero.nodes.back();
+    auto& towerbase = tower_aero.nodes.front();
+    auto towertop_position = towertop.get_position();
+    auto towerbase_position = towerbase.get_position();
+    // tower axis assumption: tower is straight from towerbottom to towertop)
+    auto tower_axis = (towertop_position - towerbase_position).normalized();
+    // get average tower velocity (for relative wind velocity)
+    auto tower_velocity = Vector3d(0.0, 0.0, 0.0);
+    for (auto& node : tower_aero.nodes) {
+        tower_velocity += node.get_velocity();
+    }
+    tower_velocity /= (tower_aero.nodes.size());
+
+    // find rotation between global z-axis and tower z-axis (IEC coordinate system)
+    auto tower_rot = Quaternion(1.0, 0.0, 0.0, 0.0);
+    auto z_global = Vector3d(0.0, 0.0, 1.0);
+    auto z_dot = tower_axis.dot(z_global);
+    double tol = 1.0e-6;
+    if (z_dot < -(1.0 - tol)) {
+        // 180 degrees rotation
+        tower_rot = AngleAxisd(PI, Vector3d(1.0, 0.0, 0.0));
+    } else if (z_dot > 1.0 - tol) {
+        // no rotation
+        tower_rot = Quaternion(1.0, 0.0, 0.0, 0.0);
+    } else {
+        auto axis_tower_rot = z_global.cross(tower_axis).normalized();
+        auto angle_tower_rot = acos(z_dot);
+        tower_rot = AngleAxisd(angle_tower_rot, axis_tower_rot);
+    }
+
     // only take wind velocity perpendicular to tower axis
-    auto wind_velocity_tower = Vector3d(wind_velocity.x(), wind_velocity.y(), 0.0);
+    auto wind_velocity_tower = tower_rot.inverse() * (wind_velocity - tower_velocity);
+    wind_velocity_tower[2] = 0.0;
+    auto wind_axis_tower = wind_velocity_tower.normalized();
 
-    // project element coordinates to tower reference frame
-    Vector3d coordinates_projected = -(towertop_rotation.inverse() * (position - towertop_position));
+    // get z positions along tower axis
+    // rotate all positions around center of tower to get relative positions to tower center in IEC coordinate system
+    auto rotation_center = 0.5 * (towerbase_position + towertop_position);
+    auto position_relative = tower_rot.inverse() * (position - rotation_center);
+    auto towerbase_relative = tower_rot.inverse() * (towerbase_position - rotation_center);
+    auto towertop_relative = tower_rot.inverse() * (towertop_position - rotation_center);
+    auto z_position = position_relative.z();
+    auto z_towerbase = towerbase_relative.z();
+    auto z_towertop = towertop_relative.z();
+    if (z_position > z_towerbase && z_position < z_towertop) {
+        // get diameter at z position
+        auto z_rel = (z_position - z_towerbase) / (z_towertop - z_towerbase);
+        std::vector<double> fractions{z_rel};
+        auto tower_radius = seahowl::get_discretized_points(fractions, tower_aero.discretized_points)[0].diameter / 2.0;
 
-    // find tower radius
-    auto tower_length =
-        (tower_aero.reference_points.back().coordinates - tower_aero.reference_points.front().coordinates).norm();
-    if (coordinates_projected.z() >= 0 && coordinates_projected.z() <= tower_length) {
-        std::vector<double> fractions{(tower_length - coordinates_projected.z()) / tower_length};
-        auto tower_radius = seahowl::get_discretized_points(fractions, tower_aero.reference_points)[0].diameter / 2.0;
-        // front distance of point from tower
-        auto xx = coordinates_projected.x();
+        // find relative position
+        auto position_projected = towerbase_relative + z_rel * (towertop_relative - towerbase_relative);
+        auto position_relative_projected = position_relative - position_projected;
+        // front position of point from tower
+        auto x_rel = position_relative_projected.dot(wind_axis_tower);
+        auto xx = abs(x_rel);
         auto xx2 = pow(xx, 2);
-        // side distance from tower of point
-        auto yy = coordinates_projected.y();
+        // side position of point from tower
+        auto y_rel = position_relative_projected.dot(Vector3d(1.0, 1.0, 1.0) - wind_axis_tower.cwiseAbs());
+        auto yy = abs(y_rel);
         auto yy2 = pow(yy, 2);
-        wind_velocity_tower =
-            (wind_velocity_tower + wind_velocity_tower.cwiseProduct(pow(tower_radius, 2) / pow(yy2 + xx2, 2) *
-                                                                    Vector3d((yy2 - xx2), (-2.0 * xx * yy), 0.0)));
 
-        // correct wind velocity
-        wind_velocity = towertop_rotation * wind_velocity_tower;
+        // update wind velocity
+        wind_velocity =
+            wind_velocity + tower_rot * wind_velocity_tower.cwiseProduct(pow(tower_radius, 2) / pow(yy2 + xx2, 2) *
+                                                                         Vector3d((yy2 - xx2), (-2.0 * xx * yy), 0.0));
     }
 }

--- a/src/aero/blade_aero.cpp
+++ b/src/aero/blade_aero.cpp
@@ -6,12 +6,8 @@
 
 #include <spdlog/spdlog.h>
 
-using seahowl::aero::BladeNodeAero;
-using seahowl::aero::BladeElementAero;
-using seahowl::aero::BladeAero;
-using seahowl::Vector3d;
-using seahowl::Vector2d;
-using seahowl::Quaternion;
+using namespace seahowl;
+using namespace seahowl::aero;
 
 BladeNodeAero::BladeNodeAero(BladeReferencePointAero& point) {
     properties = point;
@@ -95,6 +91,8 @@ void BladeAero::build() {
     }
     // elements
     elements.clear();
+    loads.clear();
+    moments.clear();
     for (int ii = 0; ii < discretized_points.size() - 1; ii++) {
         elements.push_back(BladeElementAero(nodes[ii], nodes[ii + 1]));
         loads.push_back(Vector3d(0.0, 0.0, 0.0));

--- a/src/aero/tower_aero.cpp
+++ b/src/aero/tower_aero.cpp
@@ -7,15 +7,38 @@
 
 #include <spdlog/spdlog.h>
 
-using seahowl::aero::TowerElementAero;
-using seahowl::aero::TowerAero;
+using namespace seahowl;
+using namespace seahowl::aero;
 using seahowl::env::FluidModel;
-using seahowl::Vector3d;
-using seahowl::PI;
 
-TowerElementAero::TowerElementAero(const TowerReferencePointAero& point1, const TowerReferencePointAero& point2) {
-    properties = (point1 + point2) * 0.5;
-    length = (point1.coordinates - point2.coordinates).norm();
+TowerNodeAero::TowerNodeAero(TowerReferencePointAero& point) {
+    properties = point;
+    set_position(point.coordinates);
+    set_velocity(Vector3d(0.0, 0.0, 0.0));
+    set_acceleration(Vector3d(0.0, 0.0, 0.0));
+    set_rotational_velocity(Vector3d(0.0, 0.0, 0.0));
+    set_rotational_acceleration(Vector3d(0.0, 0.0, 0.0));
+    load = Vector3d(0.0, 0.0, 0.0);
+}
+
+TowerElementAero::TowerElementAero(const TowerNodeAero& node1, const TowerNodeAero& node2)
+    : node1(node1), node2(node2) {
+    fraction = 0.5 * (node1.properties.fraction + node2.properties.fraction);
+    length = (node1.get_position() - node2.get_position()).norm();
+}
+
+Vector3d TowerElementAero::get_load() const {
+    return 0.5 * (node1.load + node2.load) * length;
+}
+
+Vector3d TowerElementAero::get_position() const {
+    return 0.5 * (node1.get_position() + node2.get_position());
+}
+
+Quaternion TowerElementAero::get_rotation() const {
+    // returning rotation of node1
+    // TODO: average rotation of node1 and node2
+    return node1.get_rotation();
 }
 
 TowerAero::TowerAero() {}
@@ -43,34 +66,40 @@ void TowerAero::build() {
 
     // build
     discretized_points = seahowl::get_discretized_points(discretization_fractions, reference_points);
-    for (int ii = 0; ii < discretized_points.size() - 1; ii++) {
-        // make element
-        auto element = TowerElementAero(discretized_points[ii], discretized_points[ii + 1]);
-        elements.push_back(element);
+    // nodes
+    nodes.clear();
+    for (int ii = 0; ii < discretized_points.size(); ii++) {
         // push empty load
+        nodes.push_back(TowerNodeAero(discretized_points[ii]));
+    }
+    // elements
+    elements.clear();
+    loads.clear();
+    for (int ii = 0; ii < discretized_points.size() - 1; ii++) {
+        elements.push_back(TowerElementAero(nodes[ii], nodes[ii + 1]));
         loads.push_back(Vector3d(0.0, 0.0, 0.0));
     }
 }
 
 void TowerAero::compute_aero_loads(const FluidModel& wind_model, double time) {
-    for (int ii = 0; ii < elements.size(); ii++) {
-        auto& element = elements[ii];
-        auto& properties = element.properties;
-
-        auto density = wind_model.get_fluid_density(properties.coordinates, time);
+    for (auto& node : nodes) {
+        auto density = wind_model.get_fluid_density(node.get_position(), time);
         // get fluid relative velocity
-        auto wind_velocity = wind_model.get_fluid_velocity(properties.coordinates, time);
-        auto velocity_relative = wind_velocity - properties.velocity;
-        auto dir = properties.rotation.vec();  // tangent direction
+        auto wind_velocity = wind_model.get_fluid_velocity(node.get_position(), time);
+        auto velocity_relative = wind_velocity - node.get_velocity();
+        auto dir = node.get_rotation() * Vector3d(0.0, 0.0, 1.0);  // tangent direction
         auto dot = velocity_relative.dot(dir);
         auto velocity_tangent = dir * dot;
         auto velocity_normal = velocity_relative - velocity_tangent;
 
-        auto length = element.length;
-        auto diameter = properties.diameter;
-        auto cd = properties.drag_coefficient;
-        auto load_drag = 0.5 * density * cd * diameter * velocity_normal.norm() * velocity_normal * length;
+        auto diameter = node.properties.diameter;
+        auto cd = node.properties.drag_coefficient;
+        auto load_drag = 0.5 * density * cd * diameter * velocity_normal.norm() * velocity_normal;
 
-        loads[ii] = load_drag;
+        node.load = load_drag;
+    }
+
+    for (int ii = 0; ii < elements.size(); ii++) {
+        loads[ii] = elements[ii].get_load();
     }
 }

--- a/src/bindings/pyseahowl_core.cpp
+++ b/src/bindings/pyseahowl_core.cpp
@@ -85,6 +85,8 @@ void initialize_pyseahowl_core(py::module& m) {
     py::class_<seahowl::core::System, std::shared_ptr<seahowl::core::System>, seahowl::core::ComponentDynamic>(m_core,
                                                                                                                "System")
         .def(py::init<seahowl::elasto::SystemElasto&, seahowl::aero::SystemAero&>())
+        .def("assemble", &seahowl::core::System::assemble)
+        .def("assemble", &seahowl::core::System::assemble)
         .def("step", &seahowl::core::System::step)
         .def("get_time", &seahowl::core::System::get_time)
         .def("set_time", &seahowl::core::System::set_time)

--- a/src/bindings/pyseahowl_env.cpp
+++ b/src/bindings/pyseahowl_env.cpp
@@ -26,7 +26,6 @@ void initialize_pyseahowl_env(py::module& m) {
         m_aero, "ShearedWind")
         .def_readwrite("shear_coefficient", &seahowl::env::ShearedWind::shear_coefficient)
         .def_readwrite("reference_height", &seahowl::env::ShearedWind::reference_height)
-        .def_readwrite("reference_length", &seahowl::env::ShearedWind::reference_length)
         .def_readwrite("direction_gravity", &seahowl::env::ShearedWind::direction_gravity);
     py::class_<seahowl::env::ConstantWind, std::shared_ptr<seahowl::env::ConstantWind>, seahowl::env::ShearedWind>(
         m_aero, "ConstantWind")

--- a/src/bindings/pyseahowl_io.cpp
+++ b/src/bindings/pyseahowl_io.cpp
@@ -29,6 +29,7 @@ void initialize_pyseahowl_io(py::module& m) {
     m_io.def("populate_tower_aero_from_json", &populate_tower_aero_from_json);
     m_io.def("populate_rna_from_json", &populate_rna_from_json);
     m_io.def("populate_turbine_from_json", &populate_turbine_from_json);
+    m_io.def("add_turbine_to_system_from_json", &add_turbine_to_system_from_json);
     m_io.def("populate_system_from_json", &populate_system_from_json);
     m_io.def("initialize_system_from_json", &initialize_system_from_json);
 

--- a/src/core/tower.cpp
+++ b/src/core/tower.cpp
@@ -49,11 +49,18 @@ void Tower::set_discretization_aero(std::vector<double> fractions) {
 
 void Tower::compute_mapping_aero2elasto() {
     // get aero element position (center) from which loads will be applied
-    std::vector<double> aero_discretization_fractions;
-    for (int ii = 0; ii < aero.elements.size(); ii++) {
-        aero_discretization_fractions.push_back(aero.elements[ii].properties.fraction);
+    std::vector<double> aero_discretization_fractions_elements;
+    for (auto& element : aero.elements) {
+        aero_discretization_fractions_elements.push_back(element.fraction);
     }
-    mapping_aero2elasto = get_indice_and_positions(aero_discretization_fractions, elasto.discretization_fractions);
+    mapping_aero2elasto_elements =
+        get_indice_and_positions(aero_discretization_fractions_elements, elasto.discretization_fractions);
+    std::vector<double> aero_discretization_fractions_nodes;
+    for (auto& node : aero.nodes) {
+        aero_discretization_fractions_nodes.push_back(node.properties.fraction);
+    }
+    mapping_aero2elasto_nodes =
+        get_indice_and_positions(aero_discretization_fractions_nodes, elasto.discretization_fractions);
 }
 
 void Tower::compute_mapping_elasto2aero() {
@@ -61,31 +68,32 @@ void Tower::compute_mapping_elasto2aero() {
 }
 
 void Tower::update_positions_aero() {
-    for (int ii = 0; ii < aero.elements.size(); ii++) {
-        // update position and rotation of aero elements
-        int elasto_element_index = mapping_aero2elasto[ii].index;
-        auto element_elasto = elasto.elements[elasto_element_index];
-        double eta = mapping_aero2elasto[ii].eta;
-        auto& element_aero = aero.elements[ii];
-        elasto.evaluate_position_rotation(element_aero.properties.coordinates, element_aero.properties.rotation,
-                                          elasto_element_index, eta);
+    for (int ii = 0; ii < aero.nodes.size(); ii++) {
+        auto& node_aero = aero.nodes[ii];
 
-        // update velocity of aero elements
-        aero.elements[ii].properties.velocity =
-            0.5 * (element_elasto->nodes[0]->get_velocity() + element_elasto->nodes[1]->get_velocity());
+        // update position and rotation of aero elements
+        int elasto_element_index = mapping_aero2elasto_nodes[ii].index;
+        double eta = mapping_aero2elasto_nodes[ii].eta;
+        auto entity = elasto.get_entity_along_component(eta, elasto_element_index);
+        node_aero.set_rotation(entity.get_rotation());
+        node_aero.set_position(entity.get_position());
+        node_aero.set_velocity(entity.get_velocity());
+        node_aero.set_rotational_velocity(entity.get_rotational_velocity());
+        node_aero.set_acceleration(entity.get_acceleration());
+        node_aero.set_rotational_acceleration(entity.get_rotational_acceleration());
     }
 }
 
 void Tower::update_loads_elasto() {
     elasto.reset_loads();
-    if (aero.loads.size() != mapping_aero2elasto.size()) {
+    if (aero.loads.size() != mapping_aero2elasto_elements.size()) {
         throw std::runtime_error("Tower: length of vector of loads (" + std::to_string(aero.loads.size()) +
-                                 " and length of aero to elasto mapping(" + std::to_string(mapping_aero2elasto.size()) +
-                                 ") do not match.");
+                                 " and length of aero to elasto mapping(" +
+                                 std::to_string(mapping_aero2elasto_elements.size()) + ") do not match.");
     }
     auto offset = Vector3d(0.0, 0.0, 0.0);
     for (int ii = 0; ii < aero.loads.size(); ii++) {
-        elasto.accumulate_element_load(aero.loads[ii], Vector3d(0.0, 0.0, 0.0), mapping_aero2elasto[ii].index,
-                                       mapping_aero2elasto[ii].eta, offset);
+        elasto.accumulate_element_load(aero.loads[ii], Vector3d(0.0, 0.0, 0.0), mapping_aero2elasto_elements[ii].index,
+                                       mapping_aero2elasto_elements[ii].eta, offset);
     }
 }

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -148,27 +148,7 @@ seahowl::Vector3d BladeElastoFEA::get_blade_root_moment() const {
 }
 
 seahowl::EntityDynamicEigen BladeElastoFEA::get_entity_along_blade(double eta, int element_index) const {
-    auto entity = seahowl::EntityDynamicEigen();
-    Vector3d new_position;
-    Quaternion new_rotation;
-    evaluate_position_rotation(new_position, new_rotation, element_index, eta);
-    entity.set_position(new_position);
-    entity.set_rotation(new_rotation);
-
-    // update properties of aero nodes
-    double weight1 = 0.5 * fabs(eta - 1.0);
-    double weight2 = 0.5 * fabs(eta + 1.0);
-    auto& element = elements[element_index];
-    auto& node1 = element->nodes[0];
-    auto& node2 = element->nodes[1];
-    entity.set_velocity(weight1 * node1->get_velocity() + weight2 * node2->get_velocity());
-    entity.set_rotational_velocity(weight1 * node1->get_rotational_velocity() +
-                                   weight2 * node2->get_rotational_velocity());
-    entity.set_acceleration(weight1 * node1->get_acceleration() + weight2 * node2->get_acceleration());
-    entity.set_rotational_acceleration(weight1 * node1->get_rotational_acceleration() +
-                                       weight2 * node2->get_rotational_acceleration());
-
-    return entity;
+    return get_entity_along_component(eta, element_index);
 }
 
 void BladeElastoFEA::accumulate_load_along_blade(const seahowl::Vector3d& load,

--- a/src/elasto/component_elasto.cpp
+++ b/src/elasto/component_elasto.cpp
@@ -188,3 +188,27 @@ std::vector<Vector3d> ComponentElastoFEA::get_nodes_loads() const {
     }
     return loads;
 }
+
+seahowl::EntityDynamicEigen ComponentElastoFEA::get_entity_along_component(double eta, int element_index) const {
+    auto entity = seahowl::EntityDynamicEigen();
+    Vector3d new_position;
+    Quaternion new_rotation;
+    evaluate_position_rotation(new_position, new_rotation, element_index, eta);
+    entity.set_position(new_position);
+    entity.set_rotation(new_rotation);
+
+    // update properties of aero nodes
+    double weight1 = 0.5 * fabs(eta - 1.0);
+    double weight2 = 0.5 * fabs(eta + 1.0);
+    auto& element = elements[element_index];
+    auto& node1 = element->nodes[0];
+    auto& node2 = element->nodes[1];
+    entity.set_velocity(weight1 * node1->get_velocity() + weight2 * node2->get_velocity());
+    entity.set_rotational_velocity(weight1 * node1->get_rotational_velocity() +
+                                   weight2 * node2->get_rotational_velocity());
+    entity.set_acceleration(weight1 * node1->get_acceleration() + weight2 * node2->get_acceleration());
+    entity.set_rotational_acceleration(weight1 * node1->get_rotational_acceleration() +
+                                       weight2 * node2->get_rotational_acceleration());
+
+    return entity;
+}

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -53,6 +53,17 @@ void RotorElasto::build() {
         // link root node of blade to rotor center
         blade->attach_root_to_body(*body_hub);
     }
+
+    // apply initial pitch of blades
+    for (auto& blade : blades) {
+        // get blade pitch diff with collective pitch
+        auto individual_blade_pitch = blade->pitch - pitch_collective;
+        // apply total pitch to blade
+        auto total_blade_pitch = pitch_collective + individual_blade_pitch;
+        blade->apply_pitch_increment(total_blade_pitch);
+        // register new pitch value
+        blade->pitch = total_blade_pitch;
+    }
 }
 
 void RotorElasto::apply_collective_pitch_increment(double pitch_increment) {

--- a/src/elasto/tower_elasto.cpp
+++ b/src/elasto/tower_elasto.cpp
@@ -65,7 +65,7 @@ void TowerElasto::build_elements_tapered_timoshenko() {
     for (size_t ii = 1; ii < nelements + 1; ii++) {
         // create element
         auto element = std::make_shared<ElementBladeElastoChrono>();
-        // add element to blade elements vector
+        // add element to tower elements vector
         elements.push_back(element);
         // set element nodes
         element->set_nodes(nodes[ii - 1], nodes[ii]);

--- a/src/env/wind_models.cpp
+++ b/src/env/wind_models.cpp
@@ -7,12 +7,8 @@ Vector3d get_sheared_wind_velocity(const Vector3d& velocity,
                                    const Vector3d& position,
                                    const Vector3d& direction_gravity,
                                    double shear_coefficient,
-                                   double reference_height,
-                                   double reference_length) {
+                                   double reference_height) {
     double distance = position.dot(-direction_gravity);
-    if (distance > reference_length) {
-        distance = reference_length;
-    }
     return velocity * pow(distance / reference_height, shear_coefficient);
 }
 
@@ -30,8 +26,8 @@ void ConstantWind::set_wind_velocity(Vector3d velocity) {
 }
 
 Vector3d ConstantWind::get_fluid_velocity(const Vector3d& position, double time) const {
-    auto velocity = get_sheared_wind_velocity(wind_velocity, position, direction_gravity, shear_coefficient,
-                                              reference_height, reference_length);
+    auto velocity =
+        get_sheared_wind_velocity(wind_velocity, position, direction_gravity, shear_coefficient, reference_height);
     return velocity;
 }
 
@@ -60,7 +56,6 @@ Vector3d WindRamp::get_fluid_velocity(const Vector3d& position, double time) con
             std::runtime_error("End time is less than start time for the wind ramp.");
         }
     }
-    velocity = get_sheared_wind_velocity(velocity, position, direction_gravity, shear_coefficient, reference_height,
-                                         reference_length);
+    velocity = get_sheared_wind_velocity(velocity, position, direction_gravity, shear_coefficient, reference_height);
     return velocity;
 }

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -420,6 +420,7 @@ void add_turbine_to_system_from_json(const std::string& filepath,
 
     // populate turbine
     populate_turbine_from_json(filepath, *turbine, output_folder);
+    turbine->build();
 }
 
 void populate_turbine_from_json(const std::string& filepath,
@@ -900,8 +901,6 @@ void populate_system_from_json(const std::string& filepath, seahowl::core::Syste
         }
 #endif
 
-        // build turbine
-        turbine.build();
         // rotate turbine to align tower with gravity vector
         auto v1 = Vector3d(-system_core.elasto.get_gravitational_acceleration()).normalized();
         auto v2 = (turbine.tower.elasto.nodes[1]->get_position() - turbine.tower.elasto.nodes[0]->get_position())
@@ -915,16 +914,6 @@ void populate_system_from_json(const std::string& filepath, seahowl::core::Syste
         // translate turbine
         auto trans = turbine_json.at("translation").get<std::vector<double>>();
         turbine.translate(Vector3d(trans[0], trans[1], trans[2]));
-
-        // apply initial pitches
-        for (auto& blade : turbine.rna.blades) {
-            auto pitch0 = blade->elasto.pitch;
-            blade->elasto.apply_pitch_increment(pitch0);
-            blade->elasto.pitch = pitch0;
-        }
-        auto rotor_pitch0 = turbine.rna.elasto.rotor->pitch_collective;
-        turbine.rna.elasto.rotor->apply_collective_pitch_increment(rotor_pitch0);
-        turbine.rna.elasto.rotor->pitch_collective = rotor_pitch0;
 
         try {
             // if floating: do not fix tower

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -295,19 +295,43 @@ TEST(test_tower, tower_shadow_check) {
     auto position1 = Vector3d(-14.0, -5.0, 50.0);
     Vector3d wind_velocity1 = wind_velocity;
     seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity1, position1, tower_aero);
-    ASSERT_NEAR(wind_velocity1.x(), 9.315126, 1e-4);
+    ASSERT_NEAR(wind_velocity1.x(), 9.258011, 1e-4);
 
     // position 2
     auto position2 = Vector3d(-15.0, 0.0, 45.0);
     Vector3d wind_velocity2 = wind_velocity;
     seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity2, position2, tower_aero);
-    ASSERT_NEAR(wind_velocity2.x(), 9.091580, 1e-4);
+    ASSERT_NEAR(wind_velocity2.x(), 8.967558, 1e-4);
 
     // position 3
     auto position3 = Vector3d(-16.0, 2.0, 20.0);
     Vector3d wind_velocity3 = wind_velocity;
     seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity3, position3, tower_aero);
-    ASSERT_NEAR(wind_velocity3.x(), 9.163947, 1e-4);
+    ASSERT_NEAR(wind_velocity3.x(), 8.977193, 1e-4);
+
+    auto wind_velocity_xz = Vector3d(10.0, 0.0, 1.0);
+
+    // position 4
+    auto position4 = Vector3d(-16.0, 2.0, 20.0);
+    Vector3d wind_velocity4 = wind_velocity_xz;
+    seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity4, position4, tower_aero);
+    ASSERT_NEAR(wind_velocity4.x(), 9.163947, 1e-4);
+
+    // position 4
+    auto position5 = Vector3d(-16.0, -2.0, 20.0);
+    Vector3d wind_velocity5 = wind_velocity_xz;
+    seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity5, position5, tower_aero);
+    ASSERT_NEAR(wind_velocity5.x(), 9.163947, 1e-4);
+
+    // position 5 rotation
+    auto rot = AngleAxisd(PI / 36.0, Vector3d(0.0, 1.0, 0.0));
+    auto position5_rot = rot * position5;
+    for (auto& node : tower_aero.nodes) {
+        node.set_position(rot * node.get_position());
+    }
+    Vector3d wind_velocity5_rot = rot * wind_velocity_xz;
+    seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity5_rot, position5_rot, tower_aero);
+    ASSERT_NEAR((rot.inverse() * wind_velocity5_rot).x(), 9.163947, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch) {
@@ -366,7 +390,7 @@ TEST(test_turbine, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.695730, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.697633, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_fpm) {
@@ -425,7 +449,7 @@ TEST(test_turbine, rpm_initial_pitch_fpm) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.699299, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.701226, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
@@ -484,7 +508,7 @@ TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.797311, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.798212, 1e-4);
 }
 
 TEST(test_turbine, controller_target_rpm) {
@@ -697,7 +721,7 @@ TEST(test_aerodyn, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.718761, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.715747, 1e-4);
 }
 #endif
 
@@ -831,6 +855,6 @@ TEST(test_inflowwind, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.685642, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.687303, 1e-4);
 }
 #endif


### PR DESCRIPTION
As an indirect follow-up to #101, in this PR:
- Tower shadow updated with relative positions in case of a pitching/rolling tower (tower rotation added in test), and axis taken as vector from towerbase to towertop instead of towertop coordinate system
- Wind ramp reference length parameter removed (should not have been there, it was not possible to set it from .json config files)
- Simplification of standalone tower setup (e.g. for python bindings)
- Update AeroDyn config files to match settings of built-in BEMT