### PR TITLE
Updates for simplifying driver and Hardware in the Loop (HIL) interfacing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ set(SEAHOWL_CORE_SOURCES
     src/core/turbine.cpp
     src/core/turbine_floating.cpp
     src/core/system.cpp
+    src/core/simulation.cpp
 )
 set(SEAHOWL_CORE_HEADERS
     include/seahowl/core/reference_point.h
@@ -175,6 +176,7 @@ set(SEAHOWL_CORE_HEADERS
     include/seahowl/core/turbine.h
     include/seahowl/core/turbine_floating.h
     include/seahowl/core/system.h
+    include/seahowl/core/simulation.h
 )
 source_group(core FILES ${SEAHOWL_CORE_SOURCES} ${SEAHOWL_CORE_HEADERS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,20 +283,22 @@ set(SEAHOWL_IO_SOURCES
     src/io/write_csv.cpp
     src/io/read_rotor_perf.cpp
     src/io/utils_io.cpp
+	src/io/viz_insitu.cpp
 )
 set(SEAHOWL_IO_HEADERS
     include/seahowl/io/read_json.h
     include/seahowl/io/write_csv.h
     include/seahowl/io/read_rotor_perf.h
     include/seahowl/io/utils_io.h
+	include/seahowl/io/viz_insitu.h
 )
 if(SEAHOWL_ENABLE_VTK)
     list(APPEND SEAHOWL_IO_SOURCES src/io/write_vtk.cpp)
     list(APPEND SEAHOWL_IO_HEADERS include/seahowl/io/write_vtk.h)
 endif(SEAHOWL_ENABLE_VTK)
 if(SEAHOWL_ENABLE_IRRLICHT)
-    list(APPEND SEAHOWL_IO_SOURCES src/io/viz_insitu.cpp)
-    list(APPEND SEAHOWL_IO_HEADERS include/seahowl/io/viz_insitu.h)
+    list(APPEND SEAHOWL_IO_SOURCES src/io/viz_insitu_irrlicht.cpp)
+    list(APPEND SEAHOWL_IO_HEADERS include/seahowl/io/viz_insitu_irrlicht.h)
 endif(SEAHOWL_ENABLE_IRRLICHT)
 source_group(io FILES ${SEAHOWL_IO_SOURCES} ${SEAHOWL_IO_HEADERS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,7 @@ set(SEAHOWL_IO_SOURCES
     src/io/read_rotor_perf.cpp
     src/io/utils_io.cpp
 	src/io/viz_insitu.cpp
+	src/io/output_manager.cpp
 )
 set(SEAHOWL_IO_HEADERS
     include/seahowl/io/read_json.h
@@ -291,6 +292,7 @@ set(SEAHOWL_IO_HEADERS
     include/seahowl/io/read_rotor_perf.h
     include/seahowl/io/utils_io.h
 	include/seahowl/io/viz_insitu.h
+	include/seahowl/io/output_manager.h
 )
 if(SEAHOWL_ENABLE_VTK)
     list(APPEND SEAHOWL_IO_SOURCES src/io/write_vtk.cpp)

--- a/data/IEA15MW/main.json
+++ b/data/IEA15MW/main.json
@@ -12,7 +12,8 @@
     "dt": 0.1,
     "folder": "./output",
     "VTK": false,
-    "log_level": "info"
+    "log_level": "info",
+    "gui": true
   },
   "environment": {
     "file": "./environment.json"

--- a/examples/ex_mooring.cpp
+++ b/examples/ex_mooring.cpp
@@ -108,7 +108,7 @@ void run_simulation() {
 
 #ifdef HAVE_VTK
     auto output_vtk = false;
-    std::vector<OutputMeshVTK> vtk_outputs;
+    std::vector<seahowl::io::OutputMeshVTK> vtk_outputs;
     if (output_vtk) {
         create_directory("./output");
         auto& post_mooring = vtk_outputs.emplace_back(mooring);

--- a/examples/ex_mooring.cpp
+++ b/examples/ex_mooring.cpp
@@ -116,11 +116,11 @@ void run_simulation() {
     }
 #endif
 
-    std::unique_ptr<VisualizationInSitu> viz_insitu;
+    std::unique_ptr<seahowl::io::VisualizationInSitu> viz_insitu;
 #ifdef HAVE_IRRLICHT
-    viz_insitu = std::make_unique<VisualizationInSituIrrlicht>();
+    viz_insitu = std::make_unique<seahowl::io::VisualizationInSituIrrlicht>();
 #else
-    viz_insitu = std::make_unique<VisualizationInSity>();
+    viz_insitu = std::make_unique<seahowl::io::VisualizationInSitu>();
 #endif
     viz_insitu->initialize_elasto(system_elasto);
     viz_insitu->draw();

--- a/examples/ex_mooring.cpp
+++ b/examples/ex_mooring.cpp
@@ -12,9 +12,9 @@ using std::filesystem::create_directory;
     #include <seahowl/io/write_vtk.h>
 #endif
 
+#include <seahowl/io/viz_insitu.h>
 #ifdef HAVE_IRRLICHT
-    #include <chrono_irrlicht/ChVisualSystemIrrlicht.h>
-    #include <seahowl/io/viz_insitu.h>
+    #include <seahowl/io/viz_insitu_irrlicht.h>
 #endif
 
 using namespace seahowl;
@@ -116,13 +116,14 @@ void run_simulation() {
     }
 #endif
 
+    std::unique_ptr<VisualizationInSitu> viz_insitu;
 #ifdef HAVE_IRRLICHT
-    auto application = chrono_types::make_shared<chrono::irrlicht::ChVisualSystemIrrlicht>();
-    application->SetWindowTitle("SEAHOWL");
-    application->Initialize();
-    application->SetCameraVertical(chrono::CameraVerticalDir::Z);
-    draw_system_init(system_elasto.chobj, application);
+    viz_insitu = std::make_unique<VisualizationInSituIrrlicht>();
+#else
+    viz_insitu = std::make_unique<VisualizationInSity>();
 #endif
+    viz_insitu->initialize_elasto(system_elasto);
+    viz_insitu->draw();
 
     spdlog::info("Setting up cables.");
     setup_cables(system_elasto, mooring, seabed, dt, 1000, fluid_density);
@@ -141,11 +142,7 @@ void run_simulation() {
             }
         }
 #endif
-#ifdef HAVE_IRRLICHT
-        application->GetDevice()->run();
-        draw_system(system_elasto.chobj, application);
-        application->EndScene();
-#endif
+        viz_insitu->draw();
     }
 }
 

--- a/examples/ex_rosco.cpp
+++ b/examples/ex_rosco.cpp
@@ -2,7 +2,7 @@
 
 int main(int argc, char* argv[]) {
     std::cout << "Hello ROSCO\n";
-    seahowl::servo::DisconController discon_params;
+    seahowl::servo::DisconInterface discon_params;
 
     std::cout << "Initialize the controller\n";
     discon_params.ResetAll();

--- a/include/seahowl/core/simulation.h
+++ b/include/seahowl/core/simulation.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "seahowl/io/output_manager.h"
+#include "seahowl/core/system.h"
+#include "seahowl/aero/system_aero.h"
+#include "seahowl/elasto/system_elasto.h"
+
+#include <memory>
+#include <string>
+
+namespace seahowl {
+namespace core {
+
+class Simulation {
+  public:
+    std::unique_ptr<System> system_core;
+
+    double dt = 0.025;
+    double dt_output = 0.;
+    double duration = 1000.0;
+
+    bool output_vtk = false;
+    std::string output_folder;
+
+    Simulation();
+
+    void initialize_from_file(const std::string& filepath);
+    void step();
+    void run_all();
+
+  private:
+    std::unique_ptr<seahowl::elasto::SystemElasto> system_elasto;
+    std::unique_ptr<seahowl::aero::SystemAero> system_aero;
+    int nstep = 0;
+    double t_output_next = 0.0;
+    std::unique_ptr<seahowl::io::OutputManager> outputs;
+};
+
+}  // namespace core
+}  // namespace seahowl

--- a/include/seahowl/core/simulation.h
+++ b/include/seahowl/core/simulation.h
@@ -14,16 +14,15 @@ namespace core {
 class Simulation {
   public:
     std::unique_ptr<System> system_core;
+    std::unique_ptr<seahowl::io::OutputManager> outputs;
 
     double dt = 0.025;
     double dt_output = 0.;
     double duration = 1000.0;
 
-    bool output_vtk = false;
-    std::string output_folder;
-
     Simulation();
 
+    void populate_from_file(const std::string& filepath);
     void initialize_from_file(const std::string& filepath);
     void step();
     void run_all();
@@ -33,7 +32,7 @@ class Simulation {
     std::unique_ptr<seahowl::aero::SystemAero> system_aero;
     int nstep = 0;
     double t_output_next = 0.0;
-    std::unique_ptr<seahowl::io::OutputManager> outputs;
+    std::string main_filepath;
 };
 
 }  // namespace core

--- a/include/seahowl/core/turbine.h
+++ b/include/seahowl/core/turbine.h
@@ -69,6 +69,11 @@ class Turbine : public ComponentDynamic {
     Turbine(seahowl::elasto::TurbineElasto& elasto, seahowl::aero::TurbineAero& aero);
 
     /**
+     * @brief Applies control to turbine.
+     */
+    void apply_control(double time, double dt);
+
+    /**
      * @brief Initialize turbine, called before starting the simulation.
      *
      * Calls init for each of its components.

--- a/include/seahowl/io/output_manager.h
+++ b/include/seahowl/io/output_manager.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "seahowl/io/viz_insitu.h"
+#ifdef HAVE_VTK
+    #include "seahowl/io/write_vtk.h"
+#endif
+
+#include <memory>
+#include <string>
+
+// Forward declaration
+namespace seahowl {
+namespace core {
+class System;
+}  // namespace core
+}  // namespace seahowl
+
+namespace seahowl {
+namespace io {
+class OutputManager {
+  public:
+    bool has_vtk = false;
+    bool has_gui = false;
+    bool has_csv = true;
+
+    OutputManager(seahowl::core::System& system_core, const std::string& output_folder);
+    void initialize();
+    void output_all(int step);
+
+  private:
+    std::string output_folder;
+    seahowl::core::System& system_core;
+#ifdef HAVE_VTK
+    std::unique_ptr<OutputSystemVTK> output_vtk;
+#endif
+    std::unique_ptr<VisualizationInSitu> output_insitu;
+};
+}  // namespace io
+}  // namespace seahowl

--- a/include/seahowl/io/output_manager.h
+++ b/include/seahowl/io/output_manager.h
@@ -23,12 +23,13 @@ class OutputManager {
     bool has_gui = false;
     bool has_csv = true;
 
-    OutputManager(seahowl::core::System& system_core, const std::string& output_folder);
+    OutputManager(seahowl::core::System& system_core);
+    void set_output_folder(const std::string& output_folder);
     void initialize();
     void output_all(int step);
 
   private:
-    std::string output_folder;
+    std::string output_folder = ".";
     seahowl::core::System& system_core;
 #ifdef HAVE_VTK
     std::unique_ptr<OutputSystemVTK> output_vtk;

--- a/include/seahowl/io/viz_insitu.h
+++ b/include/seahowl/io/viz_insitu.h
@@ -12,13 +12,6 @@ class SystemElasto;
 }  // namespace elasto
 }  // namespace seahowl
 
-namespace chrono {
-class ChSystem;
-namespace irrlicht {
-class ChVisualSystemIrrlicht;
-}  // namespace irrlicht
-}  // namespace chrono
-
 namespace seahowl {
 namespace io {
 class VisualizationInSitu {

--- a/include/seahowl/io/viz_insitu.h
+++ b/include/seahowl/io/viz_insitu.h
@@ -1,20 +1,44 @@
-#include <chrono/physics/ChSystem.h>
-#include <chrono_irrlicht/ChVisualSystemIrrlicht.h>
+#pragma once
 
-/**
- * @brief Initialization of in situ visualization for system.
- *
- * @param[in] system System to visualize.
- * @param[in] application Application on which system is visualized.
- */
-void draw_system_init(std::shared_ptr<chrono::ChSystem> system,
-                      std::shared_ptr<chrono::irrlicht::ChVisualSystemIrrlicht> application);
+#include <memory>
 
-/**
- * @brief Draw elements of systems (rigid bodies, FEA beams, etc).
- *
- * @param[in] system System to visualize.
- * @param[in] application Application on which system is visualized.
- */
-void draw_system(const std::shared_ptr<chrono::ChSystem> system,
-                 std::shared_ptr<chrono::irrlicht::ChVisualSystemIrrlicht> application);
+// forward declarations
+namespace seahowl {
+namespace core {
+class System;
+}  // namespace core
+namespace elasto {
+class SystemElasto;
+}  // namespace elasto
+}  // namespace seahowl
+
+namespace chrono {
+class ChSystem;
+namespace irrlicht {
+class ChVisualSystemIrrlicht;
+}  // namespace irrlicht
+}  // namespace chrono
+
+class VisualizationInSitu {
+  public:
+    VisualizationInSitu();
+
+    /**
+     * @brief Initialization of in situ visualization for system.
+     *
+     * @param[in] system System to visualize.
+     */
+    virtual void initialize(seahowl::core::System& system);
+
+    /**
+     * @brief Initialization of in situ visualization for system.
+     *
+     * @param[in] system System to visualize.
+     */
+    virtual void initialize_elasto(seahowl::elasto::SystemElasto& system_elasto);
+
+    /**
+     * @brief Draw elements of systems (rigid bodies, FEA beams, etc).
+     */
+    virtual void draw();
+};

--- a/include/seahowl/io/viz_insitu.h
+++ b/include/seahowl/io/viz_insitu.h
@@ -19,6 +19,8 @@ class ChVisualSystemIrrlicht;
 }  // namespace irrlicht
 }  // namespace chrono
 
+namespace seahowl {
+namespace io {
 class VisualizationInSitu {
   public:
     VisualizationInSitu();
@@ -42,3 +44,5 @@ class VisualizationInSitu {
      */
     virtual void draw();
 };
+}  // namespace io
+}  // namespace seahowl

--- a/include/seahowl/io/viz_insitu_irrlicht.h
+++ b/include/seahowl/io/viz_insitu_irrlicht.h
@@ -12,6 +12,8 @@ class ChVisualSystemIrrlicht;
 }  // namespace irrlicht
 }  // namespace chrono
 
+namespace seahowl {
+namespace io {
 class VisualizationInSituIrrlicht : public VisualizationInSitu {
   public:
     VisualizationInSituIrrlicht();
@@ -39,3 +41,5 @@ class VisualizationInSituIrrlicht : public VisualizationInSitu {
     std::shared_ptr<chrono::irrlicht::ChVisualSystemIrrlicht> application_irrlicht;
     std::shared_ptr<chrono::ChSystem> system_chrono;
 };
+}  // namespace io
+}  // namespace seahowl

--- a/include/seahowl/io/viz_insitu_irrlicht.h
+++ b/include/seahowl/io/viz_insitu_irrlicht.h
@@ -2,9 +2,6 @@
 
 #include "seahowl/io/viz_insitu.h"
 
-#include <chrono/physics/ChSystem.h>
-#include <chrono_irrlicht/ChVisualSystemIrrlicht.h>
-
 namespace chrono {
 class ChSystem;
 namespace irrlicht {

--- a/include/seahowl/io/viz_insitu_irrlicht.h
+++ b/include/seahowl/io/viz_insitu_irrlicht.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "seahowl/io/viz_insitu.h"
+
+#include <chrono/physics/ChSystem.h>
+#include <chrono_irrlicht/ChVisualSystemIrrlicht.h>
+
+namespace chrono {
+class ChSystem;
+namespace irrlicht {
+class ChVisualSystemIrrlicht;
+}  // namespace irrlicht
+}  // namespace chrono
+
+class VisualizationInSituIrrlicht : public VisualizationInSitu {
+  public:
+    VisualizationInSituIrrlicht();
+
+    /**
+     * @brief Initialization of in situ visualization for system.
+     *
+     * @param[in] system System to visualize.
+     */
+    void initialize(seahowl::core::System& system) override;
+
+    /**
+     * @brief Initialization of in situ visualization for system.
+     *
+     * @param[in] system System to visualize.
+     */
+    void initialize_elasto(seahowl::elasto::SystemElasto& system_elasto) override;
+
+    /**
+     * @brief Draw elements of systems (rigid bodies, FEA beams, etc).
+     */
+    void draw() override;
+
+  private:
+    std::shared_ptr<chrono::irrlicht::ChVisualSystemIrrlicht> application_irrlicht;
+    std::shared_ptr<chrono::ChSystem> system_chrono;
+};

--- a/include/seahowl/io/write_vtk.h
+++ b/include/seahowl/io/write_vtk.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <seahowl/elasto/component_elasto.h>
+#include "seahowl/elasto/component_elasto.h"
 
 // Forward declaration
 class vtkUnstructuredGrid;

--- a/include/seahowl/io/write_vtk.h
+++ b/include/seahowl/io/write_vtk.h
@@ -1,9 +1,18 @@
+#pragma once
+
 #include <seahowl/elasto/component_elasto.h>
 
 // Forward declaration
 class vtkUnstructuredGrid;
+namespace seahowl {
+namespace core {
+class System;
+}  // namespace core
+}  // namespace seahowl
 
-/**@brief Output with VTK format */
+namespace seahowl {
+namespace io {
+/**@brief Output mesh with VTK format */
 struct OutputMeshVTK {
     vtkUnstructuredGrid* mesh;
 
@@ -24,3 +33,18 @@ struct OutputMeshVTK {
     void initialize(const char* base_name);
     void write(double time, int time_step) const;
 };
+
+/**@brief Output system with VTK format */
+class OutputSystemVTK {
+  public:
+    OutputSystemVTK(seahowl::core::System& system_core, const std::string& output_folder);
+    void initialize();
+    void write(int step);
+
+  private:
+    seahowl::core::System& system_core;
+    std::string output_folder;
+    std::vector<OutputMeshVTK> vtk_meshes;
+};
+}  // namespace io
+}  // namespace seahowl

--- a/include/seahowl/servo/controller_discon.h
+++ b/include/seahowl/servo/controller_discon.h
@@ -18,15 +18,10 @@
 namespace seahowl {
 namespace servo {
 
-/**@brief ROSCO Discon wrapping (adapter) interface
- *
- * @todo Set as Pimpl private implementation of seahowl::servo::Controller class
+/**@brief DISCON wrapping (adapter) interface
  */
-struct DisconController {
-    // declare DISCON routine type and variable to load from dynamic library
-    typedef void (*DISCON_routine)(float* avrSWAP, int* aviFAIL, char* accINFILE, char* avcOUTNAME, char* avcMSG);
-    DISCON_routine DISCON;
-
+class DisconInterface {
+  public:
     float& m_time = avrSWAP[1];     ///<@brief Time
     float& m_dt = avrSWAP[2];       ///<@brief Time step
     float& m_pitch = avrSWAP[41];   ///<@brief Pitch return controller states
@@ -53,12 +48,12 @@ struct DisconController {
     /// <param name="omega">rotor speed</param>
     /// <param name="pitch">pitch collective</param>
     /// <param name="nblades">number of blades</param>
-    void Init(const std::string& libfile);
+    virtual void Init(const std::string& libfile = u8"");
 
     /// <summary>
     /// Call the DISCON controller
     /// </summary>
-    void Call();
+    virtual void Call();
 
     /// <summary>
     /// Helper to set the guess pitch
@@ -152,13 +147,13 @@ struct DisconController {
     /// ex! control/DISCON.in find other files in control directory
     /// </summary>
     /// <param name="name">DISCON.IN input file path</param>
-    void SetINFILE(std::string name = u8"DISCON.IN");
+    void SetINFILE(const std::string& name = u8"DISCON.IN");
 
     /// <summary>
     /// Set output base name (relative to working directory).
     /// </summary>
     /// <param name="name">a name (not a path)</param>
-    void SetOUTNAME(std::string name = u8"simDEBUG.RO.dbg");
+    void SetOUTNAME(const std::string& name = u8"simDEBUG.RO.dbg");
 
     /// <summary>
     /// Print all output
@@ -166,6 +161,12 @@ struct DisconController {
     void PrintAllOut(std::ostream& ssout = std::cout) const;
 
   private:
+    // declare DISCON routine type and variable to load from dynamic library
+    typedef void (*DISCON_routine)(float* avrSWAP, int* aviFAIL, char* accINFILE, char* avcOUTNAME, char* avcMSG);
+    DISCON_routine DISCON;
+
+    bool has_dll = false;
+
     static constexpr size_t MAX_SWAP = 500;
 
     float avrSWAP[MAX_SWAP];
@@ -181,7 +182,7 @@ struct DisconController {
 class ControllerDISCON : public Controller {
   public:
     /** @brief Object for communication with DISCON routine. */
-    seahowl::servo::DisconController pImpl;
+    seahowl::servo::DisconInterface pImpl;
 
     /**
      * @brief Constructor.
@@ -189,7 +190,7 @@ class ControllerDISCON : public Controller {
      * @param[in] infile Path of parameters file.
      * @param[in] infile Path of output file.
      */
-    ControllerDISCON(std::string infile = u8"DISCON.IN", std::string libfile = u8"libdiscon.so");
+    ControllerDISCON(const std::string& infile = u8"DISCON.IN", const std::string& libfile = u8"libdiscon.so");
 
     /**
      * @brief Initialization of controller.

--- a/include/seahowl/servo/controller_discon.h
+++ b/include/seahowl/servo/controller_discon.h
@@ -135,6 +135,9 @@ class DisconInterface {
     // Helper to force the cast of value to float
     void SetAvrSWAP(size_t index, double value);
 
+    // Forces the value of AvrSWAP even if it is of "out" type
+    void SetForcedAvrSWAP(size_t index, double value);
+
     /// <summary>
     /// Get Value from avrSWAP array of DISCON
     /// </summary>

--- a/include/seahowl/servo/controller_discon.h
+++ b/include/seahowl/servo/controller_discon.h
@@ -144,6 +144,9 @@ class DisconInterface {
     /// <param name="index">Index Fortran. (eg +1 compared to C)</param>
     float GetAvrSWAP(size_t index) const;
 
+    // Forces the value of AvrSWAP even if it is of "in" type
+    float GetForcedAvrSWAP(size_t index) const;
+
     /// <summary>
     /// Set input filename with path relative to working directory.
     /// Path is used for other files
@@ -196,6 +199,15 @@ class ControllerDISCON : public Controller {
     ControllerDISCON(const std::string& infile = u8"DISCON.IN", const std::string& libfile = u8"libdiscon.so");
 
     /**
+     * @brief Updates turbine variables of object communicating with DISCON module.
+     *
+     * @param[in] time Time of simulation.
+     * @param[in] dt Time step legnth.
+     * @param[in] turbine Turbine that is controlled by this controller.
+     */
+    void update_turbine_variables(double time, double dt, const seahowl::core::Turbine& turbine);
+
+    /**
      * @brief Initialization of controller.
      *
      * @param[in] time Time of simulation.
@@ -232,9 +244,6 @@ class ControllerDISCON : public Controller {
   private:
     /** @brief Filepath of dynamic library (for DISCON routine). */
     std::string libfile;
-
-    // updates turbine variables of object communicating with DISCON module
-    void update_turbine_variables(double time, double dt, const seahowl::core::Turbine& turbine);
 };
 
 }  // namespace servo

--- a/src/bindings/pyseahowl_core.cpp
+++ b/src/bindings/pyseahowl_core.cpp
@@ -3,6 +3,7 @@
 #include <pybind11/eigen.h>
 
 #include <seahowl/core/component.h>
+#include <seahowl/core/simulation.h>
 #include <seahowl/core/turbine.h>
 #include <seahowl/core/turbine_floating.h>
 #include <seahowl/elasto/turbine_elasto.h>
@@ -18,6 +19,7 @@
 #include <seahowl/env/wind_models.h>
 #include <seahowl/servo/controller.h>
 #include <seahowl/io/read_json.h>
+#include <seahowl/io/read_json.h>
 
 namespace py = pybind11;
 
@@ -31,6 +33,20 @@ void initialize_pyseahowl_core(py::module& m) {
         .def("initialize", &seahowl::core::ComponentDynamic::initialize)
         .def("prestep", &seahowl::core::ComponentDynamic::prestep)
         .def("poststep", &seahowl::core::ComponentDynamic::poststep);
+
+    // core/simulation.h
+    py::class_<seahowl::core::Simulation, std::shared_ptr<seahowl::core::Simulation>>(m_core, "Simulation")
+        .def(py::init<>())
+        .def("run_all", &seahowl::core::Simulation::run_all)
+        .def("step", &seahowl::core::Simulation::step)
+        .def("populate_from_file", &seahowl::core::Simulation::populate_from_file)
+        .def("initialize_from_file", &seahowl::core::Simulation::initialize_from_file)
+        .def_readwrite("dt", &seahowl::core::Simulation::dt)
+        .def_readwrite("dt_output", &seahowl::core::Simulation::dt_output)
+        .def_readwrite("duration", &seahowl::core::Simulation::duration)
+        .def_property_readonly(
+            "outputs", [](seahowl::core::Simulation& sim) { return sim.outputs.get(); },
+            py::return_value_policy::reference_internal);
 
     // core/turbine.h
     py::class_<seahowl::core::Turbine, std::shared_ptr<seahowl::core::Turbine>, seahowl::core::ComponentDynamic>(

--- a/src/bindings/pyseahowl_io.cpp
+++ b/src/bindings/pyseahowl_io.cpp
@@ -13,6 +13,7 @@
 #include <seahowl/aero/tower_aero.h>
 #include <seahowl/aero/rotor_aero.h>
 #include <seahowl/io/write_csv.h>
+#include <seahowl/io/output_manager.h>
 
 namespace py = pybind11;
 
@@ -35,4 +36,14 @@ void initialize_pyseahowl_io(py::module& m) {
 
     // io/write_csv.h
     m_io.def("write_turbine_info_to_csv", &write_turbine_info_to_csv);
+
+    // io/output_manager.h
+    py::class_<seahowl::io::OutputManager, std::shared_ptr<seahowl::io::OutputManager>>(m_io, "OutputManager")
+        .def(py::init<seahowl::core::System&>())
+        .def("set_output_folder", &seahowl::io::OutputManager::set_output_folder)
+        .def("initialize", &seahowl::io::OutputManager::initialize)
+        .def("output_all", &seahowl::io::OutputManager::output_all)
+        .def_readwrite("has_vtk", &seahowl::io::OutputManager::has_vtk)
+        .def_readwrite("has_gui", &seahowl::io::OutputManager::has_gui)
+        .def_readwrite("has_csv", &seahowl::io::OutputManager::has_csv);
 }

--- a/src/core/rotor.cpp
+++ b/src/core/rotor.cpp
@@ -32,9 +32,14 @@ void RotorNacelleAssembly::initialize(double time, double dt) {
 }
 
 void RotorNacelleAssembly::prestep(double time, double dt) {
+    // blades
     for (auto& blade : blades) {
         blade->prestep(time, dt);
     }
+
+    // hub loads
+    // reset external loads applied on RNA
+    elasto.reset_loads();
 
     // apply extra torque and thrust (if any) to hub
     elasto.rotor->body_hub->accumulate_torque(Vector3d(aero.rotor->hub_torque_aero, 0, 0), true);

--- a/src/core/rotor.cpp
+++ b/src/core/rotor.cpp
@@ -37,10 +37,6 @@ void RotorNacelleAssembly::prestep(double time, double dt) {
         blade->prestep(time, dt);
     }
 
-    // hub loads
-    // reset external loads applied on RNA
-    elasto.reset_loads();
-
     // apply extra torque and thrust (if any) to hub
     elasto.rotor->body_hub->accumulate_torque(Vector3d(aero.rotor->hub_torque_aero, 0, 0), true);
     elasto.rotor->body_hub->accumulate_force(Vector3d(aero.rotor->hub_thrust_aero, 0, 0), true);

--- a/src/core/simulation.cpp
+++ b/src/core/simulation.cpp
@@ -1,0 +1,104 @@
+#include "seahowl/core/simulation.h"
+
+#include "seahowl/core/system.h"
+#include "seahowl/elasto/system_elasto.h"
+#include "seahowl/elasto/blade_elasto.h"
+#include "seahowl/aero/system_aero.h"
+#include "seahowl/elasto/chrono_adapters.h"
+#include "seahowl/io/read_json.h"
+#include "seahowl/io/write_csv.h"
+#include "seahowl/io/output_manager.h"
+
+#include <fstream>
+#include <filesystem>  // C++17
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+#include <spdlog/stopwatch.h>
+
+using namespace seahowl::core;
+namespace fs = std::filesystem;
+using json = nlohmann::json;
+
+Simulation::Simulation() {
+    system_elasto = std::make_unique<seahowl::elasto::SystemElastoChrono>();
+    system_aero = std::make_unique<seahowl::aero::SystemAero>();
+    system_core = std::make_unique<System>(*system_elasto, *system_aero);
+}
+
+void Simulation::initialize_from_file(const std::string& filepath) {  // SETUP
+    spdlog::stopwatch sw_setup;
+    spdlog::set_pattern("[%^%l%$] %v");
+    spdlog::info("**************************************************************");
+    spdlog::info("INITIAL SIMULATION SETUP.");
+    spdlog::info("**************************************************************");
+
+    // get main file info
+    std::ifstream json_file(filepath);
+    json json_obj;
+    json_file >> json_obj;
+    json_file.close();
+
+    // NUMERICS options
+    auto num_json = json_obj.at("numerics");
+    // timestepping
+    dt = num_json.at("dt").get<double>();
+    duration = num_json.at("t_end").get<double>();
+    // outputs
+    auto outputs_json = json_obj.at("outputs");
+    dt_output = outputs_json.at("dt").get<double>();
+    std::string output_folder = "./output";
+    if (outputs_json.contains("folder")) {
+        output_folder = outputs_json.at("folder").get<std::string>();
+    }
+
+    // outputs
+    outputs = std::make_unique<seahowl::io::OutputManager>(*system_core, output_folder);
+    outputs->has_vtk = outputs_json.at("VTK").get<bool>();
+    outputs->has_gui = outputs_json.at("gui").get<bool>();
+    outputs->initialize();
+
+    // outputs
+    fs::create_directories(output_folder);
+
+    populate_system_from_json(filepath, *system_core);
+    spdlog::debug("Populated system.");
+
+    initialize_system_from_json(filepath, *system_core);
+    spdlog::debug("Fully initialized system.");
+
+    outputs->output_all(0);
+
+    t_output_next = dt_output;
+    spdlog::info("Initial setup time: {:.3}s.", sw_setup);
+};
+
+void Simulation::step() {
+    spdlog::stopwatch sw_step;
+    // prestep
+    system_core->prestep(system_core->get_time(), dt);
+
+    // step
+    system_core->step(dt);
+    nstep += 1;
+
+    // poststep
+    system_core->poststep(system_core->get_time(), dt);
+
+    // output
+    if (system_core->get_time() >= (t_output_next - 1e-6)) {
+        spdlog::info("time: {:.6}s, step: {}, stopwatch: {:.3}s", system_core->get_time(), nstep, sw_step);
+        outputs->output_all(nstep);
+        t_output_next += dt_output;
+    }
+}
+
+void Simulation::run_all() {
+    spdlog::info("**************************************************************");
+    spdlog::info("MAIN SIMULATION LOOP.");
+    spdlog::info("**************************************************************");
+    spdlog::stopwatch sw_sim;
+    while (system_core->get_time() < duration) {
+        step();
+    }
+    spdlog::info("Finished simulation (runtime: {:.3}s).", sw_sim);
+}

--- a/src/core/simulation.cpp
+++ b/src/core/simulation.cpp
@@ -25,7 +25,7 @@ Simulation::Simulation() {
     system_core = std::make_unique<System>(*system_elasto, *system_aero);
 }
 
-void Simulation::initialize_from_file(const std::string& filepath) {  // SETUP
+void Simulation::populate_from_file(const std::string& filepath) {
     spdlog::stopwatch sw_setup;
     spdlog::set_pattern("[%^%l%$] %v");
     spdlog::info("**************************************************************");
@@ -37,6 +37,8 @@ void Simulation::initialize_from_file(const std::string& filepath) {  // SETUP
     json json_obj;
     json_file >> json_obj;
     json_file.close();
+
+    populate_system_from_json(filepath, *system_core);
 
     // NUMERICS options
     auto num_json = json_obj.at("numerics");
@@ -52,16 +54,24 @@ void Simulation::initialize_from_file(const std::string& filepath) {  // SETUP
     }
 
     // outputs
-    outputs = std::make_unique<seahowl::io::OutputManager>(*system_core, output_folder);
+    outputs = std::make_unique<seahowl::io::OutputManager>(*system_core);
+    outputs->set_output_folder(output_folder);
     outputs->has_vtk = outputs_json.at("VTK").get<bool>();
     outputs->has_gui = outputs_json.at("gui").get<bool>();
+
+    spdlog::debug("Populated system in {:.3}s.", sw_setup);
+}
+
+void Simulation::initialize_from_file(const std::string& filepath) {
+    spdlog::stopwatch sw_setup;
+
+    // get main file info
+    std::ifstream json_file(filepath);
+    json json_obj;
+    json_file >> json_obj;
+    json_file.close();
+
     outputs->initialize();
-
-    // outputs
-    fs::create_directories(output_folder);
-
-    populate_system_from_json(filepath, *system_core);
-    spdlog::debug("Populated system.");
 
     initialize_system_from_json(filepath, *system_core);
     spdlog::debug("Fully initialized system.");

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -35,6 +35,8 @@ void System::initialize(double time, double dt) {
 
 void System::prestep(double time, double dt) {
     for (auto& turbine : turbines) {
+        turbine->apply_control(time, dt);
+
         // compute forces from fluid model
         if (fluid_model) {
             turbine->apply_fluid_model(*fluid_model, time);

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -28,14 +28,9 @@ void Turbine::initialize(double time, double dt) {
 }
 
 void Turbine::prestep(double time, double dt) {
+    // presteps
     rna.prestep(time, dt);
     tower.prestep(time, dt);
-}
-
-void Turbine::poststep(double time, double dt) {
-    // hub loads
-    // reset external loads applied on RNA
-    rna.elasto.reset_loads();
 
     // apply aero torque losses from gearbox efficiency for next step
     auto aero_torque = rna.elasto.get_axial_torque();
@@ -68,7 +63,9 @@ void Turbine::poststep(double time, double dt) {
             }
         }
     }
+}
 
+void Turbine::poststep(double time, double dt) {
     // poststeps
     rna.poststep(time, dt);
     tower.poststep(time, dt);

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -27,11 +27,45 @@ void Turbine::initialize(double time, double dt) {
     spdlog::info("Initialized turbine of total mass {:.4}kg.", elasto.get_mass());
 }
 
+void Turbine::apply_control(double time, double dt) {
+    // controller step
+    controller->step(time, dt, *this);
+
+    // apply electrical torque from controller
+    if (controller->has_torque_control) {
+        auto torque_elec = controller->get_torque_elec() * gearbox_ratio * gearbox_efficiency;
+        // torque elec is applied on hub body (locally)
+        rna.elasto.accumulate_electrical_torque(torque_elec);
+    }
+
+    // apply pitch from controller
+    if (controller->has_pitch_control) {
+        auto collective_pitch_increment = controller->get_collective_pitch() - rna.elasto.rotor->pitch_collective;
+        rna.elasto.rotor->apply_collective_pitch_increment(collective_pitch_increment);
+        if (rna.blades.size() <= 3) {
+            // individual pitch only works with up to 3 blades
+            for (int idx_blade = 0; idx_blade < rna.blades.size(); idx_blade++) {
+                auto& blade = *rna.blades[idx_blade];
+                // individual pitch increment difference with collective pitch increment that was already applied
+                auto blade_pitch_increment =
+                    (controller->get_pitch_blade(idx_blade) - collective_pitch_increment) - blade.elasto.pitch;
+                blade.elasto.apply_pitch_increment(blade_pitch_increment);
+                blade.update_positions_aero();
+            }
+        }
+    }
+}
+
 void Turbine::prestep(double time, double dt) {
     // presteps
     rna.prestep(time, dt);
     tower.prestep(time, dt);
+}
 
+void Turbine::poststep(double time, double dt) {
+    // hub loads
+    // reset external loads applied on RNA
+    rna.elasto.reset_loads();
     // apply aero torque losses from gearbox efficiency for next step
     auto aero_torque = rna.elasto.get_axial_torque();
     if (controller->has_torque_control) {
@@ -40,32 +74,6 @@ void Turbine::prestep(double time, double dt) {
     }
     rna.elasto.rotor->accumulate_axial_torque(-aero_torque * (1.0 - gearbox_efficiency));
 
-    // controller step
-    controller->step(time, dt, *this);
-    // apply torque from controller
-    if (controller->has_torque_control) {
-        auto torque_elec = controller->get_torque_elec() * gearbox_ratio * gearbox_efficiency;
-        // torque elec is applied on hub body (locally)
-        rna.elasto.accumulate_electrical_torque(torque_elec);
-    }
-    // apply pitch from controller
-    if (controller->has_pitch_control) {
-        auto collective_pitch_increment = controller->get_collective_pitch() - rna.elasto.rotor->pitch_collective;
-        rna.elasto.rotor->apply_collective_pitch_increment(collective_pitch_increment);
-        if (rna.blades.size() <= 3) {
-            // individual pitch only works with up to 3 blades
-            for (int idx_blade = 0; idx_blade < rna.blades.size(); idx_blade++) {
-                auto& blade = rna.blades[idx_blade]->elasto;
-                // individual pitch increment difference with collective pitch increment that was already applied
-                auto blade_pitch_increment =
-                    (controller->get_pitch_blade(idx_blade) - collective_pitch_increment) - blade.pitch;
-                blade.apply_pitch_increment(blade_pitch_increment);
-            }
-        }
-    }
-}
-
-void Turbine::poststep(double time, double dt) {
     // poststeps
     rna.poststep(time, dt);
     tower.poststep(time, dt);

--- a/src/io/output_manager.cpp
+++ b/src/io/output_manager.cpp
@@ -1,0 +1,72 @@
+#include "seahowl/io/output_manager.h"
+
+#include "seahowl/io/write_csv.h"
+#include "seahowl/io/write_vtk.h"
+#include "seahowl/io/viz_insitu.h"
+#ifdef HAVE_IRRLICHT
+    #include "seahowl/io/viz_insitu_irrlicht.h"
+#endif
+#include "seahowl/core/system.h"
+#include "seahowl/core/turbine.h"
+#include "seahowl/elasto/turbine_elasto.h"
+#include "seahowl/elasto/blade_elasto.h"
+
+#include <sstream>
+#include <iomanip>
+#include <spdlog/spdlog.h>
+
+using namespace seahowl::io;
+
+OutputManager::OutputManager(seahowl::core::System& system_core, const std::string& output_folder)
+    : system_core(system_core), output_folder(output_folder) {}
+
+void OutputManager::initialize() {
+    if (has_vtk) {
+#ifdef HAVE_VTK
+        output_vtk = std::make_unique<OutputSystemVTK>(system_core, output_folder + "/vtk/");
+        output_vtk->initialize();
+#endif
+    }
+    if (has_gui) {
+#ifdef HAVE_IRRLICHT
+        output_insitu = std::make_unique<VisualizationInSituIrrlicht>();
+#else
+        output_insitu = std::make_unique<VisualizationInSitu>();
+#endif
+        output_insitu->initialize(system_core);
+        output_insitu->draw();
+    }
+}
+
+void OutputManager::output_all(int step) {
+    if (has_vtk) {
+#ifdef HAVE_VTK
+        output_vtk->write(step);
+#endif
+    }
+    if (has_gui) {
+        output_insitu->draw();
+    }
+
+    // output
+    auto& turbine = *system_core.turbines[0];
+
+    // send info to logger
+    std::stringstream output_sstring;
+    output_sstring << "    turbine info -> rpm: " << std::setprecision(3) << turbine.rna.elasto.get_rpm()
+                   << ", power: " << turbine.get_generated_power();
+    int nblades = turbine.rna.blades.size();
+    if (nblades <= 3 && nblades > 0) {
+        for (int ii = 0; ii < turbine.rna.blades.size(); ii++) {
+            output_sstring << ", pitch" << ii + 1 << ": " << turbine.rna.elasto.rotor->blades[ii]->pitch;
+        }
+    } else {
+        output_sstring << ", pitch: " << turbine.rna.elasto.rotor->pitch_collective;
+    }
+    spdlog::info(output_sstring.str());
+
+    if (has_csv) {
+        // output info in file
+        write_turbine_info_to_csv(output_folder + "/output", system_core);
+    }
+}

--- a/src/io/output_manager.cpp
+++ b/src/io/output_manager.cpp
@@ -11,16 +11,24 @@
 #include "seahowl/elasto/turbine_elasto.h"
 #include "seahowl/elasto/blade_elasto.h"
 
+#include <filesystem>  // C++17
 #include <sstream>
 #include <iomanip>
 #include <spdlog/spdlog.h>
 
 using namespace seahowl::io;
+namespace fs = std::filesystem;
 
-OutputManager::OutputManager(seahowl::core::System& system_core, const std::string& output_folder)
-    : system_core(system_core), output_folder(output_folder) {}
+OutputManager::OutputManager(seahowl::core::System& system_core) : system_core(system_core) {}
+
+void OutputManager::set_output_folder(const std::string& output_folder) {
+    this->output_folder = output_folder;
+}
 
 void OutputManager::initialize() {
+    // outputs
+    spdlog::debug("Creating directory {} for outputs.", output_folder);
+    fs::create_directories(output_folder);
     if (has_vtk) {
 #ifdef HAVE_VTK
         output_vtk = std::make_unique<OutputSystemVTK>(system_core, output_folder + "/vtk/");

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -606,16 +606,22 @@ void populate_turbine_from_json(const std::string& filepath,
         if (!controller_json.at("options").contains("libfile")) {
             throw std::runtime_error("Need to define path to libfile for DISCON routine.");
         }
-        auto libfilepath = path(DATADIR / controller_json.at("options").at("libfile"));
 
-        // copy libdiscon to temporary folder with new name in case there are several turbines
-        check_file_exists(libfilepath.generic_string());
-        // first copy libdiscon to tmp folder
-        auto copyfilepath = copy_file_and_increment(libfilepath.generic_string(), output_folder + "/tmp");
-
+        auto libfilepath = controller_json.at("options").at("libfile").get<std::string>();
+        if (libfilepath != "") {
+            // absolute path
+            libfilepath = path(DATADIR / libfilepath).generic_string();
+            // copy libdiscon to temporary folder with new name in case there are several turbines
+            check_file_exists(libfilepath);
+            // first copy libdiscon to tmp folder
+            libfilepath = copy_file_and_increment(libfilepath, output_folder + "/tmp");
+        }
+        auto infilepath = controller_json.at("options").at("infile").get<std::string>();
+        if (infilepath != "") {
+            infilepath = (DATADIR / infilepath).generic_string();
+        }
         // instantiate controller
-        auto controller = std::make_shared<seahowl::servo::ControllerDISCON>(
-            (DATADIR / controller_json.at("options").at("infile")).generic_string(), copyfilepath);
+        auto controller = std::make_shared<seahowl::servo::ControllerDISCON>(infilepath, libfilepath);
         turbine.controller = controller;
 
     } else if (controller_json.at("type").get<std::string>() == "RPM") {

--- a/src/io/viz_insitu.cpp
+++ b/src/io/viz_insitu.cpp
@@ -1,16 +1,9 @@
 #include "seahowl/io/viz_insitu.h"
 
-#include <seahowl/core/system.h>
-
+#include "seahowl/core/system.h"
 #include <spdlog/spdlog.h>
 
-namespace fs = std::filesystem;
-
-using seahowl::Vector3d;
 using namespace seahowl::io;
-
-void draw_system(const std::shared_ptr<chrono::ChSystem> system,
-                 std::shared_ptr<chrono::irrlicht::ChVisualSystemIrrlicht> application) {}
 
 VisualizationInSitu::VisualizationInSitu() {
     spdlog::info("No concrete in situ visualization application selected.");

--- a/src/io/viz_insitu.cpp
+++ b/src/io/viz_insitu.cpp
@@ -1,63 +1,22 @@
 #include "seahowl/io/viz_insitu.h"
 
-#include <seahowl/commons/numerics.h>
+#include <seahowl/core/system.h>
+
+#include <spdlog/spdlog.h>
+
+namespace fs = std::filesystem;
 
 using seahowl::Vector3d;
 
-void draw_system_init(std::shared_ptr<chrono::ChSystem> system,
-                      std::shared_ptr<chrono::irrlicht::ChVisualSystemIrrlicht> application) {
-    // initialize default
-    application->AddTypicalLights();
-    application->AddSkyBox();
-    application->AddCamera(Vector3d(-150, -150, 150), Vector3d(0, 0, 150.));
-
-    // meshes
-    for (auto mesh : system->Get_meshlist()) {
-        // beams
-        auto beams_visu = chrono_types::make_shared<chrono::ChVisualShapeFEA>(mesh);
-        beams_visu->SetFEMdataType(chrono::ChVisualShapeFEA::DataType::ELEM_BEAM_MZ);
-        beams_visu->SetColorscaleMinMax(-0.4, 0.4);
-        mesh->AddVisualShapeFEA(beams_visu);
-
-        // nodes
-        auto nodes_visu = chrono_types::make_shared<chrono::ChVisualShapeFEA>(mesh);
-        nodes_visu->SetFEMglyphType(chrono::ChVisualShapeFEA::GlyphType::NODE_DOT_POS);
-        nodes_visu->SetFEMdataType(chrono::ChVisualShapeFEA::DataType::NODE_DISP_Y);
-        nodes_visu->SetSymbolsThickness(1.5);
-        nodes_visu->SetSymbolsScale(1.0);
-        nodes_visu->SetZbufferHide(false);
-        mesh->AddVisualShapeFEA(nodes_visu);
-
-        // nodes coordinate system
-        auto nodes_visu2 = chrono_types::make_shared<chrono::ChVisualShapeFEA>(mesh);
-        nodes_visu2->SetFEMglyphType(chrono::ChVisualShapeFEA::GlyphType::NODE_CSYS);
-        nodes_visu2->SetFEMdataType(chrono::ChVisualShapeFEA::DataType::NONE);
-        nodes_visu2->SetSymbolsThickness(10.0);
-        nodes_visu2->SetSymbolsScale(1.0);
-        nodes_visu2->SetZbufferHide(false);
-        mesh->AddVisualShapeFEA(nodes_visu2);
-    }
-
-    // bind assets
-
-    application->AttachSystem(system.get());
-    application->SetShadows(true);
-}
-
 void draw_system(const std::shared_ptr<chrono::ChSystem> system,
-                 std::shared_ptr<chrono::irrlicht::ChVisualSystemIrrlicht> application) {
-    // irrlicht must prepare frame to draw
-    application->BeginScene(true, true, chrono::ChColor(255, 140, 161));
+                 std::shared_ptr<chrono::irrlicht::ChVisualSystemIrrlicht> application) {}
 
-    // draw items belonging to Irrlicht scene, if any
-    application->Render();
-
-    // draw bodies
-    for (auto body : system->Get_bodylist()) {
-        chrono::irrlicht::tools::drawCircle(application.get(), 5.0, body->GetCoord());
-    }
-    chrono::irrlicht::tools::drawAllCOGs(application.get(), 5.0);
-
-    // grid
-    // chrono::irrlicht::tools::drawGrid(application, 10, 10);
+VisualizationInSitu::VisualizationInSitu() {
+    spdlog::info("No concrete in situ visualization application selected.");
 }
+
+void VisualizationInSitu::initialize_elasto(seahowl::elasto::SystemElasto& system) {}
+
+void VisualizationInSitu::initialize(seahowl::core::System& system) {}
+
+void VisualizationInSitu::draw() {}

--- a/src/io/viz_insitu.cpp
+++ b/src/io/viz_insitu.cpp
@@ -7,6 +7,7 @@
 namespace fs = std::filesystem;
 
 using seahowl::Vector3d;
+using namespace seahowl::io;
 
 void draw_system(const std::shared_ptr<chrono::ChSystem> system,
                  std::shared_ptr<chrono::irrlicht::ChVisualSystemIrrlicht> application) {}

--- a/src/io/viz_insitu_irrlicht.cpp
+++ b/src/io/viz_insitu_irrlicht.cpp
@@ -13,6 +13,7 @@
 namespace fs = std::filesystem;
 
 using seahowl::Vector3d;
+using namespace seahowl::io;
 
 VisualizationInSituIrrlicht::VisualizationInSituIrrlicht() {
     application_irrlicht = chrono_types::make_shared<chrono::irrlicht::ChVisualSystemIrrlicht>();

--- a/src/io/viz_insitu_irrlicht.cpp
+++ b/src/io/viz_insitu_irrlicht.cpp
@@ -1,8 +1,8 @@
 #include "seahowl/io/viz_insitu_irrlicht.h"
 
-#include <seahowl/commons/numerics.h>
-#include <seahowl/core/system.h>
-#include <seahowl/elasto/chrono_adapters.h>
+#include "seahowl/commons/numerics.h"
+#include "seahowl/core/system.h"
+#include "seahowl/elasto/chrono_adapters.h"
 
 #include <chrono/physics/ChSystem.h>
 #include <chrono_irrlicht/ChVisualSystemIrrlicht.h>

--- a/src/io/viz_insitu_irrlicht.cpp
+++ b/src/io/viz_insitu_irrlicht.cpp
@@ -1,0 +1,99 @@
+#include "seahowl/io/viz_insitu_irrlicht.h"
+
+#include <seahowl/commons/numerics.h>
+#include <seahowl/core/system.h>
+#include <seahowl/elasto/chrono_adapters.h>
+
+#include <chrono/physics/ChSystem.h>
+#include <chrono_irrlicht/ChVisualSystemIrrlicht.h>
+
+#include <spdlog/spdlog.h>
+#include <filesystem>  // C++17
+
+namespace fs = std::filesystem;
+
+using seahowl::Vector3d;
+
+VisualizationInSituIrrlicht::VisualizationInSituIrrlicht() {
+    application_irrlicht = chrono_types::make_shared<chrono::irrlicht::ChVisualSystemIrrlicht>();
+    application_irrlicht->SetWindowTitle("SEAHOWL");
+    application_irrlicht->Initialize();
+    application_irrlicht->SetCameraVertical(chrono::CameraVerticalDir::Z);
+    auto DATADIR = fs::absolute(fs::path(u8"../data"));
+    auto logoname = (DATADIR / ".." / "doc" / "source" / "totalenergies_alpha.png").generic_string();
+    application_irrlicht->AddLogo(logoname);
+}
+
+void VisualizationInSituIrrlicht::initialize_elasto(seahowl::elasto::SystemElasto& system_elasto) {
+    spdlog::debug("Initializing in situ visualization (Irrlicht).");
+
+    try {
+        system_chrono = dynamic_cast<seahowl::elasto::SystemElastoChrono&>(system_elasto).chobj;
+    } catch (const std::bad_cast& e) {
+        throw std::runtime_error("Can only use Chrono system for in situ visualization.");
+    }
+
+    // initialize default
+    application_irrlicht->AddTypicalLights();
+    application_irrlicht->AddSkyBox();
+    application_irrlicht->AddCamera(Vector3d(-150, -150, 150), Vector3d(0, 0, 150.));
+
+    // meshes
+    for (auto mesh : system_chrono->Get_meshlist()) {
+        // beams
+        auto beams_visu = chrono_types::make_shared<chrono::ChVisualShapeFEA>(mesh);
+        beams_visu->SetFEMdataType(chrono::ChVisualShapeFEA::DataType::ELEM_BEAM_MZ);
+        beams_visu->SetColorscaleMinMax(-0.4, 0.4);
+        mesh->AddVisualShapeFEA(beams_visu);
+
+        // nodes
+        auto nodes_visu = chrono_types::make_shared<chrono::ChVisualShapeFEA>(mesh);
+        nodes_visu->SetFEMglyphType(chrono::ChVisualShapeFEA::GlyphType::NODE_DOT_POS);
+        nodes_visu->SetFEMdataType(chrono::ChVisualShapeFEA::DataType::NODE_DISP_Y);
+        nodes_visu->SetSymbolsThickness(1.5);
+        nodes_visu->SetSymbolsScale(1.0);
+        nodes_visu->SetZbufferHide(false);
+        mesh->AddVisualShapeFEA(nodes_visu);
+
+        // nodes coordinate system
+        auto nodes_visu2 = chrono_types::make_shared<chrono::ChVisualShapeFEA>(mesh);
+        nodes_visu2->SetFEMglyphType(chrono::ChVisualShapeFEA::GlyphType::NODE_CSYS);
+        nodes_visu2->SetFEMdataType(chrono::ChVisualShapeFEA::DataType::NONE);
+        nodes_visu2->SetSymbolsThickness(10.0);
+        nodes_visu2->SetSymbolsScale(1.0);
+        nodes_visu2->SetZbufferHide(false);
+        mesh->AddVisualShapeFEA(nodes_visu2);
+    }
+
+    // bind assets
+
+    application_irrlicht->AttachSystem(system_chrono.get());
+    application_irrlicht->SetShadows(true);
+
+    spdlog::debug("Finished initializing in situ visualization (Irrlicht).");
+};
+
+void VisualizationInSituIrrlicht::initialize(seahowl::core::System& system) {
+    initialize_elasto(system.elasto);
+};
+
+void VisualizationInSituIrrlicht::draw() {
+    application_irrlicht->GetDevice()->run();
+
+    // irrlicht must prepare frame to draw
+    application_irrlicht->BeginScene(true, true, chrono::ChColor(255, 140, 161));
+
+    // draw items belonging to Irrlicht scene, if any
+    application_irrlicht->Render();
+
+    // draw bodies
+    for (auto body : system_chrono->Get_bodylist()) {
+        chrono::irrlicht::tools::drawCircle(application_irrlicht.get(), 5.0, body->GetCoord());
+    }
+    chrono::irrlicht::tools::drawAllCOGs(application_irrlicht.get(), 5.0);
+
+    // grid
+    // chrono::irrlicht::tools::drawGrid(application, 10, 10);
+
+    application_irrlicht->EndScene();
+}

--- a/src/io/write_vtk.cpp
+++ b/src/io/write_vtk.cpp
@@ -1,5 +1,8 @@
 #include <seahowl/io/write_vtk.h>
 #include <seahowl/commons/numerics.h>
+#include <seahowl/core/system.h>
+#include <seahowl/core/blade.h>
+#include <seahowl/elasto/blade_elasto.h>
 
 #include <vtkSmartPointer.h>
 #include <vtkUnstructuredGrid.h>
@@ -8,12 +11,16 @@
 #include <vtkPointData.h>
 #include <vtkDoubleArray.h>
 
+#include <filesystem>  // C++17
 #include <string>
 #include <vector>
 #include <map>
 #include <cstdio>
 
+namespace fs = std::filesystem;
+
 using seahowl::Vector3d;
+using namespace seahowl::io;
 
 OutputMeshVTK::OutputMeshVTK(seahowl::elasto::ComponentElastoFEA& component) : component(component) {
     mesh = vtkUnstructuredGrid::New();
@@ -125,5 +132,33 @@ void OutputMeshVTK::write(double time, int time_step) const {
         writer->SetFileName(fname);
         writer->SetInputData(mesh);
         writer->Write();
+    }
+}
+
+OutputSystemVTK::OutputSystemVTK(seahowl::core::System& system_core, const std::string& output_folder)
+    : system_core(system_core), output_folder(output_folder) {}
+
+void OutputSystemVTK::initialize() {
+    vtk_meshes.clear();
+    for (auto [turbine_ptr, idx_turbine] = std::tuple{system_core.turbines.begin(), 0};
+         turbine_ptr != system_core.turbines.end(); turbine_ptr++, idx_turbine++) {
+        auto& turbine = *turbine_ptr;
+        fs::create_directory(output_folder);
+        for (auto [blade_ptr, idx_blade] = std::tuple{turbine->rna.blades.begin(), 0};
+             blade_ptr != turbine->rna.blades.end(); blade_ptr++, idx_blade++) {
+            auto& blade = *blade_ptr;
+            auto& post_blade = vtk_meshes.emplace_back(dynamic_cast<seahowl::elasto::BladeElastoFEA&>(blade->elasto));
+            post_blade.initialize(
+                (output_folder + "/turbine" + std::to_string(idx_turbine) + "_blade" + std::to_string(idx_blade))
+                    .c_str());
+        }
+        auto& post_tower = vtk_meshes.emplace_back(turbine->tower.elasto);
+        post_tower.initialize((output_folder + "/turbine" + std::to_string(idx_turbine) + "_tower").c_str());
+    }
+}
+
+void OutputSystemVTK::write(int step) {
+    for (auto const& vtk_output : vtk_meshes) {
+        vtk_output.write(system_core.elasto.get_time(), step);
     }
 }

--- a/src/io/write_vtk.cpp
+++ b/src/io/write_vtk.cpp
@@ -1,8 +1,8 @@
-#include <seahowl/io/write_vtk.h>
-#include <seahowl/commons/numerics.h>
-#include <seahowl/core/system.h>
-#include <seahowl/core/blade.h>
-#include <seahowl/elasto/blade_elasto.h>
+#include "seahowl/io/write_vtk.h"
+#include "seahowl/commons/numerics.h"
+#include "seahowl/core/system.h"
+#include "seahowl/core/blade.h"
+#include "seahowl/elasto/blade_elasto.h"
 
 #include <vtkSmartPointer.h>
 #include <vtkUnstructuredGrid.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,120 +1,24 @@
-#include <nlohmann/json.hpp>
-using json = nlohmann::json;
-
-#include <cmath>
-
-#include <seahowl/io/read_json.h>
-#include <seahowl/io/output_manager.h>
-
-#include <seahowl/core/system.h>
-#include <seahowl/aero/system_aero.h>
-#include <seahowl/core/blade.h>
-#include <seahowl/elasto/blade_elasto.h>
-#include <seahowl/core/turbine_floating.h>
-#include <seahowl/elasto/mooring_elasto.h>
+#include <seahowl/core/simulation.h>
 
 #include <filesystem>  // C++17
-#include <fstream>
-#include <sstream>
 #include <spdlog/spdlog.h>
-#include <spdlog/stopwatch.h>
 #include <spdlog/pattern_formatter.h>
 
 namespace fs = std::filesystem;
-using std::filesystem::path;
-using std::filesystem::create_directory;
-using std::filesystem::remove_all;
 
 void run_simulation(int argc, char* argv[]) {
     spdlog::set_level(spdlog::level::info);
     spdlog::info("Start SEAHOWL simulation.");
 
-    // stopwatch before doing anything
-    spdlog::stopwatch sw0;
-
-    // SETUP
-    spdlog::set_pattern("[%^%l%$] %v");
-    spdlog::info("**************************************************************");
-    spdlog::info("INITIAL SETUP.");
-    spdlog::info("**************************************************************");
-
-    auto DATADIR = absolute(path(u8"../data"));
-    auto logoname = (DATADIR / ".." / "doc" / "source" / "totalenergies_alpha.png").generic_string();
-
     // path of main input file
-    auto filepath_main = DATADIR / "IEA15MW/main.json";
+    auto filepath_main = fs::absolute(fs::path(u8"../data/IEA15MW/main.json"));
     if (argc > 1) {
-        filepath_main = absolute(path(argv[1]));
-    }
-    // get main file info
-    std::ifstream json_file(filepath_main.generic_string());
-    json json_obj;
-    json_file >> json_obj;
-    json_file.close();
-
-    // system elasto
-    auto system_elasto = seahowl::elasto::SystemElastoChrono();
-    // system aero
-    auto system_aero = seahowl::aero::SystemAero();
-    // system core
-    auto system_core = seahowl::core::System(system_elasto, system_aero);
-
-    populate_system_from_json(filepath_main.generic_string(), system_core);
-    spdlog::debug("Populated system.");
-
-    initialize_system_from_json(filepath_main.generic_string(), system_core);
-    spdlog::debug("Fully initialized system.");
-
-    // NUMERICS options
-    auto num_json = json_obj.at("numerics");
-    // timestepping
-    auto dt = num_json.at("dt").get<double>();
-    auto t_end = num_json.at("t_end").get<double>();
-    // outputs
-    auto outputs_json = json_obj.at("outputs");
-    auto dt_outputs = outputs_json.at("dt").get<double>();
-    std::string output_folder = "./output";
-    if (outputs_json.contains("folder")) {
-        output_folder = outputs_json.at("folder").get<std::string>();
+        filepath_main = fs::absolute(fs::path(argv[1]));
     }
 
-    // outputs
-    fs::create_directories(output_folder);
-    auto outputs = seahowl::io::OutputManager(system_core, output_folder);
-    outputs.has_vtk = outputs_json.at("VTK").get<bool>();
-    outputs.has_gui = outputs_json.at("gui").get<bool>();
-    outputs.initialize();
-
-    int step = 0;
-    // outputs.output_all(step);
-
-    double time_outputs = dt_outputs;
-    spdlog::info("**************************************************************");
-    spdlog::info("MAIN SIMULATION LOOP.");
-    spdlog::info("Initial setup time: {:.3}s.", sw0);
-    spdlog::info("Resetting simulation stopwatch to 0s.");
-    spdlog::info("**************************************************************");
-    spdlog::stopwatch sw_total;
-    while (system_core.get_time() < t_end) {
-        // prestep
-        system_core.prestep(system_core.get_time(), dt);
-
-        // step
-        system_core.step(dt);
-        step += 1;
-
-        // poststep
-        system_core.poststep(system_core.get_time(), dt);
-
-        // output
-        if (system_core.get_time() >= (time_outputs - 1e-6)) {
-            spdlog::info("time: {:.6}s, step: {}, stopwatch: {:.3}s", system_core.get_time(), step, sw_total);
-
-            outputs.output_all(step);
-
-            time_outputs += dt_outputs;
-        }
-    }
+    auto simulation = seahowl::core::Simulation();
+    simulation.initialize_from_file(filepath_main.generic_string());
+    simulation.run_all();
 }
 
 /**@brief Driver main function */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@ void run_simulation(int argc, char* argv[]) {
     }
 
     auto simulation = seahowl::core::Simulation();
+    simulation.populate_from_file(filepath_main.generic_string());
     simulation.initialize_from_file(filepath_main.generic_string());
     simulation.run_all();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,6 +91,7 @@ void run_simulation(int argc, char* argv[]) {
     auto outputs_json = json_obj.at("outputs");
     auto dt_outputs = outputs_json.at("dt").get<double>();
     auto output_vtk = outputs_json.at("VTK").get<bool>();
+    auto has_gui = outputs_json.at("gui").get<bool>();
     std::string output_folder = "./output";
     if (outputs_json.contains("folder")) {
         output_folder = outputs_json.at("folder").get<std::string>();
@@ -136,14 +137,15 @@ void run_simulation(int argc, char* argv[]) {
 #endif
 
     std::unique_ptr<VisualizationInSitu> viz_insitu;
+    if (has_gui) {
 #ifdef HAVE_IRRLICHT
-    viz_insitu = std::make_unique<VisualizationInSituIrrlicht>();
+        viz_insitu = std::make_unique<VisualizationInSituIrrlicht>();
 #else
-    viz_insitu = std::make_unique<VisualizationInSitu>();
+        viz_insitu = std::make_unique<VisualizationInSitu>();
 #endif
-
-    viz_insitu->initialize(system_core);
-    viz_insitu->draw();
+        viz_insitu->initialize(system_core);
+        viz_insitu->draw();
+    }
 
     int step = 0;
     output_results(system_core, output_folder);
@@ -184,7 +186,9 @@ void run_simulation(int argc, char* argv[]) {
                 }
             }
 #endif
-            viz_insitu->draw();
+            if (has_gui) {
+                viz_insitu->draw();
+            }
             time_outputs += dt_outputs;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,15 +5,14 @@ using json = nlohmann::json;
     #include <seahowl/io/write_vtk.h>
 #endif
 
-#ifdef HAVE_IRRLICHT
-    #include <chrono_irrlicht/ChVisualSystemIrrlicht.h>
-    #include <seahowl/io/viz_insitu.h>
-#endif
-
 #include <cmath>
 
 #include <seahowl/io/read_json.h>
 #include <seahowl/io/write_csv.h>
+#include <seahowl/io/viz_insitu.h>
+#ifdef HAVE_IRRLICHT
+    #include <seahowl/io/viz_insitu_irrlicht.h>
+#endif
 
 #include <seahowl/core/system.h>
 #include <seahowl/aero/system_aero.h>
@@ -136,21 +135,15 @@ void run_simulation(int argc, char* argv[]) {
     }
 #endif
 
+    std::unique_ptr<VisualizationInSitu> viz_insitu;
 #ifdef HAVE_IRRLICHT
-    auto application = chrono_types::make_shared<chrono::irrlicht::ChVisualSystemIrrlicht>();
-    application->SetWindowTitle("SEAHOWL");
-    application->Initialize();
-    application->SetCameraVertical(chrono::CameraVerticalDir::Z);
-    application->AddLogo(logoname);
-    auto system_chrono = system_elasto.chobj;
-    draw_system_init(system_chrono, application);
+    viz_insitu = std::make_unique<VisualizationInSituIrrlicht>();
+#else
+    viz_insitu = std::make_unique<VisualizationInSitu>();
 #endif
 
-#ifdef HAVE_IRRLICHT
-    application->GetDevice()->run();
-    draw_system(system_chrono, application);
-    application->EndScene();
-#endif
+    viz_insitu->initialize(system_core);
+    viz_insitu->draw();
 
     int step = 0;
     output_results(system_core, output_folder);
@@ -191,11 +184,7 @@ void run_simulation(int argc, char* argv[]) {
                 }
             }
 #endif
-#ifdef HAVE_IRRLICHT
-            application->GetDevice()->run();
-            draw_system(system_chrono, application);
-            application->EndScene();
-#endif
+            viz_insitu->draw();
             time_outputs += dt_outputs;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,12 +120,12 @@ void run_simulation(int argc, char* argv[]) {
     }
 #endif
 
-    std::unique_ptr<VisualizationInSitu> viz_insitu;
+    std::unique_ptr<seahowl::io::VisualizationInSitu> viz_insitu;
     if (has_gui) {
 #ifdef HAVE_IRRLICHT
-        viz_insitu = std::make_unique<VisualizationInSituIrrlicht>();
+        viz_insitu = std::make_unique<seahowl::io::VisualizationInSituIrrlicht>();
 #else
-        viz_insitu = std::make_unique<VisualizationInSitu>();
+        viz_insitu = std::make_unique<seahowl::io::VisualizationInSitu>();
 #endif
         viz_insitu->initialize(system_core);
         viz_insitu->draw();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,18 +1,10 @@
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
-#ifdef HAVE_VTK
-    #include <seahowl/io/write_vtk.h>
-#endif
-
 #include <cmath>
 
 #include <seahowl/io/read_json.h>
-#include <seahowl/io/write_csv.h>
-#include <seahowl/io/viz_insitu.h>
-#ifdef HAVE_IRRLICHT
-    #include <seahowl/io/viz_insitu_irrlicht.h>
-#endif
+#include <seahowl/io/output_manager.h>
 
 #include <seahowl/core/system.h>
 #include <seahowl/aero/system_aero.h>
@@ -32,28 +24,6 @@ namespace fs = std::filesystem;
 using std::filesystem::path;
 using std::filesystem::create_directory;
 using std::filesystem::remove_all;
-
-void output_results(const seahowl::core::System& system_core, const std::string& output_folder) {
-    // output
-    auto& turbine = *system_core.turbines[0];
-
-    // send info to logger
-    std::stringstream output_sstring;
-    output_sstring << "    turbine info -> rpm: " << std::setprecision(3) << turbine.rna.elasto.get_rpm()
-                   << ", power: " << turbine.get_generated_power();
-    int nblades = turbine.rna.blades.size();
-    if (nblades <= 3 && nblades > 0) {
-        for (int ii = 0; ii < turbine.rna.blades.size(); ii++) {
-            output_sstring << ", pitch" << ii + 1 << ": " << turbine.rna.elasto.rotor->blades[ii]->pitch;
-        }
-    } else {
-        output_sstring << ", pitch: " << turbine.rna.elasto.rotor->pitch_collective;
-    }
-    spdlog::info(output_sstring.str());
-
-    // output info in file
-    write_turbine_info_to_csv(output_folder + "/output", system_core);
-}
 
 void run_simulation(int argc, char* argv[]) {
     spdlog::set_level(spdlog::level::info);
@@ -82,24 +52,6 @@ void run_simulation(int argc, char* argv[]) {
     json_file >> json_obj;
     json_file.close();
 
-    // NUMERICS options
-    auto num_json = json_obj.at("numerics");
-    // timestepping
-    auto dt = num_json.at("dt").get<double>();
-    auto t_end = num_json.at("t_end").get<double>();
-    // outputs
-    auto outputs_json = json_obj.at("outputs");
-    auto dt_outputs = outputs_json.at("dt").get<double>();
-    auto output_vtk = outputs_json.at("VTK").get<bool>();
-    auto has_gui = outputs_json.at("gui").get<bool>();
-    std::string output_folder = "./output";
-    if (outputs_json.contains("folder")) {
-        output_folder = outputs_json.at("folder").get<std::string>();
-    }
-
-    // outputs
-    fs::create_directories(output_folder);
-
     // system elasto
     auto system_elasto = seahowl::elasto::SystemElastoChrono();
     // system aero
@@ -113,31 +65,28 @@ void run_simulation(int argc, char* argv[]) {
     initialize_system_from_json(filepath_main.generic_string(), system_core);
     spdlog::debug("Fully initialized system.");
 
-#ifdef HAVE_VTK
-    auto vtk_system = seahowl::io::OutputSystemVTK(system_core, output_folder + "/vtk/");
-    if (output_vtk) {
-        vtk_system.initialize();
+    // NUMERICS options
+    auto num_json = json_obj.at("numerics");
+    // timestepping
+    auto dt = num_json.at("dt").get<double>();
+    auto t_end = num_json.at("t_end").get<double>();
+    // outputs
+    auto outputs_json = json_obj.at("outputs");
+    auto dt_outputs = outputs_json.at("dt").get<double>();
+    std::string output_folder = "./output";
+    if (outputs_json.contains("folder")) {
+        output_folder = outputs_json.at("folder").get<std::string>();
     }
-#endif
 
-    std::unique_ptr<seahowl::io::VisualizationInSitu> viz_insitu;
-    if (has_gui) {
-#ifdef HAVE_IRRLICHT
-        viz_insitu = std::make_unique<seahowl::io::VisualizationInSituIrrlicht>();
-#else
-        viz_insitu = std::make_unique<seahowl::io::VisualizationInSitu>();
-#endif
-        viz_insitu->initialize(system_core);
-        viz_insitu->draw();
-    }
+    // outputs
+    fs::create_directories(output_folder);
+    auto outputs = seahowl::io::OutputManager(system_core, output_folder);
+    outputs.has_vtk = outputs_json.at("VTK").get<bool>();
+    outputs.has_gui = outputs_json.at("gui").get<bool>();
+    outputs.initialize();
 
     int step = 0;
-    output_results(system_core, output_folder);
-#ifdef HAVE_VTK
-    if (output_vtk) {
-        vtk_system.write(step);
-    }
-#endif
+    // outputs.output_all(step);
 
     double time_outputs = dt_outputs;
     spdlog::info("**************************************************************");
@@ -160,15 +109,9 @@ void run_simulation(int argc, char* argv[]) {
         // output
         if (system_core.get_time() >= (time_outputs - 1e-6)) {
             spdlog::info("time: {:.6}s, step: {}, stopwatch: {:.3}s", system_core.get_time(), step, sw_total);
-            output_results(system_core, output_folder);
-#ifdef HAVE_VTK
-            if (output_vtk) {
-                vtk_system.write(step);
-            }
-#endif
-            if (has_gui) {
-                viz_insitu->draw();
-            }
+
+            outputs.output_all(step);
+
             time_outputs += dt_outputs;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,25 +114,9 @@ void run_simulation(int argc, char* argv[]) {
     spdlog::debug("Fully initialized system.");
 
 #ifdef HAVE_VTK
-    std::vector<OutputMeshVTK> vtk_outputs;
+    auto vtk_system = seahowl::io::OutputSystemVTK(system_core, output_folder + "/vtk/");
     if (output_vtk) {
-        for (auto [turbine_ptr, idx_turbine] = std::tuple{system_core.turbines.begin(), 0};
-             turbine_ptr != system_core.turbines.end(); turbine_ptr++, idx_turbine++) {
-            auto& turbine = *turbine_ptr;
-            auto output_folder_vtk = output_folder + "/vtk";
-            create_directory(output_folder_vtk);
-            for (auto [blade_ptr, idx_blade] = std::tuple{turbine->rna.blades.begin(), 0};
-                 blade_ptr != turbine->rna.blades.end(); blade_ptr++, idx_blade++) {
-                auto& blade = *blade_ptr;
-                auto& post_blade =
-                    vtk_outputs.emplace_back(dynamic_cast<seahowl::elasto::BladeElastoFEA&>(blade->elasto));
-                post_blade.initialize((output_folder_vtk + "/turbine" + std::to_string(idx_turbine) + "_blade" +
-                                       std::to_string(idx_blade))
-                                          .c_str());
-            }
-            auto& post_tower = vtk_outputs.emplace_back(turbine->tower.elasto);
-            post_tower.initialize((output_folder_vtk + "/turbine" + std::to_string(idx_turbine) + "_tower").c_str());
-        }
+        vtk_system.initialize();
     }
 #endif
 
@@ -151,9 +135,7 @@ void run_simulation(int argc, char* argv[]) {
     output_results(system_core, output_folder);
 #ifdef HAVE_VTK
     if (output_vtk) {
-        for (auto const& vtk_output : vtk_outputs) {
-            vtk_output.write(system_elasto.get_time(), step);
-        }
+        vtk_system.write(step);
     }
 #endif
 
@@ -181,9 +163,7 @@ void run_simulation(int argc, char* argv[]) {
             output_results(system_core, output_folder);
 #ifdef HAVE_VTK
             if (output_vtk) {
-                for (auto const& vtk_output : vtk_outputs) {
-                    vtk_output.write(system_core.get_time(), step);
-                }
+                vtk_system.write(step);
             }
 #endif
             if (has_gui) {

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -15,17 +15,11 @@
     #include <windows.h>
 #endif
 
-seahowl::servo::ControllerDISCON::ControllerDISCON(std::string infile, std::string libfile_in) {
+seahowl::servo::ControllerDISCON::ControllerDISCON(const std::string& infile, const std::string& libfile)
+    : libfile(libfile) {
     has_pitch_control = true;
     has_torque_control = true;
 
-    if (!std::filesystem::exists(std::filesystem::path(libfile_in))) {
-        throw std::runtime_error("Dynamic library path for DISCON routine does not exist: " + libfile_in);
-    } else if (!std::filesystem::exists(std::filesystem::path(infile))) {
-        throw std::runtime_error("Input file path for DISCON routine does not exist: " + infile);
-    }
-
-    libfile = libfile_in;
     pImpl.ResetAll();
     pImpl.SetINFILE(infile);
     pImpl.SetOUTNAME(libfile + ".dbg");
@@ -340,86 +334,25 @@ static std::vector<discon::ParamDef> ArrayInfo{
     {164, "in", 'R', "Yaw bearing angular acceleration", "rad/s2"}};
 }  // namespace discon
 
-/*
-
-Record
-number
-Data
-flow8
-Data
-type
-9
-Description
-See
-note(
-s)
-Units
-1 in I See Section A.2 -
-
-
-
-
-*/
-
-/*
-
-CHARACTER(KIND=C_CHAR),         INTENT(IN   )   :: accINFILE(NINT(avrSWAP(50)))     ! The name of the parameter
-input file CHARACTER(KIND=C_CHAR),         INTENT(IN   )   :: avcOUTNAME(NINT(avrSWAP(51)))    ! OUTNAME (Simulation
-RootName) CHARACTER(KIND=C_CHAR),         INTENT(INOUT)   :: avcMSG(NINT(avrSWAP(49)))        ! MESSAGE (Message
-from DLL to simulation code [ErrMsg])  The message which will be displayed by the calling program if aviFAIL <> 0.
-CHARACTER(SIZE(avcOUTNAME)-1)                   :: RootName                         ! a Fortran version of the input
-C string (not considered an array here)    [subtract 1 for the C null-character] CHARACTER(SIZE(avcMSG)-1) :: ErrMsg
-
-
-    LocalVar%GenSpeed           = avrSWAP(20)
-    LocalVar%RotSpeed           = avrSWAP(21)
-    LocalVar%GenTqMeas          = avrSWAP(23)
-    LocalVar%Y_M                = avrSWAP(24)
-    LocalVar%HorWindV           = avrSWAP(27)
-    LocalVar%rootMOOP(1)        = avrSWAP(30)
-    LocalVar%rootMOOP(2)        = avrSWAP(31)
-    LocalVar%rootMOOP(3)        = avrSWAP(32)
-    LocalVar%FA_Acc             = avrSWAP(53)
-    LocalVar%NacIMU_FA_Acc      = avrSWAP(83)
-    LocalVar%Azimuth            = avrSWAP(60)
-    LocalVar%NumBl              = NINT(avrSWAP(61))
-
-    ! --- NJA: usually feedback back the previous pitch command helps for numerical stability, sometimes it does
-not... IF (LocalVar%iStatus == 0) THEN LocalVar%BlPitch(1) = avrSWAP(4) LocalVar%BlPitch(2) = avrSWAP(33)
-        LocalVar%BlPitch(3) = avrSWAP(34)
-    ELSE
-        LocalVar%BlPitch(1) = LocalVar%PitCom(1)
-        LocalVar%BlPitch(2) = LocalVar%PitCom(2)
-        LocalVar%BlPitch(3) = LocalVar%PitCom(3)
-    ENDIF
-
-
-    ! Set unused outputs to zero (See Appendix A of Bladed User's Guide):
-    avrSWAP(35) = 1.0 ! Generator contactor status: 1=main (high speed) variable-speed generator
-    avrSWAP(36) = 0.0 ! Shaft brake status: 0=off
-    avrSWAP(41) = 0.0 ! Demanded yaw actuator torque
-    avrSWAP(46) = 0.0 ! Demanded pitch rate (Collective pitch)
-    avrSWAP(55) = 0.0 ! Pitch override: 0=yes
-    avrSWAP(56) = 0.0 ! Torque override: 0=yes
-    avrSWAP(65) = 0.0 ! Number of variables returned for logging
-    avrSWAP(72) = 0.0 ! Generator start-up resistance
-    avrSWAP(79) = 0.0 ! Request for loads: 0=none
-    avrSWAP(80) = 0.0 ! Variable slip current status
-    avrSWAP(81) = 0.0 ! Variable slip current demand
-
-
-    */
-
-void seahowl::servo::DisconController::Init(const std::string& libfile) {
-    // Load dynamic library and point to DISCON routine
+void seahowl::servo::DisconInterface::Init(const std::string& libfile) {
+    if (libfile != "") {
+        if (!std::filesystem::exists(std::filesystem::path(libfile)) && libfile != "") {
+            throw std::runtime_error("DISCON: dynamic library path for DISCON routine does not exist: " + libfile +
+                                     ".");
+        }
+        has_dll = true;
+        // Load dynamic library and point to DISCON routine
 #ifdef __unix__
-    void* handler = dlopen(libfile.c_str(), RTLD_LAZY);
-    DISCON = (DISCON_routine)dlsym(handler, "DISCON");
+        void* handler = dlopen(libfile.c_str(), RTLD_LAZY);
+        DISCON = (DISCON_routine)dlsym(handler, "DISCON");
 #endif
 #ifdef _WIN32
-    HMODULE handler = LoadLibrary(libfile.c_str());
-    DISCON = (DISCON_routine)GetProcAddress(handler, "DISCON");
+        HMODULE handler = LoadLibrary(libfile.c_str());
+        DISCON = (DISCON_routine)GetProcAddress(handler, "DISCON");
 #endif
+    } else {
+        spdlog::warn("DISCON: no dynamic library transmitted to DISCON interface.");
+    }
 
     avrSWAP[58] = 500;  // Buffer chaar size
     avrSWAP[50] = 500;  // self.char_buffer
@@ -433,13 +366,13 @@ void seahowl::servo::DisconController::Init(const std::string& libfile) {
     SetAvrSWAP(1, 1.0);  // iStatus : standard  step (not the first, which was already just called)
 };
 
-void seahowl::servo::DisconController::ResetAll() {
+void seahowl::servo::DisconInterface::ResetAll() {
     for (auto& v : avrSWAP) {
         v = 0.0;
     }
 }
 
-void seahowl::servo::DisconController::PrintAllOut(std::ostream& ssout) const {
+void seahowl::servo::DisconInterface::PrintAllOut(std::ostream& ssout) const {
     for (int i = 1; i < 150; ++i) {
         auto& ap = discon::ArrayInfo.at(i);
         ///@todo Better to use GetAvrSWAP but without log
@@ -450,25 +383,30 @@ void seahowl::servo::DisconController::PrintAllOut(std::ostream& ssout) const {
     }
 }
 
-void seahowl::servo::DisconController::SetINFILE(std::string name) {
-    spdlog::debug("Set DISCON INFILE: '" + name + "'\n");
+void seahowl::servo::DisconInterface::SetINFILE(const std::string& name) {
+    spdlog::debug("Set DISCON INFILE: " + name + ".");
+    if (name == "") {
+        spdlog::warn("DISCON: no input file transmitted to DISCON interface.");
+    } else if (!std::filesystem::exists(std::filesystem::path(name))) {
+        throw std::runtime_error("DISCON: input file path for DISCON routine does not exist: " + name + ".");
+    }
     strcpy(accINFILE, name.c_str());
     SetAvrSWAP(50, name.length());
 }
 
-void seahowl::servo::DisconController::SetOUTNAME(std::string name) {
-    spdlog::debug("Set DISCON OUTNAME:'" + name + "'\n");
+void seahowl::servo::DisconInterface::SetOUTNAME(const std::string& name) {
+    spdlog::debug("Set DISCON OUTNAME:'" + name + ".");
     strcpy(avcOUTNAME, name.c_str());
     SetAvrSWAP(51, name.length());
 }
 
-void seahowl::servo::DisconController::SetPitch(double pitch_angle) {
+void seahowl::servo::DisconInterface::SetPitch(double pitch_angle) {
     SetAvrSWAP(4, static_cast<float>(pitch_angle));
     SetAvrSWAP(33, static_cast<float>(pitch_angle));
     SetAvrSWAP(34, static_cast<float>(pitch_angle));
 }
 
-void seahowl::servo::DisconController::SetPitchBlade(int index_blade, double pitch_angle) {
+void seahowl::servo::DisconInterface::SetPitchBlade(int index_blade, double pitch_angle) {
     switch (index_blade) {
         case 0:
             SetAvrSWAP(4, static_cast<float>(pitch_angle));
@@ -484,7 +422,7 @@ void seahowl::servo::DisconController::SetPitchBlade(int index_blade, double pit
     }
 }
 
-void seahowl::servo::DisconController::SetRootMomentBlade(int index_blade, double flap, double edge) {
+void seahowl::servo::DisconInterface::SetRootMomentBlade(int index_blade, double flap, double edge) {
     switch (index_blade) {
         case 0:
             SetAvrSWAP(30, static_cast<float>(flap));
@@ -503,56 +441,56 @@ void seahowl::servo::DisconController::SetRootMomentBlade(int index_blade, doubl
     }
 }
 
-void seahowl::servo::DisconController::SetTowerTopAcceleration(double foreaft, double sideside) {
+void seahowl::servo::DisconInterface::SetTowerTopAcceleration(double foreaft, double sideside) {
     SetAvrSWAP(53, static_cast<float>(foreaft));
     SetAvrSWAP(54, static_cast<float>(sideside));
 };
 
-void seahowl::servo::DisconController::SetNacelleRotationalAcceleration(double roll, double pitch, double yaw) {
+void seahowl::servo::DisconInterface::SetNacelleRotationalAcceleration(double roll, double pitch, double yaw) {
     SetAvrSWAP(82, static_cast<float>(roll));
     SetAvrSWAP(83, static_cast<float>(pitch));
     SetAvrSWAP(84, static_cast<float>(yaw));
 };
 
-void seahowl::servo::DisconController::SetWindSpeed(double ws) {
+void seahowl::servo::DisconInterface::SetWindSpeed(double ws) {
     SetAvrSWAP(27, static_cast<float>(ws));
 }
 
-void seahowl::servo::DisconController::SetRotorSpeed(double omega) {
+void seahowl::servo::DisconInterface::SetRotorSpeed(double omega) {
     SetAvrSWAP(21, omega);
 }
 
-void seahowl::servo::DisconController::SetGeneratorSpeed(double omega) {
+void seahowl::servo::DisconInterface::SetGeneratorSpeed(double omega) {
     SetAvrSWAP(20, omega);
 }
 
-void seahowl::servo::DisconController::SetTime(double time) {
+void seahowl::servo::DisconInterface::SetTime(double time) {
     SetAvrSWAP(2, time);
 }
 
-void seahowl::servo::DisconController::SetDeltaTime(double dt) {
+void seahowl::servo::DisconInterface::SetDeltaTime(double dt) {
     SetAvrSWAP(3, dt);
 }
 
-void seahowl::servo::DisconController::SetRotorAzimuth(double azimuth) {
+void seahowl::servo::DisconInterface::SetRotorAzimuth(double azimuth) {
     SetAvrSWAP(60, azimuth);
 }
 
-void seahowl::servo::DisconController::SetGeneratedPower(double power) {
+void seahowl::servo::DisconInterface::SetGeneratedPower(double power) {
     SetAvrSWAP(15, power);
 }
 
-void seahowl::servo::DisconController::SetShaftPower(double power) {
+void seahowl::servo::DisconInterface::SetShaftPower(double power) {
     SetAvrSWAP(14, power);
 }
 
-void seahowl::servo::DisconController::SetNumberOfBlades(size_t nblades) {
+void seahowl::servo::DisconInterface::SetNumberOfBlades(size_t nblades) {
     SetAvrSWAP(61, nblades);
 }
 
-void seahowl::servo::DisconController::SetAvrSWAP(size_t index, float value) {
+void seahowl::servo::DisconInterface::SetAvrSWAP(size_t index, float value) {
     if (index < 1 || index > MAX_SWAP) {
-        throw std::runtime_error("DISCON: avrSWAP index out of bounds");
+        throw std::runtime_error("DISCON: avrSWAP index out of bounds.");
     }
 
     auto& ap = discon::ArrayInfo.at(index);
@@ -569,14 +507,14 @@ void seahowl::servo::DisconController::SetAvrSWAP(size_t index, float value) {
     avrSWAP[ap.index - 1] = value;
 }
 
-void seahowl::servo::DisconController::SetAvrSWAP(size_t index, size_t value) {
+void seahowl::servo::DisconInterface::SetAvrSWAP(size_t index, size_t value) {
     SetAvrSWAP(index, static_cast<float>(value));
 }
-void seahowl::servo::DisconController::SetAvrSWAP(size_t index, double value) {
+void seahowl::servo::DisconInterface::SetAvrSWAP(size_t index, double value) {
     SetAvrSWAP(index, static_cast<float>(value));
 }
 
-float seahowl::servo::DisconController::GetAvrSWAP(size_t index) const {
+float seahowl::servo::DisconInterface::GetAvrSWAP(size_t index) const {
     if (index < 1 || index > MAX_SWAP) {
         throw std::runtime_error("DISCON: avrSWAP index out of bounds");
     }
@@ -596,6 +534,8 @@ float seahowl::servo::DisconController::GetAvrSWAP(size_t index) const {
     return value;
 }
 
-void seahowl::servo::DisconController::Call() {
-    DISCON(avrSWAP, &aviFAIL, accINFILE, avcOUTNAME, avcMSG);
+void seahowl::servo::DisconInterface::Call() {
+    if (has_dll) {
+        DISCON(avrSWAP, &aviFAIL, accINFILE, avcOUTNAME, avcMSG);
+    }
 }

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -514,6 +514,21 @@ void seahowl::servo::DisconInterface::SetAvrSWAP(size_t index, double value) {
     SetAvrSWAP(index, static_cast<float>(value));
 }
 
+void seahowl::servo::DisconInterface::SetForcedAvrSWAP(size_t index, double value) {
+    if (index < 1 || index > MAX_SWAP) {
+        throw std::runtime_error("DISCON: avrSWAP index out of bounds.");
+    }
+
+    auto& ap = discon::ArrayInfo.at(index);
+    if (ap.index != index) {
+        spdlog::warn("DISCON: mismatch array index {} and record number {}.", index, ap.index);
+    }
+
+    spdlog::trace("DISCON: set [{}] {}: {} {}.\n", index, ap.description, value, ap.unit);
+
+    avrSWAP[ap.index - 1] = static_cast<float>(value);
+}
+
 float seahowl::servo::DisconInterface::GetAvrSWAP(size_t index) const {
     if (index < 1 || index > MAX_SWAP) {
         throw std::runtime_error("DISCON: avrSWAP index out of bounds");

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -549,6 +549,22 @@ float seahowl::servo::DisconInterface::GetAvrSWAP(size_t index) const {
     return value;
 }
 
+float seahowl::servo::DisconInterface::GetForcedAvrSWAP(size_t index) const {
+    if (index < 1 || index > MAX_SWAP) {
+        throw std::runtime_error("DISCON: avrSWAP index out of bounds");
+    }
+
+    auto& ap = discon::ArrayInfo.at(index);
+    if (ap.index != index) {
+        spdlog::warn("DISCON: mismatch array index {} and record number {}.", index, ap.index);
+    }
+
+    auto& value = avrSWAP[index - 1];
+    spdlog::trace("DISCON: get [{}] {}: {} {}.", index, ap.description, value, ap.unit);
+
+    return value;
+}
+
 void seahowl::servo::DisconInterface::Call() {
     if (has_dll) {
         DISCON(avrSWAP, &aviFAIL, accINFILE, avcOUTNAME, avcMSG);

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -398,10 +398,10 @@ TEST(test_turbine, rpm_initial_pitch) {
     double time = 0.0;
     turbine.rna.elasto.rotor->apply_collective_pitch_increment(initial_pitch);
     turbine.initialize(time, dt);
-    // while (application.GetDevice()->run()) {
     while (time < 50) {
         // prestep
         // compute forces
+        turbine.apply_control(time, dt);
         turbine.aero.compute_aero_loads(wind_model, time);
         // prestep (accumulates loads from aero to elasto)
         turbine.prestep(time, dt);
@@ -457,10 +457,10 @@ TEST(test_turbine, rpm_initial_pitch_fpm) {
     double time = 0.0;
     turbine.rna.elasto.rotor->apply_collective_pitch_increment(initial_pitch);
     turbine.initialize(time, dt);
-    // while (application.GetDevice()->run()) {
     while (time < 50) {
         // prestep
         // compute forces
+        turbine.apply_control(time, dt);
         turbine.aero.compute_aero_loads(wind_model, time);
         // prestep (accumulates loads from aero to elasto)
         turbine.prestep(time, dt);
@@ -516,10 +516,10 @@ TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
     double time = 0.0;
     turbine.rna.elasto.rotor->apply_collective_pitch_increment(initial_pitch);
     turbine.initialize(time, dt);
-    // while (application.GetDevice()->run()) {
     while (time < 50) {
         // prestep
         // compute forces
+        turbine.apply_control(time, dt);
         turbine.aero.compute_aero_loads(wind_model, time);
         // prestep (accumulates loads from aero to elasto)
         turbine.prestep(time, dt);
@@ -578,10 +578,10 @@ TEST(test_turbine, controller_target_rpm) {
     double time = 0.0;
     turbine.rna.elasto.rotor->apply_collective_pitch_increment(initial_pitch);
     turbine.initialize(time, dt);
-    // while (application.GetDevice()->run()) {
     while (time < 100) {
         // prestep
         // compute forces
+        turbine.apply_control(time, dt);
         turbine.aero.compute_aero_loads(wind_model, time);
         // prestep (accumulates loads from aero to elasto)
         turbine.prestep(time, dt);
@@ -642,10 +642,10 @@ TEST(test_turbine, actuator_disk) {
     double time = 0.0;
     turbine.rna.elasto.rotor->apply_collective_pitch_increment(initial_pitch);
     turbine.initialize(time, dt);
-    // while (application.GetDevice()->run()) {
     while (time < 100) {
         // prestep
         // compute forces
+        turbine.apply_control(time, dt);
         turbine.aero.compute_aero_loads(wind_model, time);
         // prestep (accumulates loads from aero to elasto)
         turbine.prestep(time, dt);
@@ -670,6 +670,7 @@ TEST(test_turbine, actuator_disk) {
     while (time < 200) {
         // prestep
         // compute forces
+        turbine.apply_control(time, dt);
         turbine.aero.compute_aero_loads(wind_model, time);
         // prestep (accumulates loads from aero to elasto)
         turbine.prestep(time, dt);
@@ -729,10 +730,10 @@ TEST(test_aerodyn, rpm_initial_pitch) {
     double time = 0.0;
     turbine.rna.elasto.rotor->apply_collective_pitch_increment(initial_pitch);
     turbine.initialize(time, dt);
-    // while (application.GetDevice()->run()) {
     while (time < 50) {
         // prestep
         // compute forces
+        turbine.apply_control(time, dt);
         turbine.aero.compute_aero_loads(wind_model, time);
         // prestep (accumulates loads from aero to elasto)
         turbine.prestep(time, dt);
@@ -863,10 +864,10 @@ TEST(test_inflowwind, rpm_initial_pitch) {
     double time = 0.0;
     turbine.rna.elasto.rotor->apply_collective_pitch_increment(initial_pitch);
     turbine.initialize(time, dt);
-    // while (application.GetDevice()->run()) {
     while (time < 50) {
         // prestep
         // compute forces
+        turbine.apply_control(time, dt);
         turbine.aero.compute_aero_loads(wind_model, time);
         // prestep (accumulates loads from aero to elasto)
         turbine.prestep(time, dt);


### PR DESCRIPTION
Several changes are introduced here for helping managing simulation workflow with simple API calls and to allow for using controller through Simulink or equivalent. In this PR:
- New classes for:
  - managing simulation logic
  - managing in situ visualization
  - managing VTK otputs
  - managing all otputs (in situ, VTK, csv)
- Allow for DISCON controller without inut file (DLL only) or without DLL (interface only)
- Controller logic applied in prestep (necessary for applying external controller commands such as in Simulink)
- Allow for forcing AvrSWAP in DISCON interface through specific function