### PR TITLE
Tower shadow simplification and tests + drivetrain/shaft overhaul

### DIFF
--- a/include/seahowl/elasto/blade_elasto.h
+++ b/include/seahowl/elasto/blade_elasto.h
@@ -37,9 +37,14 @@ class BladeElasto : public virtual ComponentElasto {
     virtual void apply_pitch_increment(double pitch_increment) = 0;
 
     /**
-     * @brief Returns blade root moment (first node of first element of blade).
+     * @brief Returns blade root moment.
      */
     virtual Vector3d get_blade_root_moment() const = 0;
+
+    /**
+     * @brief Returns blade root force.
+     */
+    virtual Vector3d get_blade_root_force() const = 0;
 
     virtual EntityDynamicEigen get_entity_along_blade(double eta, int element_index = 0) const = 0;
 
@@ -89,6 +94,7 @@ class BladeElastoFEA : public BladeElasto, public ComponentElastoFEA {
 
     virtual void apply_pitch_increment(double pitch_increment) override;
     virtual Vector3d get_blade_root_moment() const override;
+    virtual Vector3d get_blade_root_force() const override;
     virtual EntityDynamicEigen get_entity_along_blade(double eta, int element_index = 0) const override;
     virtual void accumulate_load_along_blade(const Vector3d& load,
                                              const seahowl::Vector3d& moment,
@@ -116,13 +122,6 @@ class BladeElastoFEA : public BladeElasto, public ComponentElastoFEA {
  */
 class BladeElastoRigid : public BladeElasto {
   public:
-    /** @brief Body at the root of the blade. */
-    std::unique_ptr<BodyElastoChrono> body_root;
-    /** @brief Length of the blade. */
-    double length = 0.0;
-    /** @brief Mass of the blade. */
-    double mass = 0.0;
-
     /**
      * @brief Constructor.
      */
@@ -136,6 +135,7 @@ class BladeElastoRigid : public BladeElasto {
 
     virtual void apply_pitch_increment(double pitch_increment) override;
     virtual Vector3d get_blade_root_moment() const override;
+    virtual Vector3d get_blade_root_force() const override;
     virtual EntityDynamicEigen get_entity_along_blade(double eta, int element_index = 0) const override;
     virtual void reset_loads() override;
     virtual void accumulate_load_along_blade(const Vector3d& load,
@@ -144,6 +144,16 @@ class BladeElastoRigid : public BladeElasto {
                                              double eta,
                                              const Vector3d& offset) override;
     virtual void attach_root_to_body(const BodyElasto& body) override;
+
+  private:
+    /** @brief Length of the blade. */
+    double length = 0.0;
+    /** @brief Body at the root of the blade. */
+    std::unique_ptr<BodyElastoChrono> body_root;
+    /** @brief Body at the COG of the blade. */
+    std::unique_ptr<BodyElastoChrono> body_cog;
+    /** @brief Link between bodies at the root and COG of the blade. */
+    std::unique_ptr<Link> link_cog_root;
 };
 
 }  // namespace elasto

--- a/include/seahowl/elasto/rotor_elasto.h
+++ b/include/seahowl/elasto/rotor_elasto.h
@@ -56,6 +56,8 @@ struct ShaftProperties {
     double tilt = 0.0;
     /** @brief Distance of shaft axis from towertop. */
     double distance_from_towertop = 0.0;
+    /** @brief Inertia of the hub. */
+    double generator_inertia = 0.0;
 };
 
 class RotorElasto : public ComponentElasto {
@@ -95,6 +97,11 @@ class RotorElasto : public ComponentElasto {
     virtual double get_mass() const override;
 
     /**
+     * @brief Resets all loads.
+     */
+    void reset_loads();
+
+    /**
      * @brief Applies pitch increment to all blades (i.e. rotates blades around their respective longitudinal axis).
      *
      * This function links the towertop node to the yaw bearing rigid body by translating the RNA so that the tower
@@ -104,6 +111,13 @@ class RotorElasto : public ComponentElasto {
      * @param[in] pitch_increment Pitch increment to apply (in radians).
      */
     void apply_collective_pitch_increment(double pitch_increment);
+
+    /**
+     * @brief Accumulates torque on the hub.
+     *
+     * @param[in] torque Torque to accumulate on axial axis of hub.
+     */
+    void accumulate_axial_torque(double torque);
 };
 
 /**
@@ -120,6 +134,8 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
     std::unique_ptr<seahowl::elasto::RotorElasto> rotor;
     /** @brief Shaft rigid body. */
     std::unique_ptr<seahowl::elasto::BodyElasto> body_shaft;
+    /** @brief Bedplate rigid body (to fix shaft). */
+    std::unique_ptr<seahowl::elasto::BodyElasto> body_bedplate;
     /** @brief Nacelle rigid body. */
     std::unique_ptr<seahowl::elasto::BodyElasto> body_nacelle;
     /** @brief Yaw bearing rigid body. */
@@ -127,12 +143,14 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
 
     // links
     //
-    /** @brief Link between shaft and hub (revolute). */
+    /** @brief Link between shaft and hub (fixed). */
     std::unique_ptr<Link> link_shaft_hub;
-    /** @brief Link between shaft and nacelle (fixed). */
-    std::unique_ptr<Link> link_shaft_nacelle;
-    /** @brief Link between shaft and yaw bearing (fixed). */
-    std::unique_ptr<Link> link_shaft_yaw_bearing;
+    /** @brief Link between shaft and bedplate (revolute). */
+    std::unique_ptr<Link> link_shaft_bedplate;
+    /** @brief Link between bedplate and nacelle (fixed). */
+    std::unique_ptr<Link> link_bedplate_nacelle;
+    /** @brief Link between nacelle and yaw bearing (fixed). */
+    std::unique_ptr<Link> link_nacelle_yaw_bearing;
     /** @brief Link between towertop (if any) and yaw bearing (fixed). */
     std::unique_ptr<Link> link_towertop_yaw_bearing;
     ///@}
@@ -166,6 +184,16 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
     double get_mass() const override;                                   ///< @see ElastoComponent::get_mass
 
     /**
+     * @brief Resets all loads.
+     */
+    void reset_loads();
+
+    /**
+     * @brief Locks shaft if true, unlocks it if false.
+     */
+    void lock_shaft(bool locked);
+
+    /**
      * @brief Returns the RPM of the rotor.
      */
     double get_rpm() const;
@@ -186,11 +214,11 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
     double get_azimuth() const;
 
     /**
-     * @brief Accumulates torque on the rotor.
+     * @brief Accumulates electrical torque on the rotor.
      *
-     * @param[in] torque Torque to accumulate on axial axis of hub.
+     * @param[in] torque Torque to accumulate on axial axis of rotor.
      */
-    void accumulate_axial_torque(double torque);
+    void accumulate_electrical_torque(double torque);
 };
 
 }  // namespace elasto

--- a/include/seahowl/elasto/tower_elasto.h
+++ b/include/seahowl/elasto/tower_elasto.h
@@ -38,6 +38,21 @@ class TowerElasto : public ComponentElastoFEA {
      */
     Vector3d get_tower_base_moment() const;
 
+    /**
+     * @brief Returns tower base moment (second node of last element of tower).
+     */
+    Vector3d get_tower_top_moment() const;
+
+    /**
+     * @brief Returns tower base force (first node of first element of tower).
+     */
+    Vector3d get_tower_base_force() const;
+
+    /**
+     * @brief Returns tower base force (second node of last element of tower).
+     */
+    Vector3d get_tower_top_force() const;
+
   private:
     /**
      * @brief Builds the blade with Timoshenko elements (lineic density, foreaft stiffness, sideside stiffness).

--- a/src/aero/bemt.cpp
+++ b/src/aero/bemt.cpp
@@ -230,6 +230,7 @@ void seahowl::aero::apply_tower_shadow_effect_on_wind(Vector3d& wind_velocity,
     auto wind_velocity_tower = tower_rot.inverse() * (wind_velocity - tower_velocity);
     wind_velocity_tower[2] = 0.0;
     auto wind_axis_tower = wind_velocity_tower.normalized();
+    auto wind_normal_tower = Vector3d(0., 0., 1.).cross(wind_axis_tower);
 
     // get z positions along tower axis
     // rotate all positions around center of tower to get relative positions to tower center in IEC coordinate system
@@ -250,17 +251,23 @@ void seahowl::aero::apply_tower_shadow_effect_on_wind(Vector3d& wind_velocity,
         auto position_projected = towerbase_relative + z_rel * (towertop_relative - towerbase_relative);
         auto position_relative_projected = position_relative - position_projected;
         // front position of point from tower
-        auto x_rel = position_relative_projected.dot(wind_axis_tower);
-        auto xx = abs(x_rel);
+        auto xx = position_relative_projected.dot(wind_axis_tower);
         auto xx2 = pow(xx, 2);
         // side position of point from tower
-        auto y_rel = position_relative_projected.dot(Vector3d(1.0, 1.0, 1.0) - wind_axis_tower.cwiseAbs());
-        auto yy = abs(y_rel);
+        auto yy = position_relative_projected.dot(wind_normal_tower);
         auto yy2 = pow(yy, 2);
+        // factor for tower shadow calculations
+        auto factor = pow(tower_radius, 2) / pow(yy2 + xx2, 2);
+
+        // wind shadow tangential to wind direction
+        auto wind_shadow_x = factor * (yy2 - xx2) * wind_velocity_tower.norm();
+        // wind shadow normal to wind direction
+        auto wind_shadow_y = factor * (-2.0 * xx * yy) * wind_velocity_tower.norm();
+
+        // total tower shadow contributions
+        auto wind_shadow = wind_shadow_x * wind_axis_tower + wind_shadow_y * wind_normal_tower;
 
         // update wind velocity
-        wind_velocity =
-            wind_velocity + tower_rot * wind_velocity_tower.cwiseProduct(pow(tower_radius, 2) / pow(yy2 + xx2, 2) *
-                                                                         Vector3d((yy2 - xx2), (-2.0 * xx * yy), 0.0));
+        wind_velocity += tower_rot * wind_shadow;
     }
 }

--- a/src/aero/bemt.cpp
+++ b/src/aero/bemt.cpp
@@ -209,47 +209,25 @@ void seahowl::aero::apply_tower_shadow_effect_on_wind(Vector3d& wind_velocity,
     }
     tower_velocity /= (tower_aero.nodes.size());
 
-    // find rotation between global z-axis and tower z-axis (IEC coordinate system)
-    auto tower_rot = Quaternion(1.0, 0.0, 0.0, 0.0);
-    auto z_global = Vector3d(0.0, 0.0, 1.0);
-    auto z_dot = tower_axis.dot(z_global);
-    double tol = 1.0e-6;
-    if (z_dot < -(1.0 - tol)) {
-        // 180 degrees rotation
-        tower_rot = AngleAxisd(PI, Vector3d(1.0, 0.0, 0.0));
-    } else if (z_dot > 1.0 - tol) {
-        // no rotation
-        tower_rot = Quaternion(1.0, 0.0, 0.0, 0.0);
-    } else {
-        auto axis_tower_rot = z_global.cross(tower_axis).normalized();
-        auto angle_tower_rot = acos(z_dot);
-        tower_rot = AngleAxisd(angle_tower_rot, axis_tower_rot);
-    }
-
     // only take wind velocity perpendicular to tower axis
-    auto wind_velocity_tower = tower_rot.inverse() * (wind_velocity - tower_velocity);
-    wind_velocity_tower[2] = 0.0;
+    auto wind_velocity_tower =
+        (wind_velocity - tower_velocity) - ((wind_velocity - tower_velocity).dot(tower_axis)) * (tower_axis);
     auto wind_axis_tower = wind_velocity_tower.normalized();
-    auto wind_normal_tower = Vector3d(0., 0., 1.).cross(wind_axis_tower);
+    auto wind_normal_tower = tower_axis.cross(wind_axis_tower);
 
     // get z positions along tower axis
     // rotate all positions around center of tower to get relative positions to tower center in IEC coordinate system
-    auto rotation_center = 0.5 * (towerbase_position + towertop_position);
-    auto position_relative = tower_rot.inverse() * (position - rotation_center);
-    auto towerbase_relative = tower_rot.inverse() * (towerbase_position - rotation_center);
-    auto towertop_relative = tower_rot.inverse() * (towertop_position - rotation_center);
-    auto z_position = position_relative.z();
-    auto z_towerbase = towerbase_relative.z();
-    auto z_towertop = towertop_relative.z();
-    if (z_position > z_towerbase && z_position < z_towertop) {
+    auto z_position = (position - towerbase_position).dot(tower_axis);
+    auto z_towertop = (towertop_position - towerbase_position).dot(tower_axis);
+    if (z_position >= 0 && z_position <= z_towertop) {
         // get diameter at z position
-        auto z_rel = (z_position - z_towerbase) / (z_towertop - z_towerbase);
+        auto z_rel = z_position / z_towertop;
         std::vector<double> fractions{z_rel};
         auto tower_radius = seahowl::get_discretized_points(fractions, tower_aero.discretized_points)[0].diameter / 2.0;
 
         // find relative position
-        auto position_projected = towerbase_relative + z_rel * (towertop_relative - towerbase_relative);
-        auto position_relative_projected = position_relative - position_projected;
+        auto position_projected = towerbase_position + z_rel * (towertop_position - towerbase_position);
+        auto position_relative_projected = position - position_projected;
         // front position of point from tower
         auto xx = position_relative_projected.dot(wind_axis_tower);
         auto xx2 = pow(xx, 2);
@@ -268,6 +246,6 @@ void seahowl::aero::apply_tower_shadow_effect_on_wind(Vector3d& wind_velocity,
         auto wind_shadow = wind_shadow_x * wind_axis_tower + wind_shadow_y * wind_normal_tower;
 
         // update wind velocity
-        wind_velocity += tower_rot * wind_shadow;
+        wind_velocity += wind_shadow;
     }
 }

--- a/src/bindings/pyseahowl_elasto.cpp
+++ b/src/bindings/pyseahowl_elasto.cpp
@@ -157,6 +157,7 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def_readwrite("discretization_fractions", &seahowl::elasto::BladeElasto::discretization_fractions)
         .def("apply_pitch_increment", &seahowl::elasto::BladeElasto::apply_pitch_increment)
         .def("get_blade_root_moment", &seahowl::elasto::BladeElasto::get_blade_root_moment)
+        .def("get_blade_root_force", &seahowl::elasto::BladeElasto::get_blade_root_force)
         .def("get_entity_along_blade", &seahowl::elasto::BladeElasto::get_entity_along_blade)
         .def("accumulate_load_along_blade", &seahowl::elasto::BladeElasto::accumulate_load_along_blade)
         .def("attach_root_to_body", &seahowl::elasto::BladeElasto::attach_root_to_body);
@@ -167,11 +168,6 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def(py::init<>());
     py::class_<seahowl::elasto::BladeElastoRigid, std::shared_ptr<seahowl::elasto::BladeElastoRigid>,
                seahowl::elasto::BladeElasto>(m_elasto, "BladeElastoRigid")
-        .def_property_readonly(
-            "body_root", [](seahowl::elasto::BladeElastoRigid& blade) { return blade.body_root.get(); },
-            py::return_value_policy::reference_internal)
-        .def_readwrite("length", &seahowl::elasto::BladeElastoRigid::length)
-        .def_readwrite("mass", &seahowl::elasto::BladeElastoRigid::mass)
         .def(py::init<>());
 
     // elasto/rotor_elasto.h
@@ -227,8 +223,8 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("get_tower_base_moment", &seahowl::elasto::TowerElasto::get_tower_base_moment);
 
     // elasto/turbine_elasto.h
-    py::class_<seahowl::elasto::TurbineElasto, std::shared_ptr<seahowl::elasto::TurbineElasto>>(m_elasto,
-                                                                                                "TurbineElasto")
+    py::class_<seahowl::elasto::TurbineElasto, std::shared_ptr<seahowl::elasto::TurbineElasto>,
+               seahowl::elasto::ComponentElasto>(m_elasto, "TurbineElasto")
         .def_readonly("rna", &seahowl::elasto::TurbineElasto::rna)
         .def_readonly("tower", &seahowl::elasto::TurbineElasto::tower)
         .def(py::init<>());

--- a/src/bindings/pyseahowl_elasto.cpp
+++ b/src/bindings/pyseahowl_elasto.cpp
@@ -61,11 +61,19 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("set_rest_length", &seahowl::elasto::ElementMooringElasto::set_rest_length)
         .def("get_rest_length", &seahowl::elasto::ElementMooringElasto::get_rest_length);
     py::class_<seahowl::elasto::Link, std::shared_ptr<seahowl::elasto::Link>>(m_elasto, "Link")
+        .def("initialize", [](seahowl::elasto::Link& link, seahowl::elasto::BodyElasto& body,
+                              seahowl::elasto::BodyElasto& body2) { link.initialize(body, body2); })
+        .def("initialize", [](seahowl::elasto::Link& link, seahowl::elasto::BodyElasto& body,
+                              seahowl::elasto::NodeElasto& node) { link.initialize(body, node); })
+        .def("initialize", [](seahowl::elasto::Link& link, seahowl::elasto::NodeElasto& node,
+                              seahowl::elasto::BodyElasto& body) { link.initialize(node, body); })
         .def("set_constraints", &seahowl::elasto::Link::set_constraints)
         .def("get_reaction_force", &seahowl::elasto::Link::get_reaction_force)
         .def("get_reaction_torque", &seahowl::elasto::Link::get_reaction_torque);
     py::class_<seahowl::elasto::MeshElasto, std::shared_ptr<seahowl::elasto::MeshElasto>>(m_elasto, "MeshElasto");
     py::class_<seahowl::elasto::SystemElasto, std::shared_ptr<seahowl::elasto::SystemElasto>>(m_elasto, "SystemElasto")
+        .def("add", [](seahowl::elasto::SystemElasto& system, seahowl::elasto::BodyElasto& body) { system.add(body); })
+        .def("add", [](seahowl::elasto::SystemElasto& system, seahowl::elasto::Link& link) { system.add(link); })
         .def("step", &seahowl::elasto::SystemElasto::step)
         .def("get_time", &seahowl::elasto::SystemElasto::get_time)
         .def("set_gravitational_acceleration", &seahowl::elasto::SystemElasto::set_gravitational_acceleration)
@@ -191,6 +199,9 @@ void initialize_pyseahowl_elasto(py::module& m) {
             "body_shaft", [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.body_shaft.get(); },
             py::return_value_policy::reference_internal)
         .def_property_readonly(
+            "body_bedplate", [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.body_bedplate.get(); },
+            py::return_value_policy::reference_internal)
+        .def_property_readonly(
             "body_nacelle", [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.body_nacelle.get(); },
             py::return_value_policy::reference_internal)
         .def_property_readonly(
@@ -201,15 +212,19 @@ void initialize_pyseahowl_elasto(py::module& m) {
             "link_shaft_hub", [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_shaft_hub.get(); },
             py::return_value_policy::reference_internal)
         .def_property_readonly(
+            "link_shaft_bedplate",
+            [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_shaft_bedplate.get(); },
+            py::return_value_policy::reference_internal)
+        .def_property_readonly(
             "link_shaft_nacelle",
-            [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_shaft_nacelle.get(); },
+            [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_bedplate_nacelle.get(); },
             py::return_value_policy::reference_internal)
         .def_property_readonly(
-            "link_shaft_yaw_bearing",
-            [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_shaft_yaw_bearing.get(); },
+            "link_nacelle_yaw_bearing",
+            [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_nacelle_yaw_bearing.get(); },
             py::return_value_policy::reference_internal)
         .def_property_readonly(
-            "link_shaft_yaw_bearing",
+            "link_nacelle_yaw_bearing",
             [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_towertop_yaw_bearing.get(); },
             py::return_value_policy::reference_internal);
 

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -35,14 +35,17 @@ void Turbine::prestep(double time, double dt) {
 void Turbine::poststep(double time, double dt) {
     // hub loads
     // reset external loads applied on rotor hub
-    rna.elasto.rotor->body_hub->reset_loads();
-    // apply aero torque losses from gearbox efficiency for next step
-    auto aero_torque = rna.elasto.get_axial_torque();
-    if (controller->has_torque_control) {
-        // remove previously applied electrical torque from total rotor torque
-        aero_torque += controller->get_torque_elec() * gearbox_ratio * gearbox_efficiency;
+    rna.elasto.reset_loads();
+
+    if (gearbox_ratio != 1.0) {
+        // apply aero torque losses from gearbox efficiency for next step
+        auto aero_torque = rna.elasto.get_axial_torque();
+        if (controller->has_torque_control) {
+            // remove previously applied electrical torque from total rotor torque
+            aero_torque += controller->get_torque_elec() * gearbox_ratio * gearbox_efficiency;
+        }
+        rna.elasto.rotor->accumulate_axial_torque(-aero_torque * (1.0 - gearbox_efficiency));
     }
-    rna.elasto.accumulate_axial_torque(-aero_torque * (1.0 - gearbox_efficiency));
 
     // controller step
     controller->step(time, dt, *this);
@@ -50,7 +53,7 @@ void Turbine::poststep(double time, double dt) {
     if (controller->has_torque_control) {
         auto torque_elec = controller->get_torque_elec() * gearbox_ratio * gearbox_efficiency;
         // torque elec is applied on hub body (locally)
-        rna.elasto.accumulate_axial_torque(-torque_elec);
+        rna.elasto.accumulate_electrical_torque(-torque_elec);
     }
     // apply pitch from controller
     if (controller->has_pitch_control) {

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -156,6 +156,19 @@ seahowl::Vector3d BladeElastoFEA::get_blade_root_moment() const {
     return Vector3d(x2, y2, root_moment.z());
 }
 
+seahowl::Vector3d BladeElastoFEA::get_blade_root_force() const {
+    auto root_force = elements[0]->get_force(-1.0);
+    auto root_twist = reference_points[0].structural_twist;
+
+    // remove twist from blade root moment
+    auto x1 = root_force.x();
+    auto y1 = root_force.y();
+    auto x2 = cos(-root_twist) * x1 - sin(-root_twist) * y1;
+    auto y2 = sin(-root_twist) * x1 + cos(-root_twist) * y1;
+
+    return Vector3d(x2, y2, root_force.z());
+}
+
 seahowl::EntityDynamicEigen BladeElastoFEA::get_entity_along_blade(double eta, int element_index) const {
     return get_entity_along_component(eta, element_index);
 }
@@ -177,11 +190,13 @@ BladeElastoRigid::BladeElastoRigid() {}
 
 void BladeElastoRigid::build() {
     body_root = std::make_unique<BodyElastoChrono>();
+    body_cog = std::make_unique<BodyElastoChrono>();
     length = reference_points.back().coordinates.z();
 
     // calculate mass
     double mass_total = 0.0;
     double inertia_total = 0.0;
+    double z_pos = 0.0;
     for (int ii = 0; ii < reference_points.size() - 1; ii++) {
         auto& point1 = reference_points[ii];
         auto& point2 = reference_points[ii + 1];
@@ -192,23 +207,37 @@ void BladeElastoRigid::build() {
         auto length_segment = abs(l2 - l1);
 
         // mass of blade segment
-        mass_total += 0.5 * (rho1 + rho2) * length_segment;
+        auto mass_segment = 0.5 * (rho1 + rho2) * length_segment;
+        mass_total += mass_segment;
+        z_pos += 0.5 * (l1 + l2) * mass_segment;
 
         // inertia assuming rod element with non-uniform linear density
         inertia_total += ((pow(l2, 4) - pow(l1, 4)) / 4.0 * (rho2 - rho1) +
                           (pow(l2, 3) - pow(l1, 3)) / 3.0 * (rho1 * l2 - rho2 * l1)) /
                          length_segment;
     };
+    z_pos /= mass_total;
 
     // set mass and inertia at root
-    body_root->set_mass(mass_total);
+    body_cog->set_position(Vector3d(0., 0., z_pos));
+    body_cog->set_mass(mass_total);
+    body_cog->set_inertia_diagonal(Vector3d(0., 0., 0.));
     // inertia of blade calculated from body root for rotation along local x and y
+    body_root->set_position(Vector3d(0., 0., 0.));
+    body_root->set_mass(0.);
     body_root->set_inertia_diagonal(Vector3d(inertia_total, inertia_total, 0.0));
+
+    // link root and cog
+    link_cog_root = std::make_unique<LinkChrono>();
+    link_cog_root->set_constraints(true, true, true, true, true, true);
+    link_cog_root->initialize(*body_cog, *body_root);
 }
 
 void BladeElastoRigid::assemble(SystemElasto& system) {
     BladeElasto::assemble(system);
     system.add(*(body_root.get()));
+    system.add(*(body_cog.get()));
+    system.add(*(link_cog_root.get()));
 }
 
 void BladeElastoRigid::rotate(double angle, const Vector3d& axis) const {
@@ -218,15 +247,21 @@ void BladeElastoRigid::rotate(double angle, const Vector3d& axis) const {
     auto new_rotation_root = (rotation * body_root->get_rotation()).normalized();
     body_root->set_position(new_position_root);
     body_root->set_rotation(new_rotation_root);
+    // blade cog
+    auto new_position_cog = rotation * body_cog->get_position();
+    auto new_rotation_cog = (rotation * body_cog->get_rotation()).normalized();
+    body_cog->set_position(new_position_cog);
+    body_cog->set_rotation(new_rotation_cog);
 }
 
 void BladeElastoRigid::translate(const Vector3d& translation_vector) const {
     // blade root
     body_root->set_position(body_root->get_position() + translation_vector);
+    body_cog->set_position(body_cog->get_position() + translation_vector);
 }
 
 double BladeElastoRigid::get_mass() const {
-    return body_root->get_mass();
+    return body_cog->get_mass() + body_root->get_mass();
 }
 
 void BladeElastoRigid::apply_pitch_increment(double pitch_increment) {
@@ -240,7 +275,11 @@ void BladeElastoRigid::apply_pitch_increment(double pitch_increment) {
 }
 
 seahowl::Vector3d BladeElastoRigid::get_blade_root_moment() const {
-    return body_root->get_torque();
+    return link_cog_root->get_reaction_torque() + body_root->get_torque();
+}
+
+seahowl::Vector3d BladeElastoRigid::get_blade_root_force() const {
+    return link_cog_root->get_reaction_force() + body_root->get_force();
 }
 
 seahowl::EntityDynamicEigen BladeElastoRigid::get_entity_along_blade(double eta, int element_index) const {
@@ -282,6 +321,7 @@ seahowl::EntityDynamicEigen BladeElastoRigid::get_entity_along_blade(double eta,
 
 void BladeElastoRigid::reset_loads() {
     body_root->reset_loads();
+    body_cog->reset_loads();
 }
 
 void BladeElastoRigid::accumulate_load_along_blade(const seahowl::Vector3d& load,

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -144,7 +144,16 @@ void BladeElastoFEA::apply_pitch_increment(double pitch_increment) {
 }
 
 seahowl::Vector3d BladeElastoFEA::get_blade_root_moment() const {
-    return elements[0]->get_torque(-1.0);
+    auto root_moment = elements[0]->get_torque(-1.0);
+    auto root_twist = reference_points[0].structural_twist;
+
+    // remove twist from blade root moment
+    auto x1 = root_moment.x();
+    auto y1 = root_moment.y();
+    auto x2 = cos(-root_twist) * x1 - sin(-root_twist) * y1;
+    auto y2 = sin(-root_twist) * x1 + cos(-root_twist) * y1;
+
+    return Vector3d(x2, y2, root_moment.z());
 }
 
 seahowl::EntityDynamicEigen BladeElastoFEA::get_entity_along_blade(double eta, int element_index) const {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -752,7 +752,7 @@ void SystemElastoChrono::do_statics(bool linear, int nonlinear_steps) {
     std::vector<bool> tower_fixed;
     for (auto& turbine : turbines) {
         // rotor
-        turbine->rna.link_shaft_hub->set_constraints(true, true, true, true, true, true);
+        turbine->rna.lock_shaft(true);
         // tower
         tower_fixed.push_back(turbine->tower.nodes.front()->is_fixed());
         turbine->tower.nodes.front()->set_fixed(true);
@@ -771,7 +771,7 @@ void SystemElastoChrono::do_statics(bool linear, int nonlinear_steps) {
     int idx_turbine = 0;
     for (auto& turbine : turbines) {
         // rotor
-        turbine->rna.link_shaft_hub->set_constraints(true, true, true, false, true, true);
+        turbine->rna.lock_shaft(false);
         // tower
         turbine->tower.nodes.front()->set_fixed(tower_fixed[idx_turbine]);
     }

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -50,9 +50,6 @@ void RotorElasto::build() {
         // rotate blade around hub
         blade->rotate(azimuth0,
                       Vector3d(1.0, 0.0, 0.0));  // X is the axis pointing towards nacelle for blade (IEC standard)
-
-        // link root node of blade to rotor center
-        blade->attach_root_to_body(*body_hub);
     }
 
     // apply initial pitch of blades
@@ -64,6 +61,9 @@ void RotorElasto::build() {
         blade->apply_pitch_increment(total_blade_pitch);
         // register new pitch value
         blade->pitch = total_blade_pitch;
+
+        // link root node of blade to rotor center
+        blade->attach_root_to_body(*body_hub);
     }
 }
 

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -8,7 +8,9 @@ using seahowl::elasto::BladeElasto;
 using seahowl::elasto::RotorElasto;
 using seahowl::elasto::RotorNacelleAssemblyElasto;
 
-RotorElasto::RotorElasto() {}
+RotorElasto::RotorElasto() {
+    body_hub = std::make_unique<BodyElastoChrono>();
+}
 
 void RotorElasto::assemble(SystemElasto& system) {
     for (auto& blade : blades) {
@@ -26,7 +28,6 @@ void RotorElasto::build() {
     auto rotation0 = Quaternion(1.0, 0.0, 0.0, 0.0);
 
     // hub
-    body_hub = std::make_unique<BodyElastoChrono>();
     // mass and inertia
     body_hub->set_mass(hub.mass);
     body_hub->set_inertia_diagonal(Vector3d(hub.inertia, 0., 0.));
@@ -76,6 +77,11 @@ void RotorElasto::apply_collective_pitch_increment(double pitch_increment) {
     }
     pitch_collective += pitch_increment;
 }
+
+void RotorElasto::accumulate_axial_torque(double torque) {
+    body_hub->accumulate_torque(Vector3d(torque, 0.0, 0.0), true);
+}
+
 void RotorElasto::rotate(double angle, const Vector3d& axis) const {
     // blades
     for (auto& blade : blades) {
@@ -108,18 +114,41 @@ double RotorElasto::get_mass() const {
     return total_mass;
 }
 
+void RotorElasto::reset_loads() {
+    body_hub->reset_loads();
+}
+
 RotorNacelleAssemblyElasto::RotorNacelleAssemblyElasto() {
+    // rotor
     rotor = std::make_unique<RotorElasto>();
+
+    // shaft
+    body_shaft = std::make_unique<BodyElastoChrono>();
+    link_shaft_hub = std::make_unique<LinkChrono>();
+
+    // bedplate
+    body_bedplate = std::make_unique<BodyElastoChrono>();
+    link_shaft_bedplate = std::make_unique<LinkChrono>();
+
+    // nacelle
+    body_nacelle = std::make_unique<BodyElastoChrono>();
+    link_bedplate_nacelle = std::make_unique<LinkChrono>();
+
+    // yaw bearing
+    body_yaw_bearing = std::make_unique<BodyElastoChrono>();
+    link_nacelle_yaw_bearing = std::make_unique<LinkChrono>();
 }
 
 void RotorNacelleAssemblyElasto::assemble(SystemElasto& system) {
     rotor->assemble(system);
     system.add(*(body_shaft.get()));
+    system.add(*(body_bedplate.get()));
+    system.add(*(link_shaft_bedplate.get()));
     system.add(*(link_shaft_hub.get()));
     system.add(*(body_nacelle.get()));
-    system.add(*(link_shaft_nacelle.get()));
+    system.add(*(link_bedplate_nacelle.get()));
     system.add(*(body_yaw_bearing.get()));
-    system.add(*(link_shaft_yaw_bearing.get()));
+    system.add(*(link_nacelle_yaw_bearing.get()));
 }
 
 void RotorNacelleAssemblyElasto::build() {
@@ -134,20 +163,29 @@ void RotorNacelleAssemblyElasto::build() {
     auto rotation0 = Quaternion(1.0, 0.0, 0.0, 0.0);
 
     // shaft
-    body_shaft = std::make_unique<BodyElastoChrono>();
     // move end of shaft at yaw axis of nacelle
     body_shaft->set_position(Vector3d(0.0, 0.0, shaft.distance_from_towertop));
     // align rotation
     body_shaft->set_rotation(rotor->body_hub->get_rotation());
     // massless body
     body_shaft->set_mass(0.0);
+    body_shaft->set_inertia_diagonal(Vector3d(shaft.generator_inertia, 0.0, 0.0));
     // link hub to shaft
-    link_shaft_hub = std::make_unique<LinkChrono>();
     link_shaft_hub->initialize(*(rotor->body_hub.get()), *(body_shaft.get()));
-    link_shaft_hub->set_constraints(true, true, true, false, true, true);
+    link_shaft_hub->set_constraints(true, true, true, true, true, true);
+
+    // bedplate
+    // move bedplate at yaw axis of nacelle
+    body_bedplate->set_position(Vector3d(0.0, 0.0, shaft.distance_from_towertop));
+    // align rotation
+    body_bedplate->set_rotation(rotor->body_hub->get_rotation());
+    // massless body
+    body_bedplate->set_mass(0.0);
+    // link shaft to bedplate
+    link_shaft_bedplate->initialize(*(body_shaft.get()), *(body_bedplate.get()));
+    link_shaft_bedplate->set_constraints(true, true, true, false, true, true);
 
     // nacelle
-    body_nacelle = std::make_unique<BodyElastoChrono>();
     body_nacelle->set_position(nacelle.center_of_mass);
     body_nacelle->set_rotation(rotation0);
     // mass and inertia
@@ -155,19 +193,16 @@ void RotorNacelleAssemblyElasto::build() {
     ///@todo  change to full 3x3 inertia matrix
     body_nacelle->set_inertia_diagonal(Vector3d(0.0, 0.0, nacelle.inertia));
     // link nacelle body to shaft body
-    link_shaft_nacelle = std::make_unique<LinkChrono>();
-    link_shaft_nacelle->initialize(*(body_nacelle.get()), *(body_shaft.get()));
-    link_shaft_nacelle->set_constraints(true, true, true, true, true, true);
+    link_bedplate_nacelle->initialize(*(body_bedplate.get()), *(body_nacelle.get()));
+    link_bedplate_nacelle->set_constraints(true, true, true, true, true, true);
 
     // yaw bearing
-    body_yaw_bearing = std::make_unique<BodyElastoChrono>();
     body_yaw_bearing->set_position(Vector3d(0.0, 0.0, 0.0));
     body_yaw_bearing->set_rotation(rotation0);
     body_yaw_bearing->set_mass(nacelle.yaw_bearing_mass);
     // link yaw bearing body to shaft body
-    link_shaft_yaw_bearing = std::make_unique<LinkChrono>();
-    link_shaft_yaw_bearing->initialize(*(body_shaft.get()), *(body_yaw_bearing.get()));
-    link_shaft_yaw_bearing->set_constraints(true, true, true, true, true, true);
+    link_nacelle_yaw_bearing->initialize(*(body_bedplate.get()), *(body_yaw_bearing.get()));
+    link_nacelle_yaw_bearing->set_constraints(true, true, true, true, true, true);
 }
 
 void RotorNacelleAssemblyElasto::rotate(double angle, const Vector3d& axis) const {
@@ -179,6 +214,11 @@ void RotorNacelleAssemblyElasto::rotate(double angle, const Vector3d& axis) cons
     auto new_rotation_shaft = (rotation * body_shaft->get_rotation()).normalized();
     body_shaft->set_position(new_position_shaft);
     body_shaft->set_rotation(new_rotation_shaft);
+    // bedplate
+    auto new_position_bedplate = rotation * body_bedplate->get_position();
+    auto new_rotation_bedplate = (rotation * body_bedplate->get_rotation()).normalized();
+    body_bedplate->set_position(new_position_bedplate);
+    body_bedplate->set_rotation(new_rotation_bedplate);
     // nacelle
     auto new_position_nacelle = rotation * body_nacelle->get_position();
     auto new_rotation_nacelle = (rotation * body_nacelle->get_rotation()).normalized();
@@ -196,6 +236,8 @@ void RotorNacelleAssemblyElasto::translate(const Vector3d& translation_vector) c
     rotor->translate(translation_vector);
     // shaft
     body_shaft->set_position(body_shaft->get_position() + translation_vector);
+    // bedplate
+    body_bedplate->set_position(body_bedplate->get_position() + translation_vector);
     // nacelle
     body_nacelle->set_position(body_nacelle->get_position() + translation_vector);
     // yaw_bearing
@@ -208,6 +250,8 @@ double RotorNacelleAssemblyElasto::get_mass() const {
     total_mass += rotor->get_mass();
     // shaft
     total_mass += body_shaft->get_mass();
+    // bedplate
+    total_mass += body_bedplate->get_mass();
     // nacelle
     total_mass += body_nacelle->get_mass();
     // yaw_bearing
@@ -215,10 +259,26 @@ double RotorNacelleAssemblyElasto::get_mass() const {
     return total_mass;
 }
 
+void RotorNacelleAssemblyElasto::reset_loads() {
+    rotor->reset_loads();
+    body_shaft->reset_loads();
+    body_bedplate->reset_loads();
+    body_nacelle->reset_loads();
+    body_yaw_bearing->reset_loads();
+}
+
+void RotorNacelleAssemblyElasto::lock_shaft(bool locked) {
+    if (locked) {
+        link_shaft_bedplate->set_constraints(true, true, true, true, true, true);
+    } else {
+        link_shaft_bedplate->set_constraints(true, true, true, false, true, true);
+    }
+}
+
 double RotorNacelleAssemblyElasto::get_rpm() const {
     // relative rotational velocity between hub and shaft (in local reference frame of the hub)
     auto rotational_velocity =
-        (rotor->body_hub->get_rotational_velocity(true) - body_shaft->get_rotational_velocity(true));
+        (body_shaft->get_rotational_velocity(true) - body_bedplate->get_rotational_velocity(true));
     // convert to rpm
     auto rpm = rotational_velocity.x() * 60 / (2 * PI);
     return rpm;
@@ -226,7 +286,7 @@ double RotorNacelleAssemblyElasto::get_rpm() const {
 
 double RotorNacelleAssemblyElasto::get_azimuth() const {
     // get angle between quaternions
-    auto qq = (body_shaft->get_rotation().conjugate() * rotor->body_hub->get_rotation()).normalized();
+    auto qq = (body_bedplate->get_rotation().conjugate() * body_shaft->get_rotation()).normalized();
     double angle0 = 2 * std::atan2(qq.vec().x(), qq.w());
     // get angle between 0 and 2pi
     double angle1 = fmod(angle0, 2 * PI);
@@ -250,6 +310,7 @@ double RotorNacelleAssemblyElasto::get_axial_torque() const {
     return react_torque.x();
 }
 
-void RotorNacelleAssemblyElasto::accumulate_axial_torque(double torque) {
-    rotor->body_hub->accumulate_torque(Vector3d(torque, 0.0, 0.0), true);
+void RotorNacelleAssemblyElasto::accumulate_electrical_torque(double torque) {
+    body_shaft->accumulate_torque(Vector3d(torque, 0.0, 0.0), true);
+    body_bedplate->accumulate_torque(Vector3d(-torque, 0.0, 0.0), true);
 }

--- a/src/elasto/tower_elasto.cpp
+++ b/src/elasto/tower_elasto.cpp
@@ -73,5 +73,17 @@ void TowerElasto::build_elements_tapered_timoshenko() {
 }
 
 seahowl::Vector3d TowerElasto::get_tower_base_moment() const {
-    return elements[0]->get_torque(-1.0);
+    return elements.front()->get_torque(-1.0);
+}
+
+seahowl::Vector3d TowerElasto::get_tower_top_moment() const {
+    return elements.back()->get_torque(1.0);
+}
+
+seahowl::Vector3d TowerElasto::get_tower_base_force() const {
+    return elements.front()->get_force(-1.0);
+}
+
+seahowl::Vector3d TowerElasto::get_tower_top_force() const {
+    return elements.back()->get_force(1.0);
 }

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -360,6 +360,9 @@ void populate_rna_elasto_from_json(const std::string& filepath, seahowl::elasto:
     shaft.at("tilt").get_to(rna.shaft.tilt);
     // convert to radians
     rna.shaft.tilt *= PI / 180.0;
+    // drivetrain
+    auto drivetrain = json_obj.at("drivetrain");
+    drivetrain.at("generator_inertia").get_to(rna.shaft.generator_inertia);
 }
 
 void populate_rna_aero_from_json(const std::string& filepath, seahowl::aero::RotorNacelleAssemblyAero& rna) {
@@ -614,10 +617,6 @@ void populate_turbine_from_json(const std::string& filepath,
     // generator
     drivetrain.at("generator_efficiency").get_to(turbine.generator_efficiency);
     turbine.generator_efficiency /= 100.0;
-    // add inertia of generator to hub directly
-    double drivetrain_inertia;
-    drivetrain.at("generator_inertia").get_to(drivetrain_inertia);
-    turbine.rna.elasto.rotor->hub.inertia += drivetrain_inertia;
 
     if (json_obj.contains("floater")) {
         try {

--- a/src/io/write_csv.cpp
+++ b/src/io/write_csv.cpp
@@ -29,7 +29,9 @@ void write_turbine_info_to_csv(std::string fileprefix, const seahowl::core::Syst
             myfile.open(filename);
             myfile << "time (s),wind x (m/s),wind y (m/s),wind z (m/s),rpm,power (W),pitch (rad),torque elec "
                       "(Nm),axial thrust (N),axial torque (Nm),rotor azimuth (rad),tower base moment x (Nm),tower base "
-                      "moment y (Nm),tower base moment z (Nm),";
+                      "moment y (Nm),tower base moment z (Nm),tower base force x (N),tower base force y (N),tower "
+                      "base force z (N),tower top moment x (Nm),tower top moment y (Nm),tower top moment z (Nm),"
+                      "tower top force x (N),tower top force y (N),tower top force z (N),";
             for (int idx_blade = 1; idx_blade < turbine.rna.blades.size() + 1; idx_blade++) {
                 myfile << "blade" + std::to_string(idx_blade) + " wind x (m/s),";
                 myfile << "blade" + std::to_string(idx_blade) + " wind y (m/s),";
@@ -76,6 +78,27 @@ void write_turbine_info_to_csv(std::string fileprefix, const seahowl::core::Syst
         myfile << std::to_string(tower_base_moment.y());
         myfile << ",";
         myfile << std::to_string(tower_base_moment.z());
+        myfile << ",";
+        auto tower_base_force = turbine.tower.elasto.get_tower_base_force();
+        myfile << std::to_string(tower_base_force.x());
+        myfile << ",";
+        myfile << std::to_string(tower_base_force.y());
+        myfile << ",";
+        myfile << std::to_string(tower_base_force.z());
+        myfile << ",";
+        auto tower_top_moment = turbine.tower.elasto.get_tower_top_moment();
+        myfile << std::to_string(tower_top_moment.x());
+        myfile << ",";
+        myfile << std::to_string(tower_top_moment.y());
+        myfile << ",";
+        myfile << std::to_string(tower_top_moment.z());
+        myfile << ",";
+        auto tower_top_force = turbine.tower.elasto.get_tower_top_force();
+        myfile << std::to_string(tower_top_force.x());
+        myfile << ",";
+        myfile << std::to_string(tower_top_force.y());
+        myfile << ",";
+        myfile << std::to_string(tower_top_force.z());
         myfile << ",";
         for (int ii = 0; ii < turbine.rna.blades.size(); ii++) {
             auto& blade = turbine.rna.blades[ii];

--- a/src/servo/controller.cpp
+++ b/src/servo/controller.cpp
@@ -48,7 +48,6 @@ void ControllerVariableTorque::step(double time, double dt, const seahowl::core:
         // @todo Line below is specific to actuator disk (otherwise torque_aero is zero), need to move it
         // inside turbine.rna.elasto.get_axial_torque()
         torque_aero += turbine.rna.aero.rotor->hub_torque_aero;
-
         torque_elec = torque_aero * std::pow(rpm / target_rpm, 2);
         // torque_elec must be the torque at the generator --> scaled by gearbox ratio and efficiency
         torque_elec *= turbine.gearbox_efficiency / turbine.gearbox_ratio;

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -390,9 +390,9 @@ TEST(test_turbine, rpm_initial_pitch) {
 
     // statics
     if (statics_prestep) {
-        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
+        turbine.rna.elasto.lock_shaft(true);
         system_elasto.do_statics(true, 10);
-        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
+        turbine.rna.elasto.lock_shaft(false);
     }
 
     double time = 0.0;
@@ -449,9 +449,9 @@ TEST(test_turbine, rpm_initial_pitch_fpm) {
 
     // statics
     if (statics_prestep) {
-        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
+        turbine.rna.elasto.lock_shaft(true);
         system_elasto.do_statics(true, 10);
-        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
+        turbine.rna.elasto.lock_shaft(false);
     }
 
     double time = 0.0;
@@ -508,9 +508,9 @@ TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
 
     // statics
     if (statics_prestep) {
-        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
+        turbine.rna.elasto.lock_shaft(true);
         system_elasto.do_statics(true, 10);
-        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
+        turbine.rna.elasto.lock_shaft(false);
     }
 
     double time = 0.0;
@@ -541,7 +541,7 @@ TEST(test_turbine, controller_target_rpm) {
     // solver
     auto verbose = false;
     // timestepping
-    double dt = 0.1;
+    double dt = 0.05;
     // wind
     auto wind_model = seahowl::env::ConstantWind();
     wind_model.set_wind_velocity(Vector3d(8.0, 0.0, 0.0));
@@ -570,16 +570,16 @@ TEST(test_turbine, controller_target_rpm) {
 
     // statics
     if (statics_prestep) {
-        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
+        turbine.rna.elasto.lock_shaft(true);
         system_elasto.do_statics(true, 10);
-        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
+        turbine.rna.elasto.lock_shaft(false);
     }
 
     double time = 0.0;
     turbine.rna.elasto.rotor->apply_collective_pitch_increment(initial_pitch);
     turbine.initialize(time, dt);
     // while (application.GetDevice()->run()) {
-    while (time < 200) {
+    while (time < 100) {
         // prestep
         // compute forces
         turbine.aero.compute_aero_loads(wind_model, time);
@@ -634,9 +634,9 @@ TEST(test_turbine, actuator_disk) {
 
     // statics
     if (statics_prestep) {
-        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
+        turbine.rna.elasto.lock_shaft(true);
         system_elasto.do_statics(true, 10);
-        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
+        turbine.rna.elasto.lock_shaft(false);
     }
 
     double time = 0.0;
@@ -721,9 +721,9 @@ TEST(test_aerodyn, rpm_initial_pitch) {
 
     // statics
     if (statics_prestep) {
-        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
+        turbine.rna.elasto.lock_shaft(true);
         system_elasto.do_statics(true, 10);
-        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
+        turbine.rna.elasto.lock_shaft(false);
     }
 
     double time = 0.0;
@@ -855,9 +855,9 @@ TEST(test_inflowwind, rpm_initial_pitch) {
 
     // statics
     if (statics_prestep) {
-        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, true, true, true);
+        turbine.rna.elasto.lock_shaft(true);
         system_elasto.do_statics(true, 10);
-        turbine.rna.elasto.link_shaft_hub->set_constraints(true, true, true, false, true, true);
+        turbine.rna.elasto.lock_shaft(false);
     }
 
     double time = 0.0;

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -268,7 +268,7 @@ TEST(test_blade, flapwise) {
     ASSERT_NEAR(natural_period_ref, natural_period, 0.01);
 }
 
-TEST(test_tower, tower_shadow_check) {
+TEST(test_bemt, tower_shadow_check) {
     // system
     auto system_elasto = SystemElastoChrono();
     system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
@@ -295,35 +295,55 @@ TEST(test_tower, tower_shadow_check) {
     auto position1 = Vector3d(-14.0, -5.0, 50.0);
     Vector3d wind_velocity1 = wind_velocity;
     seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity1, position1, tower_aero);
-    ASSERT_NEAR(wind_velocity1.x(), 9.258011, 1e-4);
+    ASSERT_NEAR(wind_velocity1.x(), 9.100318, 1e-4);
+    ASSERT_NEAR(wind_velocity1.y(), 2.625343, 1e-4);
+    ASSERT_NEAR(wind_velocity1.z(), 1.0, 1e-4);
 
     // position 2
     auto position2 = Vector3d(-15.0, 0.0, 45.0);
     Vector3d wind_velocity2 = wind_velocity;
     seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity2, position2, tower_aero);
-    ASSERT_NEAR(wind_velocity2.x(), 8.967558, 1e-4);
+    ASSERT_NEAR(wind_velocity2.x(), 9.047282, 1e-4);
+    ASSERT_NEAR(wind_velocity2.y(), 3.285815, 1e-4);
+    ASSERT_NEAR(wind_velocity2.z(), 1.0, 1e-4);
 
     // position 3
     auto position3 = Vector3d(-16.0, 2.0, 20.0);
     Vector3d wind_velocity3 = wind_velocity;
     seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity3, position3, tower_aero);
-    ASSERT_NEAR(wind_velocity3.x(), 8.977193, 1e-4);
+    ASSERT_NEAR(wind_velocity3.x(), 9.227646, 1e-4);
+    ASSERT_NEAR(wind_velocity3.y(), 3.463146, 1e-4);
+    ASSERT_NEAR(wind_velocity3.z(), 1.0, 1e-4);
 
     auto wind_velocity_xz = Vector3d(10.0, 0.0, 1.0);
 
     // position 4
-    auto position4 = Vector3d(-16.0, 2.0, 20.0);
+    auto position4 = Vector3d(-6.0, 2.0, 20.0);
     Vector3d wind_velocity4 = wind_velocity_xz;
     seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity4, position4, tower_aero);
-    ASSERT_NEAR(wind_velocity4.x(), 9.163947, 1e-4);
+    ASSERT_NEAR(wind_velocity4.x(), 5.514508, 1e-4);
+    ASSERT_NEAR(wind_velocity4.y(), 3.364119, 1e-4);
+    ASSERT_NEAR(wind_velocity4.z(), 1.0, 1e-4);
 
-    // position 4
+    // position 5
     auto position5 = Vector3d(-16.0, -2.0, 20.0);
     Vector3d wind_velocity5 = wind_velocity_xz;
     seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity5, position5, tower_aero);
     ASSERT_NEAR(wind_velocity5.x(), 9.163947, 1e-4);
+    ASSERT_NEAR(wind_velocity5.y(), -0.212330, 1e-4);
+    ASSERT_NEAR(wind_velocity5.z(), 1.0, 1e-4);
 
-    // position 5 rotation
+    // position 5 wind rotation
+    auto rot2 = AngleAxisd(PI / 36.0, Vector3d(0.0, 0.0, 1.0));
+    auto position5_rot2 = rot2 * position5;
+    Vector3d wind_velocity5_rot2 = rot2 * wind_velocity_xz;
+    seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity5_rot2, position5_rot2, tower_aero);
+    auto rot2_wind = rot2.inverse() * wind_velocity5_rot2;
+    ASSERT_NEAR(rot2_wind.x(), 9.163947, 1e-4);
+    ASSERT_NEAR(rot2_wind.y(), -0.212330, 1e-4);
+    ASSERT_NEAR(rot2_wind.z(), 1.0, 1e-4);
+
+    // position 5 tower and wind rotation
     auto rot = AngleAxisd(PI / 36.0, Vector3d(0.0, 1.0, 0.0));
     auto position5_rot = rot * position5;
     for (auto& node : tower_aero.nodes) {
@@ -331,7 +351,10 @@ TEST(test_tower, tower_shadow_check) {
     }
     Vector3d wind_velocity5_rot = rot * wind_velocity_xz;
     seahowl::aero::apply_tower_shadow_effect_on_wind(wind_velocity5_rot, position5_rot, tower_aero);
-    ASSERT_NEAR((rot.inverse() * wind_velocity5_rot).x(), 9.163947, 1e-4);
+    auto rot_wind = rot.inverse() * wind_velocity5_rot;
+    ASSERT_NEAR(rot_wind.x(), 9.163947, 1e-4);
+    ASSERT_NEAR(rot_wind.y(), -0.212330, 1e-4);
+    ASSERT_NEAR(rot_wind.z(), 1.0, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch) {
@@ -390,7 +413,7 @@ TEST(test_turbine, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.697633, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.696608, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_fpm) {
@@ -449,7 +472,7 @@ TEST(test_turbine, rpm_initial_pitch_fpm) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.701226, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.700212, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
@@ -508,7 +531,7 @@ TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.798212, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.798572, 1e-4);
 }
 
 TEST(test_turbine, controller_target_rpm) {
@@ -855,6 +878,6 @@ TEST(test_inflowwind, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.687303, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.686469, 1e-4);
 }
 #endif

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -531,7 +531,7 @@ TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.798572, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.728150, 1e-4);
 }
 
 TEST(test_turbine, controller_target_rpm) {
@@ -816,7 +816,7 @@ TEST(test_turbine, multiturbines) {
     }
 
     for (auto& turbine : system_core.turbines) {
-        ASSERT_NEAR(turbine->rna.elasto.get_rpm(), 2.791585, 0.02);
+        ASSERT_NEAR(turbine->rna.elasto.get_rpm(), 2.728150, 0.02);
     }
 }
 


### PR DESCRIPTION
Following #103, in this PR:
- Simplified tower shadow calculations (vector operations instead of rotations)
- Added more tests for tower shadow
- Fixed issue when wind vector outside of global x-z plane
- Remove twist at root when retrieving blade root moment

Additional modifications:
- Introduce bedplate body with revolute joint between bedplate and shaft (fixed joint between hub and shaft)
- Electrical torque applied to shaft, reaction torque applied to bedplate
- Additional outputs in csv
- Initialize hub to blade root link after applying initial pitch (needed otherwise static step removes initial pitch)

Below is the comparison between built-in BEMT and AeroDyn for asteady inflow of 12m/s shear 0.12 reaching the rotor disk at angles of 0 degree and 20 degrees. The blade flapwise moment and towerbase fore-aft moment as a function of rotor azimuth for a full rotation (long after transient part of simulation) shows good agreement:

![blade_flapwise_moment](https://github.com/Total-RD/seahowl/assets/12599696/94e99189-f57e-42e2-b736-ebe41c9ca65a)
![towerbase_moment](https://github.com/Total-RD/seahowl/assets/12599696/f2fbf1c5-81e7-4aac-b504-8bcafb2e5861)
 at 0 degree and 20 degrees