### PR TITLE
Updates for sims involving cables + robustness improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ source_group(commons FILES ${SEAHOWL_COMMONS_SOURCES} ${SEAHOWL_COMMONS_HEADERS}
 # core
 set(SEAHOWL_CORE_SOURCES
     src/core/reference_point.cpp
+    src/core/component.cpp
     src/core/rotor.cpp
     src/core/blade.cpp
     src/core/tower.cpp

--- a/examples/python/ex_main.py
+++ b/examples/python/ex_main.py
@@ -1,0 +1,14 @@
+import seahowl
+
+# options
+main_filepath = "../../data/IEA15MW/main.json"  # change to actual filepath
+seahowl.set_log_level_global("info")  # log levels: critical, info, debug, warn, trace
+
+# make simulation object
+simulation = seahowl.core.Simulation()
+simulation.populate_from_file(main_filepath)
+simulation.initialize_from_file(main_filepath)
+
+# simulation loop
+while simulation.system_core.get_time() < simulation.duration:
+    simulation.step()

--- a/examples/python/ex_simulation.py
+++ b/examples/python/ex_simulation.py
@@ -1,0 +1,44 @@
+import seahowl
+
+# options
+turbine_filepath = "../../data/IEA15MW/turbine.json"  # change to actual filepath
+output_folder = "./output"
+seahowl.set_log_level_global("info")  # log levels: critical, info, debug, warn, trace
+
+# make simulation object
+simulation = seahowl.core.Simulation()
+simulation.dt = 0.05
+simulation.duration = 200.0
+simulation.dt_output = 0.0
+simulation.outputs.has_gui = True
+simulation.outputs.has_vtk = False
+simulation.outputs.has_csv = True
+simulation.outputs.set_output_folder(output_folder)
+
+# add turbine to system
+system_core = simulation.system_core
+seahowl.io.add_turbine_to_system_from_json(turbine_filepath, system_core, output_folder)
+turbine = system_core.turbines[0]
+
+# fix tower bottom nodes and statics step
+system_elasto = system_core.elasto
+turbine.elasto.tower.nodes[0].set_fixed(True)
+system_elasto.do_statics(True, 10)
+
+# add fluid model
+wind_model = seahowl.env.ConstantWind()
+system_core.fluid_model = wind_model
+wind_model.set_wind_velocity(
+    [12.0, 0.0, 0.0],
+)
+wind_model.shear_coefficient = 0.12
+hub_pos = turbine.elasto.rna.rotor.body_hub.get_position()
+wind_model.reference_height = hub_pos[2]  # put reference height at hub height
+wind_model.air_density = 1.225
+
+# initialize simulation
+simulation.initialize()
+
+# simulation loop
+while simulation.system_core.get_time() < simulation.duration:
+    simulation.step()

--- a/examples/python/ex_system.py
+++ b/examples/python/ex_system.py
@@ -1,4 +1,4 @@
-import pyseahowl
+import seahowl
 
 # options
 filepath = "../../data/IEA15MW/main.json"  # change to actual filepath
@@ -8,10 +8,10 @@ t_end = 200.0
 t_output_next = 0.0
 
 # get system
-system_elasto = pyseahowl.elasto.SystemElastoChrono()
-system_aero = pyseahowl.aero.SystemAero()
-system_core = pyseahowl.core.System(system_elasto, system_aero)
-pyseahowl.io.populate_system_from_json(filepath, system_core)
+system_elasto = seahowl.elasto.SystemElastoChrono()
+system_aero = seahowl.aero.SystemAero()
+system_core = seahowl.core.System(system_elasto, system_aero)
+seahowl.io.populate_system_from_json(filepath, system_core)
 
 # fix tower bottom nodes
 for turbine in system_core.turbines:

--- a/include/seahowl/core/blade.h
+++ b/include/seahowl/core/blade.h
@@ -52,16 +52,6 @@ class Blade : public ComponentDynamic {
     Blade(seahowl::elasto::BladeElasto& elasto, seahowl::aero::BladeAero& aero);
 
     /**
-     * @brief Initialize blade, called before starting the simulation.
-     *
-     * Runs the preset and poststep once to make elasto and aero components match.
-     *
-     * @param[in] time Time of the simulation (usually 0 at init).
-     * @param[in] dt Time step length.
-     */
-    void initialize(double time, double dt) override;
-
-    /**
      * @brief Prestep for blade, called before elastodynamic stepping.
      *
      * Updates aero loads on elasto component.
@@ -114,6 +104,16 @@ class Blade : public ComponentDynamic {
     void update_loads_elasto();
 
   private:
+    /**
+     * @brief Initialize blade, called before starting the simulation.
+     *
+     * Runs the preset and poststep once to make elasto and aero components match.
+     *
+     * @param[in] time Time of the simulation (usually 0 at init).
+     * @param[in] dt Time step length.
+     */
+    void initialize_this(double time, double dt) override;
+
     /**
      * @brief Computes the aero->elasto mapping that is used when accumulating aero loads on elasto component.
      */

--- a/include/seahowl/core/component.h
+++ b/include/seahowl/core/component.h
@@ -18,7 +18,7 @@ class ComponentDynamic {
      * @param[in] time Time of the simulation (usually 0 at init).
      * @param[in] dt Time step length.
      */
-    virtual void initialize(double time, double dt) = 0;
+    void initialize(double time, double dt);
 
     /**
      * @brief Prestep for component, called before elastodynamic stepping.
@@ -35,6 +35,12 @@ class ComponentDynamic {
      * @param[in] dt Time step length.
      */
     virtual void poststep(double time, double dt) = 0;
+
+  protected:
+    bool is_initialized = false;
+
+  private:
+    virtual void initialize_this(double time, double dt) = 0;
 };
 
 }  // namespace core

--- a/include/seahowl/core/rotor.h
+++ b/include/seahowl/core/rotor.h
@@ -47,16 +47,6 @@ class RotorNacelleAssembly : public ComponentDynamic {
                          seahowl::aero::RotorNacelleAssemblyAero& aero);
 
     /**
-     * @brief Initialize RNA, called before starting the simulation.
-     *
-     * Runs preset and poststep once to make elasto and aero components match.
-     *
-     * @param[in] time Time of the simulation (usually 0 at init).
-     * @param[in] dt Time step length.
-     */
-    void initialize(double time, double dt) override;
-
-    /**
      * @brief Prestep for RNA, called before elastodynamic stepping.
      *
      * Calls prestep for each blade.
@@ -85,6 +75,17 @@ class RotorNacelleAssembly : public ComponentDynamic {
      * @brief Builds the RNA and blades associated to it.
      */
     void build();
+
+  private:
+    /**
+     * @brief Initialize RNA, called before starting the simulation.
+     *
+     * Runs preset and poststep once to make elasto and aero components match.
+     *
+     * @param[in] time Time of the simulation (usually 0 at init).
+     * @param[in] dt Time step length.
+     */
+    void initialize_this(double time, double dt) override;
 };
 
 }  // namespace core

--- a/include/seahowl/core/simulation.h
+++ b/include/seahowl/core/simulation.h
@@ -19,11 +19,13 @@ class Simulation {
     double dt = 0.025;
     double dt_output = 0.;
     double duration = 1000.0;
+    bool is_initialized = false;
 
     Simulation();
 
     void populate_from_file(const std::string& filepath);
     void initialize_from_file(const std::string& filepath);
+    void initialize();
     void step();
     void run_all();
 

--- a/include/seahowl/core/system.h
+++ b/include/seahowl/core/system.h
@@ -76,16 +76,6 @@ class System : public ComponentDynamic {
     virtual void poststep(double time, double dt) override;
 
     /**
-     * @brief Assembles the turbine (elasto part).*
-     *
-     * Calls assemble for each of the components of the turbine.
-     *
-     * @param[out] system System on which to add bodies, links, etc.
-     * @param[out] mesh Mesh on which to add nodes and elements.
-     */
-    void assemble();
-
-    /**
      * @brief Returns time of simulation.
      */
     double get_time() const;

--- a/include/seahowl/core/system.h
+++ b/include/seahowl/core/system.h
@@ -53,14 +53,6 @@ class System : public ComponentDynamic {
     System(seahowl::elasto::SystemElasto& elasto, seahowl::aero::SystemAero& aero);
 
     /**
-     * @brief Initialize system.
-     *
-     * @param[in] time Time of the simulation (usually 0 at init).
-     * @param[in] dt Time step length.
-     */
-    virtual void initialize(double time, double dt) override;
-
-    /**
      * @brief Prestep for system, called before elastodynamic stepping.
      *
      * @param[in] time Time of the simulation.
@@ -129,6 +121,15 @@ class System : public ComponentDynamic {
      * @param[in] turbine Turbine to add to system.
      */
     void add_turbine(std::shared_ptr<seahowl::core::Turbine> turbine);
+
+  private:
+    /**
+     * @brief Initialize system.
+     *
+     * @param[in] time Time of the simulation (usually 0 at init).
+     * @param[in] dt Time step length.
+     */
+    virtual void initialize_this(double time, double dt) override;
 };
 }  // namespace core
 }  // namespace seahowl

--- a/include/seahowl/core/tower.h
+++ b/include/seahowl/core/tower.h
@@ -52,16 +52,6 @@ class Tower : public ComponentDynamic {
     Tower(seahowl::elasto::TowerElasto& elasto, seahowl::aero::TowerAero& aero);
 
     /**
-     * @brief Initialize tower, called before starting the simulation.
-     *
-     * Runs the preset and poststep once to make elasto and aero components match.
-     *
-     * @param[in] time Time of the simulation (usually 0 at init).
-     * @param[in] dt Time step length.
-     */
-    void initialize(double time, double dt) override;
-
-    /**
      * @brief Prestep for tower, called before elastodynamic stepping.
      *
      * Updates aero loads on elasto component.
@@ -114,6 +104,16 @@ class Tower : public ComponentDynamic {
     void update_loads_elasto();
 
   private:
+    /**
+     * @brief Initialize tower, called before starting the simulation.
+     *
+     * Runs the preset and poststep once to make elasto and aero components match.
+     *
+     * @param[in] time Time of the simulation (usually 0 at init).
+     * @param[in] dt Time step length.
+     */
+    void initialize_this(double time, double dt) override;
+
     /**
      * @brief Computes the aero->elasto mapping that is used when accumulating aero loads on elasto component.
      */

--- a/include/seahowl/core/turbine.h
+++ b/include/seahowl/core/turbine.h
@@ -74,16 +74,6 @@ class Turbine : public ComponentDynamic {
     void apply_control(double time, double dt);
 
     /**
-     * @brief Initialize turbine, called before starting the simulation.
-     *
-     * Calls init for each of its components.
-     *
-     * @param[in] time Time of the simulation (usually 0 at init).
-     * @param[in] dt Time step length.
-     */
-    virtual void initialize(double time, double dt) override;
-
-    /**
      * @brief Prestep for turbine, called before elastodynamic stepping.
      *
      * Calls prestep on each of the components of the turbine.
@@ -156,6 +146,17 @@ class Turbine : public ComponentDynamic {
      * @param[in] time Time of simulation.
      */
     virtual void apply_soil_model(seahowl::env::SoilModel& soil_model, double time);
+
+  protected:
+    /**
+     * @brief Initialize turbine, called before starting the simulation.
+     *
+     * Calls init for each of its components.
+     *
+     * @param[in] time Time of the simulation (usually 0 at init).
+     * @param[in] dt Time step length.
+     */
+    virtual void initialize_this(double time, double dt) override;
 };
 
 }  // namespace core

--- a/include/seahowl/core/turbine_floating.h
+++ b/include/seahowl/core/turbine_floating.h
@@ -32,16 +32,6 @@ class TurbineFloating : public Turbine {
     TurbineFloating(seahowl::elasto::TurbineFloatingElasto& elasto, seahowl::aero::TurbineAero& aero);
 
     /**
-     * @brief Initialize turbine, called before starting the simulation.
-     *
-     * Calls init for each of its components.
-     *
-     * @param[in] time Time of the simulation (usually 0 at init).
-     * @param[in] dt Time step length.
-     */
-    virtual void initialize(double time, double dt) override;
-
-    /**
      * @brief Prestep for turbine, called before elastodynamic stepping.
      *
      * Calls prestep on each of the components of the turbine.
@@ -84,6 +74,17 @@ class TurbineFloating : public Turbine {
      * @param[in] time Time of simulation.
      */
     virtual void apply_soil_model(seahowl::env::SoilModel& soil_model, double time) override;
+
+  private:
+    /**
+     * @brief Initialize turbine, called before starting the simulation.
+     *
+     * Calls init for each of its components.
+     *
+     * @param[in] time Time of the simulation (usually 0 at init).
+     * @param[in] dt Time step length.
+     */
+    virtual void initialize_this(double time, double dt) override;
 };
 
 }  // namespace core

--- a/include/seahowl/elasto/blade_elasto.h
+++ b/include/seahowl/elasto/blade_elasto.h
@@ -27,8 +27,6 @@ class BladeElasto : public virtual ComponentElasto {
 
     BladeElasto();
 
-    virtual void assemble(SystemElasto& system) override;
-
     /**
      * @brief Applies pitch increment to the blade (i.e. rotates the blade around its longitudinal axis).
      *
@@ -59,6 +57,8 @@ class BladeElasto : public virtual ComponentElasto {
   protected:
     /** @brief Whether the blade is mounted (e.g. on a rotor) or not. */
     bool is_mounted = false;
+
+    virtual void assemble_this(SystemElasto& system) override;
 };
 
 /**
@@ -82,7 +82,6 @@ class BladeElastoFEA : public BladeElasto, public ComponentElastoFEA {
     BladeElastoFEA();
 
     virtual void build() override;
-    virtual void assemble(SystemElasto& system) override;
     using ComponentElastoFEA::rotate;
     using ComponentElastoFEA::translate;
     using ComponentElastoFEA::get_mass;
@@ -104,6 +103,8 @@ class BladeElastoFEA : public BladeElasto, public ComponentElastoFEA {
     virtual void attach_root_to_body(const BodyElasto& body) override;
 
   private:
+    virtual void assemble_this(SystemElasto& system) override;
+
     /**
      * @brief Builds the blade with simple Timoshenko elements (lineic density, flap stiffness, edge stiffness).
      */
@@ -128,7 +129,6 @@ class BladeElastoRigid : public BladeElasto {
     BladeElastoRigid();
 
     virtual void build() override;
-    virtual void assemble(SystemElasto& system) override;
     virtual void rotate(double angle, const Vector3d& axis) const override;
     virtual void translate(const Vector3d& translation_vector) const override;
     virtual double get_mass() const override;
@@ -154,6 +154,8 @@ class BladeElastoRigid : public BladeElasto {
     std::unique_ptr<BodyElastoChrono> body_cog;
     /** @brief Link between bodies at the root and COG of the blade. */
     std::unique_ptr<Link> link_cog_root;
+
+    virtual void assemble_this(SystemElasto& system) override;
 };
 
 }  // namespace elasto

--- a/include/seahowl/elasto/chrono_adapters.h
+++ b/include/seahowl/elasto/chrono_adapters.h
@@ -293,6 +293,7 @@ class SystemElastoChrono : public SystemElasto {
     std::shared_ptr<chrono::ChSystem> chobj;
 
     SystemElastoChrono();
+    virtual void assemble() override;
     virtual void step(double dt) override;
     virtual double get_time() const override;
     virtual void set_time(double time) override;

--- a/include/seahowl/elasto/component_elasto.h
+++ b/include/seahowl/elasto/component_elasto.h
@@ -35,7 +35,7 @@ class ComponentElasto {
      *
      * @param[out] mesh System on which to assemble component.
      */
-    virtual void assemble(SystemElasto& system){};
+    void assemble(SystemElasto& system);
 
     /**
      * @brief Initializes component.
@@ -66,6 +66,10 @@ class ComponentElasto {
      * @brief Returns the mass of the component.
      */
     virtual double get_mass() const = 0;
+
+  protected:
+    bool is_assembled = false;
+    virtual void assemble_this(SystemElasto& system) = 0;
 };
 
 /**
@@ -88,13 +92,6 @@ class ComponentElastoFEA : public virtual ComponentElasto {
      * @param[in] discretized_points Reference points from which the FEA nodes are built.
      */
     void build_nodes(const std::vector<ReferencePointElasto>& discretized_points);
-
-    /**
-     * @brief Assembles the FEA component (adds all nodes and elements to mesh).
-     *
-     * @param[out] mesh System on which to add nodes and elements.
-     */
-    virtual void assemble(SystemElasto& system) override;
 
     virtual void rotate(double angle, const Vector3d& axis) const override;
     virtual void translate(const Vector3d& translation_vector) const override;
@@ -180,6 +177,14 @@ class ComponentElastoFEA : public virtual ComponentElasto {
      * @param[in] element Element index.
      */
     seahowl::EntityDynamicEigen get_entity_along_component(double eta, int element_index) const;
+
+  protected:
+    /**
+     * @brief Assembles the FEA component (adds all nodes and elements to mesh).
+     *
+     * @param[out] mesh System on which to add nodes and elements.
+     */
+    virtual void assemble_this(SystemElasto& system) override;
 };
 
 }  // namespace elasto

--- a/include/seahowl/elasto/floater_elasto.h
+++ b/include/seahowl/elasto/floater_elasto.h
@@ -24,13 +24,6 @@ class FloaterElasto : public ComponentElasto {
     virtual void prestep(double time, double dt);
 
     /**
-     * @brief Assembles the component (adds all bodies to the system).
-     *
-     * @param[out] system System to which bodies.
-     */
-    virtual void assemble(seahowl::elasto::SystemElasto& system) override;
-
-    /**
      * @brief Creates and adds body to floater.
      *
      * @param[in] name The name of the body (for access purposes).
@@ -104,6 +97,8 @@ class FloaterElasto : public ComponentElasto {
     std::map<std::string, std::deque<std::unique_ptr<seahowl::elasto::BodyElasto>>> fairlead_bodies;
     /** @brief Name of body for tower connection */
     std::string tower_connection_name = "";
+
+    virtual void assemble_this(seahowl::elasto::SystemElasto& system) override;
 };
 
 }  // namespace elasto

--- a/include/seahowl/elasto/mooring_elasto.h
+++ b/include/seahowl/elasto/mooring_elasto.h
@@ -66,10 +66,12 @@ struct MooringSystem : public ComponentElasto {
     MooringSystem();
 
     virtual void build() override;
-    virtual void assemble(SystemElasto& system) override;
     virtual void rotate(double angle, const Vector3d& axis) const override;
     virtual void translate(const Vector3d& translation_vector) const override;
     virtual double get_mass() const override;
+
+  protected:
+    virtual void assemble_this(SystemElasto& system) override;
 };
 
 /**
@@ -117,8 +119,6 @@ class MooringElastoFEA : public MooringElasto, public ComponentElastoFEA {
 
     void build_nodes(const std::vector<ReferencePointElasto>& discretized_points);
 
-    virtual void assemble(SystemElasto& system) override;
-
     /**
      * @brief Computes hydro loads on cable.
      *
@@ -148,6 +148,9 @@ class MooringElastoFEA : public MooringElasto, public ComponentElastoFEA {
      * @brief Returns total length of mooring.
      */
     virtual double get_length() const override;
+
+  protected:
+    virtual void assemble_this(SystemElasto& system) override;
 
   private:
     /**

--- a/include/seahowl/elasto/mooring_elasto.h
+++ b/include/seahowl/elasto/mooring_elasto.h
@@ -43,6 +43,11 @@ class MooringElasto : public virtual ComponentElasto {
      * @brief Returns tension at anchor.
      */
     virtual Vector3d get_tension_anchor() const = 0;
+
+    /**
+     * @brief Returns total length of mooring.
+     */
+    virtual double get_length() const = 0;
 };
 
 /**
@@ -138,6 +143,11 @@ class MooringElastoFEA : public MooringElasto, public ComponentElastoFEA {
      * @brief Returns tension at anchor.
      */
     virtual Vector3d get_tension_anchor() const override;
+
+    /**
+     * @brief Returns total length of mooring.
+     */
+    virtual double get_length() const override;
 
   private:
     /**

--- a/include/seahowl/elasto/rotor_elasto.h
+++ b/include/seahowl/elasto/rotor_elasto.h
@@ -79,13 +79,6 @@ class RotorElasto : public ComponentElasto {
     RotorElasto();
 
     /**
-     * @brief Assembles the component (adds all rigid bodies and links to the system).
-     *
-     * @param[out] system System to which rigid bodies and links are added.
-     */
-    virtual void assemble(seahowl::elasto::SystemElasto& system) override;
-
-    /**
      * @brief Builds the rotor.
      */
     void build();
@@ -120,6 +113,9 @@ class RotorElasto : public ComponentElasto {
      * @param[in] torque Torque to accumulate on axial axis of hub.
      */
     void accumulate_axial_torque(double torque);
+
+  protected:
+    virtual void assemble_this(seahowl::elasto::SystemElasto& system) override;
 };
 
 /**
@@ -166,13 +162,6 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
     RotorNacelleAssemblyElasto();
 
     /**
-     * @brief Assembles the component (adds all rigid bodies and links to the system).
-     *
-     * @param[out] system System to which rigid bodies and links are added.
-     */
-    virtual void assemble(seahowl::elasto::SystemElasto& system) override;
-
-    /**
      * @brief Builds the rotor.
      */
     void build();
@@ -217,6 +206,9 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
      * @brief Returns the electrical torque applied on the rotor.
      */
     double get_electrical_torque() const;
+
+  protected:
+    virtual void assemble_this(seahowl::elasto::SystemElasto& system) override;
 
   private:
     /** @brief Accumulated Electrical torque on the rotor.*/

--- a/include/seahowl/elasto/system_elasto.h
+++ b/include/seahowl/elasto/system_elasto.h
@@ -19,6 +19,15 @@ class SystemElasto {
     std::deque<std::shared_ptr<TurbineElasto>> turbines{};
     /** @brief Mesh used for FEA elements. */
     std::shared_ptr<MeshElasto> mesh;
+    /** @brief Whether system has been assembled or not. */
+    bool is_assembled = false;
+
+    /**
+     * @brief Assembles the system.*
+     *
+     * Calls assemble for each turbine of the system.
+     */
+    virtual void assemble() = 0;
 
     /**
      * @brief Does an elasto step.

--- a/include/seahowl/elasto/turbine_elasto.h
+++ b/include/seahowl/elasto/turbine_elasto.h
@@ -39,15 +39,6 @@ class TurbineElasto : public ComponentElasto {
     TurbineElasto();
 
     /**
-     * @brief Assembles the turbine (elasto part).*
-     *
-     * Calls assemble for each of the components of the turbine.
-     *
-     * @param[out] system System on which to add bodies, links, etc.
-     */
-    virtual void assemble(seahowl::elasto::SystemElasto& system) override;
-
-    /**
      * @brief Links RNA to tower.
      *
      * This function links the towertop node to the yaw bearing rigid body by translating the RNA so that the tower
@@ -82,6 +73,9 @@ class TurbineElasto : public ComponentElasto {
      * @brief Returns the mass of the turbine.
      */
     virtual double get_mass() const override;
+
+  protected:
+    virtual void assemble_this(seahowl::elasto::SystemElasto& system) override;
 };
 
 }  // namespace elasto

--- a/include/seahowl/elasto/turbine_floating_elasto.h
+++ b/include/seahowl/elasto/turbine_floating_elasto.h
@@ -42,15 +42,6 @@ class TurbineFloatingElasto : public TurbineElasto {
     TurbineFloatingElasto();
 
     /**
-     * @brief Assembles the turbine (elasto part).*
-     *
-     * Calls assemble for each of the components of the turbine.
-     *
-     * @param[out] system System on which to add bodies, links, etc.
-     */
-    void assemble(seahowl::elasto::SystemElasto& system) override;
-
-    /**
      * @brief Builds the turbine.
      *
      * Calls build for each of the components of the turbine.
@@ -76,6 +67,9 @@ class TurbineFloatingElasto : public TurbineElasto {
      * @brief Returns the mass of the turbine.
      */
     virtual double get_mass() const override;
+
+  protected:
+    void assemble_this(seahowl::elasto::SystemElasto& system) override;
 };
 
 }  // namespace elasto

--- a/include/seahowl/io/output_manager.h
+++ b/include/seahowl/io/output_manager.h
@@ -29,6 +29,7 @@ class OutputManager {
     void output_all(int step);
 
   private:
+    bool is_initialized = false;
     std::string output_folder = ".";
     seahowl::core::System& system_core;
 #ifdef HAVE_VTK

--- a/src/bindings/python/pyseahowl.cpp
+++ b/src/bindings/python/pyseahowl.cpp
@@ -3,6 +3,7 @@
 #include <pybind11/eigen.h>
 
 #include <seahowl/commons/entities.h>
+#include <seahowl/commons/utils.h>
 
 namespace py = pybind11;
 
@@ -14,7 +15,10 @@ void initialize_pyseahowl_core(py::module& m);
 void initialize_pyseahowl_io(py::module& m);
 
 PYBIND11_MODULE(seahowl, m) {
-    // commons.h
+    // utils.h
+    m.def("set_log_level_global", &seahowl::set_log_level_global);
+
+    // entities.h
     py::class_<seahowl::Entity, std::shared_ptr<seahowl::Entity>>(m, "Entity")
         .def("get_position", &seahowl::Entity::get_position)
         .def("set_position", &seahowl::Entity::set_position)

--- a/src/bindings/python/pyseahowl_core.cpp
+++ b/src/bindings/python/pyseahowl_core.cpp
@@ -105,8 +105,6 @@ void initialize_pyseahowl_core(py::module& m) {
     py::class_<seahowl::core::System, std::shared_ptr<seahowl::core::System>, seahowl::core::ComponentDynamic>(m_core,
                                                                                                                "System")
         .def(py::init<seahowl::elasto::SystemElasto&, seahowl::aero::SystemAero&>())
-        .def("assemble", &seahowl::core::System::assemble)
-        .def("assemble", &seahowl::core::System::assemble)
         .def("step", &seahowl::core::System::step)
         .def("get_time", &seahowl::core::System::get_time)
         .def("set_time", &seahowl::core::System::set_time)

--- a/src/bindings/python/pyseahowl_core.cpp
+++ b/src/bindings/python/pyseahowl_core.cpp
@@ -40,6 +40,7 @@ void initialize_pyseahowl_core(py::module& m) {
         .def("run_all", &seahowl::core::Simulation::run_all)
         .def("step", &seahowl::core::Simulation::step)
         .def("populate_from_file", &seahowl::core::Simulation::populate_from_file)
+        .def("initialize", &seahowl::core::Simulation::initialize)
         .def("initialize_from_file", &seahowl::core::Simulation::initialize_from_file)
         .def_readwrite("dt", &seahowl::core::Simulation::dt)
         .def_readwrite("dt_output", &seahowl::core::Simulation::dt_output)

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -72,7 +72,7 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("set_damping_matrix", &seahowl::elasto::LinkMatrixStiffnessDamping::set_damping_matrix);
     py::class_<seahowl::elasto::MeshElasto, std::shared_ptr<seahowl::elasto::MeshElasto>>(m_elasto, "MeshElasto");
     py::class_<seahowl::elasto::SystemElasto, std::shared_ptr<seahowl::elasto::SystemElasto>>(m_elasto, "SystemElasto")
-        .def("step", &seahowl::elasto::SystemElasto::step)
+        .def("assemble", &seahowl::elasto::SystemElasto::assemble)
         .def("get_time", &seahowl::elasto::SystemElasto::get_time)
         .def("set_gravitational_acceleration", &seahowl::elasto::SystemElasto::set_gravitational_acceleration)
         .def("get_gravitational_acceleration", &seahowl::elasto::SystemElasto::get_gravitational_acceleration)

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -279,7 +279,8 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def_property_readonly("fairlead", [](seahowl::elasto::MooringElasto& mooring) { return &mooring.fairlead; })
         .def_property_readonly("anchor", [](seahowl::elasto::MooringElasto& mooring) { return &mooring.anchor; })
         .def("get_tension_fairlead", &seahowl::elasto::MooringElasto::get_tension_fairlead)
-        .def("get_tension_anchor", &seahowl::elasto::MooringElasto::get_tension_anchor);
+        .def("get_tension_anchor", &seahowl::elasto::MooringElasto::get_tension_anchor)
+        .def("get_length", &seahowl::elasto::MooringElasto::get_length);
     py::class_<seahowl::elasto::MooringElastoFEA, std::shared_ptr<seahowl::elasto::MooringElastoFEA>,
                seahowl::elasto::MooringElasto, seahowl::elasto::ComponentElastoFEA>(m_elasto, "MooringElastoFEA")
         .def(py::init<seahowl::elasto::BodyElasto&, seahowl::elasto::BodyElasto&>())

--- a/src/core/blade.cpp
+++ b/src/core/blade.cpp
@@ -14,7 +14,7 @@ using seahowl::Vector3d;
 
 Blade::Blade(seahowl::elasto::BladeElasto& elasto, seahowl::aero::BladeAero& aero) : elasto(elasto), aero(aero) {}
 
-void Blade::initialize(double time, double dt) {
+void Blade::initialize_this(double time, double dt) {
     // mappings
     compute_mapping_aero2elasto();
     compute_mapping_elasto2aero();

--- a/src/core/component.cpp
+++ b/src/core/component.cpp
@@ -1,0 +1,18 @@
+#include "seahowl/core/component.h"
+
+#include <typeinfo>
+#include <spdlog/spdlog.h>
+
+using namespace seahowl::core;
+
+void ComponentDynamic::initialize(double time, double dt) {
+    spdlog::debug("Initialization of component: {}.", std::string(typeid(*this).name()));
+    if (is_initialized) {
+        throw std::runtime_error("Component already initialized: " + std::string(typeid(*this).name()) + ".");
+    }
+
+    initialize_this(time, dt);  // component-specific initialization
+    is_initialized = true;
+
+    spdlog::debug("Finished initialization of component: {}.", std::string(typeid(*this).name()));
+}

--- a/src/core/rotor.cpp
+++ b/src/core/rotor.cpp
@@ -18,7 +18,7 @@ RotorNacelleAssembly::RotorNacelleAssembly(seahowl::elasto::RotorNacelleAssembly
                                            seahowl::aero::RotorNacelleAssemblyAero& aero)
     : elasto(elasto), aero(aero) {}
 
-void RotorNacelleAssembly::initialize(double time, double dt) {
+void RotorNacelleAssembly::initialize_this(double time, double dt) {
     for (auto& blade : blades) {
         blade->initialize(time, dt);
         // update initial azimuth of aero blade

--- a/src/core/simulation.cpp
+++ b/src/core/simulation.cpp
@@ -23,6 +23,7 @@ Simulation::Simulation() {
     system_elasto = std::make_unique<seahowl::elasto::SystemElastoChrono>();
     system_aero = std::make_unique<seahowl::aero::SystemAero>();
     system_core = std::make_unique<System>(*system_elasto, *system_aero);
+    outputs = std::make_unique<seahowl::io::OutputManager>(*system_core);
 }
 
 void Simulation::populate_from_file(const std::string& filepath) {
@@ -62,7 +63,19 @@ void Simulation::populate_from_file(const std::string& filepath) {
     spdlog::debug("Populated system in {:.3}s.", sw_setup);
 }
 
+void Simulation::initialize() {
+    if (is_initialized) {
+        throw std::runtime_error("Simulation was already initialized.");
+    }
+    outputs->initialize();
+    system_core->initialize(system_core->get_time(), dt);
+    is_initialized = true;
+}
+
 void Simulation::initialize_from_file(const std::string& filepath) {
+    if (is_initialized) {
+        throw std::runtime_error("Simulation was already initialized.");
+    }
     spdlog::stopwatch sw_setup;
 
     // get main file info
@@ -79,10 +92,14 @@ void Simulation::initialize_from_file(const std::string& filepath) {
     outputs->output_all(0);
 
     t_output_next = dt_output;
+    is_initialized = true;
     spdlog::info("Initial setup time: {:.3}s.", sw_setup);
 };
 
 void Simulation::step() {
+    if (!is_initialized) {
+        initialize();
+    }
     spdlog::stopwatch sw_step;
     // prestep
     system_core->prestep(system_core->get_time(), dt);

--- a/src/core/simulation.cpp
+++ b/src/core/simulation.cpp
@@ -87,7 +87,6 @@ void Simulation::initialize_from_file(const std::string& filepath) {
     outputs->initialize();
 
     initialize_system_from_json(filepath, *system_core);
-    spdlog::debug("Fully initialized system.");
 
     outputs->output_all(0);
 

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -19,7 +19,7 @@ using namespace seahowl::core;
 
 System::System(seahowl::elasto::SystemElasto& elasto, seahowl::aero::SystemAero& aero) : elasto(elasto), aero(aero) {}
 
-void System::initialize(double time, double dt) {
+void System::initialize_this(double time, double dt) {
     for (auto& turbine : turbines) {
         turbine->initialize(time, dt);
     }

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -20,16 +20,26 @@ using namespace seahowl::core;
 System::System(seahowl::elasto::SystemElasto& elasto, seahowl::aero::SystemAero& aero) : elasto(elasto), aero(aero) {}
 
 void System::initialize_this(double time, double dt) {
+    // assemble elasto system if it hasn't been already
+    if (!elasto.is_assembled) {
+        elasto.assemble();
+    }
+
+    // initialize all turbines
     for (auto& turbine : turbines) {
         turbine->initialize(time, dt);
     }
 
+    // check if fluid model exists
     if (!fluid_model) {
         spdlog::warn("No fluid model was attached to the system.");
     }
+
+    // check if soil model exists
     if (!soil_model) {
         spdlog::warn("No soil model was attached to the system.");
     }
+
     spdlog::info("Initialized system with number of turbines: {}.", turbines.size());
 }
 
@@ -58,12 +68,6 @@ void System::poststep(double time, double dt) {
     for (auto& turbine : turbines) {
         // turbine poststep
         turbine->poststep(time, dt);
-    }
-}
-
-void System::assemble() {
-    for (auto& turbine : turbines) {
-        turbine->elasto.assemble(elasto);
     }
 }
 

--- a/src/core/tower.cpp
+++ b/src/core/tower.cpp
@@ -12,7 +12,7 @@ using namespace seahowl::aero;
 
 Tower::Tower(TowerElasto& elasto, TowerAero& aero) : elasto(elasto), aero(aero) {}
 
-void Tower::initialize(double time, double dt) {
+void Tower::initialize_this(double time, double dt) {
     // mappings
     compute_mapping_aero2elasto();
     compute_mapping_elasto2aero();

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -17,7 +17,7 @@ Turbine::Turbine(seahowl::elasto::TurbineElasto& elasto, seahowl::aero::TurbineA
     controller = std::make_shared<Controller>();
 }
 
-void Turbine::initialize(double time, double dt) {
+void Turbine::initialize_this(double time, double dt) {
     rna.initialize(time, dt);
     tower.initialize(time, dt);
     controller->initialize(time, dt, *this);

--- a/src/core/turbine_floating.cpp
+++ b/src/core/turbine_floating.cpp
@@ -12,9 +12,8 @@ using namespace seahowl::elasto;
 TurbineFloating::TurbineFloating(seahowl::elasto::TurbineFloatingElasto& elasto, seahowl::aero::TurbineAero& aero)
     : elasto(elasto), Turbine(elasto, aero) {}
 
-void TurbineFloating::initialize(double time, double dt) {
-    // parent class initialize
-    Turbine::initialize(time, dt);
+void TurbineFloating::initialize_this(double time, double dt) {
+    Turbine::initialize_this(time, dt);  // initialize parent class
 
     if (elasto.floater) {
         elasto.floater->initialize();

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -15,7 +15,7 @@ BladeElasto::BladeElasto() {
     link_root->set_constraints(true, true, true, true, true, true);
 }
 
-void BladeElasto::assemble(SystemElasto& system) {
+void BladeElasto::assemble_this(SystemElasto& system) {
     if (is_mounted) {
         system.add(*(link_root.get()));
     }
@@ -23,9 +23,9 @@ void BladeElasto::assemble(SystemElasto& system) {
 
 BladeElastoFEA::BladeElastoFEA() {}
 
-void BladeElastoFEA::assemble(SystemElasto& system) {
-    BladeElasto::assemble(system);
-    ComponentElastoFEA::assemble(system);
+void BladeElastoFEA::assemble_this(SystemElasto& system) {
+    BladeElasto::assemble_this(system);
+    ComponentElastoFEA::assemble_this(system);
 }
 
 void BladeElastoFEA::build() {
@@ -233,8 +233,8 @@ void BladeElastoRigid::build() {
     link_cog_root->initialize(*body_cog, *body_root);
 }
 
-void BladeElastoRigid::assemble(SystemElasto& system) {
-    BladeElasto::assemble(system);
+void BladeElastoRigid::assemble_this(SystemElasto& system) {
+    BladeElasto::assemble_this(system);
     system.add(*(body_root.get()));
     system.add(*(body_cog.get()));
     system.add(*(link_cog_root.get()));

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -774,6 +774,18 @@ SystemElastoChrono::SystemElastoChrono() {
     add(*(mesh.get()));
 }
 
+void SystemElastoChrono::assemble() {
+    spdlog::debug("Assembly of system.");
+    if (is_assembled) {
+        throw std::runtime_error("Component already assembled: " + std::string(typeid(*this).name()) + ".");
+    }
+    for (auto& turbine : turbines) {
+        turbine->assemble(*this);
+    }
+    is_assembled = true;
+    spdlog::debug("Finished assembly of system.");
+}
+
 void SystemElastoChrono::step(double dt) {
     chobj->DoStepDynamics(dt);
 }
@@ -787,6 +799,11 @@ void SystemElastoChrono::set_time(double time) {
 }
 
 void SystemElastoChrono::do_statics(bool linear, int nonlinear_steps) {
+    // assemble system if it was not already
+    if (!is_assembled) {
+        assemble();
+    }
+
     // constrain rotor and tower
     std::vector<bool> tower_fixed;
     for (auto& turbine : turbines) {

--- a/src/elasto/component_elasto.cpp
+++ b/src/elasto/component_elasto.cpp
@@ -7,9 +7,22 @@
 #include <vector>
 #include <numeric>
 #include <spdlog/spdlog.h>
+#include <typeinfo>
 
 using namespace seahowl::elasto;
 using namespace seahowl;
+
+void ComponentElasto::assemble(SystemElasto& system) {
+    spdlog::debug("Assembly of component: {}.", std::string(typeid(*this).name()));
+    if (is_assembled) {
+        throw std::runtime_error("Component already assembled: " + std::string(typeid(*this).name()) + ".");
+    }
+
+    assemble_this(system);  // component-specific initialization
+    is_assembled = true;
+
+    spdlog::debug("Finished assembly of component: {}.", std::string(typeid(*this).name()));
+}
 
 void ComponentElastoFEA::build_nodes(const std::vector<ReferencePointElasto>& discretized_points) {
     nodes.clear();
@@ -44,7 +57,7 @@ void ComponentElastoFEA::build_nodes(const std::vector<ReferencePointElasto>& di
     };
 };
 
-void ComponentElastoFEA::assemble(SystemElasto& system) {
+void ComponentElastoFEA::assemble_this(SystemElasto& system) {
     for (auto node : nodes) {
         system.mesh->add(*(node.get()));
     }

--- a/src/elasto/floater_elasto.cpp
+++ b/src/elasto/floater_elasto.cpp
@@ -95,7 +95,7 @@ seahowl::elasto::Link& FloaterElasto::get_fairlead_link(const std::string& body_
     }
 }
 
-void FloaterElasto::assemble(seahowl::elasto::SystemElasto& system) {
+void FloaterElasto::assemble_this(seahowl::elasto::SystemElasto& system) {
     for (auto& bodymap : floater_bodies) {
         auto& body = *bodymap.second;
         system.add(body);

--- a/src/elasto/mooring_elasto.cpp
+++ b/src/elasto/mooring_elasto.cpp
@@ -226,3 +226,11 @@ seahowl::Vector3d MooringElastoFEA::get_tension_fairlead() const {
 seahowl::Vector3d MooringElastoFEA::get_tension_anchor() const {
     return anchor_link->get_reaction_force();
 };
+
+double MooringElastoFEA::get_length() const {
+    double total_length = 0.0;
+    for (auto& element : elements) {
+        total_length += dynamic_cast<seahowl::elasto::ElementMooringElasto&>(*element).get_rest_length();
+    }
+    return total_length;
+}

--- a/src/elasto/mooring_elasto.cpp
+++ b/src/elasto/mooring_elasto.cpp
@@ -17,7 +17,7 @@ void MooringSystem::build() {
     }
 }
 
-void MooringSystem::assemble(SystemElasto& system) {
+void MooringSystem::assemble_this(SystemElasto& system) {
     for (auto& mooring : moorings) {
         mooring->assemble(system);
     }
@@ -150,8 +150,8 @@ void MooringElastoFEA::build_elements() {
     }
 }
 
-void MooringElastoFEA::assemble(SystemElasto& system) {
-    ComponentElastoFEA::assemble(system);
+void MooringElastoFEA::assemble_this(SystemElasto& system) {
+    ComponentElastoFEA::assemble_this(system);
     system.add(*fairlead_link);
     system.add(*anchor_link);
     gravitational_acceleration = system.get_gravitational_acceleration();

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -10,7 +10,7 @@ using seahowl::elasto::RotorNacelleAssemblyElasto;
 
 RotorElasto::RotorElasto() {}
 
-void RotorElasto::assemble(SystemElasto& system) {
+void RotorElasto::assemble_this(SystemElasto& system) {
     for (auto& blade : blades) {
         blade->assemble(system);
     }
@@ -118,7 +118,7 @@ RotorNacelleAssemblyElasto::RotorNacelleAssemblyElasto() {
     rotor = std::make_unique<RotorElasto>();
 }
 
-void RotorNacelleAssemblyElasto::assemble(SystemElasto& system) {
+void RotorNacelleAssemblyElasto::assemble_this(SystemElasto& system) {
     rotor->assemble(system);
     system.add(*(body_shaft.get()));
     system.add(*(link_shaft_hub.get()));

--- a/src/elasto/turbine_elasto.cpp
+++ b/src/elasto/turbine_elasto.cpp
@@ -10,7 +10,7 @@ TurbineElasto::TurbineElasto() {
     tower = TowerElasto();
 }
 
-void TurbineElasto::assemble(SystemElasto& system) {
+void TurbineElasto::assemble_this(SystemElasto& system) {
     // assemble rotor & tower
     rna.assemble(system);
     tower.assemble(system);

--- a/src/elasto/turbine_floating_elasto.cpp
+++ b/src/elasto/turbine_floating_elasto.cpp
@@ -12,7 +12,7 @@ TurbineFloatingElasto::TurbineFloatingElasto() : TurbineElasto() {
     mooring_system = std::make_unique<MooringSystem>();
 }
 
-void TurbineFloatingElasto::assemble(SystemElasto& system) {
+void TurbineFloatingElasto::assemble_this(SystemElasto& system) {
     // assemble floater first
     if (floater) {
         // assemble floater
@@ -27,7 +27,7 @@ void TurbineFloatingElasto::assemble(SystemElasto& system) {
     }
 
     // assemble parent class
-    TurbineElasto::assemble(system);
+    TurbineElasto::assemble_this(system);
 
     // moorings
     mooring_system->assemble(system);

--- a/src/io/output_manager.cpp
+++ b/src/io/output_manager.cpp
@@ -33,6 +33,8 @@ void OutputManager::initialize() {
 #ifdef HAVE_VTK
         output_vtk = std::make_unique<OutputSystemVTK>(system_core, output_folder + "/vtk/");
         output_vtk->initialize();
+#else
+        spdlog::warn("Outputs: VTK is enabled but this feature was not compiled.")
 #endif
     }
     if (has_gui) {
@@ -40,13 +42,18 @@ void OutputManager::initialize() {
         output_insitu = std::make_unique<VisualizationInSituIrrlicht>();
 #else
         output_insitu = std::make_unique<VisualizationInSitu>();
+        spdlog::warn("Outputs: in situ visualization is enabled but this feature was not compiled.")
 #endif
         output_insitu->initialize(system_core);
         output_insitu->draw();
     }
+    is_initialized = true;
 }
 
 void OutputManager::output_all(int step) {
+    if (!is_initialized) {
+        throw std::runtime_error("Outputs: trying to output results but output manager was not initialized.");
+    }
     if (has_vtk) {
 #ifdef HAVE_VTK
         output_vtk->write(step);
@@ -57,24 +64,29 @@ void OutputManager::output_all(int step) {
     }
 
     // output
-    auto& turbine = *system_core.turbines[0];
+    int turbine_id = 1;
+    for (auto& turbine_ptr : system_core.turbines) {
+        auto& turbine = *turbine_ptr;
 
-    // send info to logger
-    std::stringstream output_sstring;
-    output_sstring << "    turbine info -> rpm: " << std::setprecision(3) << turbine.rna.elasto.get_rpm()
-                   << ", power: " << turbine.get_generated_power();
-    int nblades = turbine.rna.blades.size();
-    if (nblades <= 3 && nblades > 0) {
-        for (int ii = 0; ii < turbine.rna.blades.size(); ii++) {
-            output_sstring << ", pitch" << ii + 1 << ": " << turbine.rna.elasto.rotor->blades[ii]->pitch;
+        // send info to logger
+        std::stringstream output_sstring;
+        output_sstring << "    turbine " << turbine_id << " info -> rpm: " << std::setprecision(3)
+                       << turbine.rna.elasto.get_rpm() << ", power: " << turbine.get_generated_power();
+        int nblades = turbine.rna.blades.size();
+        if (nblades <= 3 && nblades > 0) {
+            for (int ii = 0; ii < turbine.rna.blades.size(); ii++) {
+                output_sstring << ", pitch" << ii + 1 << ": " << turbine.rna.elasto.rotor->blades[ii]->pitch;
+            }
+        } else {
+            output_sstring << ", pitch: " << turbine.rna.elasto.rotor->pitch_collective;
         }
-    } else {
-        output_sstring << ", pitch: " << turbine.rna.elasto.rotor->pitch_collective;
-    }
-    spdlog::info(output_sstring.str());
+        spdlog::info(output_sstring.str());
 
-    if (has_csv) {
-        // output info in file
-        write_turbine_info_to_csv(output_folder + "/output", system_core);
+        if (has_csv) {
+            // output info in file
+            write_turbine_info_to_csv(output_folder + "/turbine" + std::to_string(turbine_id) + "_output", system_core);
+        }
+
+        turbine_id += 1;
     }
 }

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -1123,13 +1123,15 @@ void populate_system_from_json(const std::string& filepath, seahowl::core::Syste
             turbine.tower.elasto.nodes.front()->set_fixed(true);
         }
     }
-
-    // assemble whole system (Chrono)
-    system_core.assemble();
 }
 
 void initialize_system_from_json(const std::string& filepath, seahowl::core::System& system_core) {
     auto json_obj = get_json_from_file(filepath);
+
+    // assemble system if it was not already
+    if (system_core.elasto.is_assembled) {
+        system_core.elasto.assemble();
+    }
 
     // NUMERICS options
     auto num_json = json_obj.at("numerics");

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -728,105 +728,113 @@ void populate_turbine_from_json(const std::string& filepath,
         auto& turbine_floating = dynamic_cast<seahowl::elasto::TurbineFloatingElasto&>(turbine.elasto);
 
         auto floater_json = json_obj.at("floater");
-        auto json_obj_floater =
-            get_json_from_file((DATADIR / floater_json.at("file").get<std::string>()).generic_string());
+        if (floater_json.contains("file")) {
+            auto json_obj_floater =
+                get_json_from_file((DATADIR / floater_json.at("file").get<std::string>()).generic_string());
 
-        auto floater_type = json_obj_floater.at("type").get<std::string>();
-        if (floater_type == "HydroChrono") {
-            spdlog::info("Hydrodynamic model: HydroChrono.");
+            auto floater_type = json_obj_floater.at("type").get<std::string>();
+            if (floater_type == "HydroChrono") {
+                spdlog::info("Hydrodynamic model: HydroChrono.");
 #ifdef HAVE_HYDROCHRONO
-            // make floater
-            turbine_floating.floater = std::make_shared<seahowl::hydro::FloaterHydroChrono>();
-            auto& floater = dynamic_cast<seahowl::hydro::FloaterHydroChrono&>(*turbine_floating.floater);
-            auto floater_options = json_obj_floater.at("options");
-            // add h5file path
-            floater.set_h5_filepath((DATADIR / floater_options.at("file").get<std::string>()).generic_string());
-            // get main body info
-            auto& body = *floater.body_main;
-            populate_body_from_json(json_obj_floater, body);
-            // get other bodies info
-            auto bodies_json = json_obj_floater.at("bodies");
-            for (auto& body_json : bodies_json) {
-                auto body_name = body_json.at("name").get<std::string>();
-                floater.add_body(body_name);
-                populate_body_from_json(body_json, floater.get_body(body_name));
-            }
+                // make floater
+                turbine_floating.floater = std::make_shared<seahowl::hydro::FloaterHydroChrono>();
+                auto& floater = dynamic_cast<seahowl::hydro::FloaterHydroChrono&>(*turbine_floating.floater);
+                auto floater_options = json_obj_floater.at("options");
+                // add h5file path
+                floater.set_h5_filepath((DATADIR / floater_options.at("file").get<std::string>()).generic_string());
+                // get main body info
+                auto& body = *floater.body_main;
+                populate_body_from_json(json_obj_floater, body);
+                // get other bodies info
+                auto bodies_json = json_obj_floater.at("bodies");
+                for (auto& body_json : bodies_json) {
+                    auto body_name = body_json.at("name").get<std::string>();
+                    floater.add_body(body_name);
+                    populate_body_from_json(body_json, floater.get_body(body_name));
+                }
 
-            auto dm = json_obj_floater.at("damping_matrix").get<std::vector<std::vector<double>>>();
-            if (dm.size() != 6) {
-                throw std::runtime_error("Viscous damping matrix for floater body has to be defined as 6x6 matrices.");
-            }
-            for (int irow = 0; irow < 6; irow++) {
-                if (dm[irow].size() != 6) {
+                auto dm = json_obj_floater.at("damping_matrix").get<std::vector<std::vector<double>>>();
+                if (dm.size() != 6) {
                     throw std::runtime_error(
                         "Viscous damping matrix for floater body has to be defined as 6x6 matrices.");
                 }
-                for (int icol = 0; icol < 6; icol++) {
-                    floater.damping_matrix(irow, icol) = dm[irow][icol];
+                for (int irow = 0; irow < 6; irow++) {
+                    if (dm[irow].size() != 6) {
+                        throw std::runtime_error(
+                            "Viscous damping matrix for floater body has to be defined as 6x6 matrices.");
+                    }
+                    for (int icol = 0; icol < 6; icol++) {
+                        floater.damping_matrix(irow, icol) = dm[irow][icol];
+                    }
                 }
-            }
 #else
-            throw std::runtime_error("Trying to use HydroChrono but did not compile with HydroChrono dependency.");
+                throw std::runtime_error("Trying to use HydroChrono but did not compile with HydroChrono dependency.");
 #endif
 
-            auto moorings_json = json_obj_floater.at("moorings");
-            for (auto& mooring_json : moorings_json) {
-                auto axis = mooring_json.at("rotation_axis").get<std::vector<double>>();
-                auto rotation_axis = seahowl::Vector3d(axis[0], axis[1], axis[2]);
-                auto rotation_angle = mooring_json.at("rotation_angle").get<double>() * seahowl::PI / 180.0;
-                auto rotation = seahowl::AngleAxisd(rotation_angle, rotation_axis);
+                auto moorings_json = json_obj_floater.at("moorings");
+                for (auto& mooring_json : moorings_json) {
+                    auto axis = mooring_json.at("rotation_axis").get<std::vector<double>>();
+                    auto rotation_axis = seahowl::Vector3d(axis[0], axis[1], axis[2]);
+                    auto rotation_angle = mooring_json.at("rotation_angle").get<double>() * seahowl::PI / 180.0;
+                    auto rotation = seahowl::AngleAxisd(rotation_angle, rotation_axis);
 
-                if (!turbine_floating.floater) {
-                    throw std::runtime_error("Trying to add moorings to a floating turbine without floater.");
+                    if (!turbine_floating.floater) {
+                        throw std::runtime_error("Trying to add moorings to a floating turbine without floater.");
+                    }
+                    auto& floater = *turbine_floating.floater;
+
+                    // fairlead
+                    auto body_name = mooring_json.at("connected_body_name").get<std::string>();
+                    auto fpos = mooring_json.at("fairlead_position").get<std::vector<double>>();
+                    auto fairlead_relative_position = seahowl::Vector3d(fpos[0], fpos[1], fpos[2]);
+                    seahowl::Vector3d fairlead_position = rotation * fairlead_relative_position;
+                    if (mooring_json.at("relative_fairlead").get<bool>()) {
+                        fairlead_position += floater.body_main->get_position();
+                    }
+                    floater.add_fairlead(fairlead_position, body_name);
+                    auto& fairlead_body =
+                        floater.get_fairlead_body(body_name, floater.get_fairlead_count(body_name) - 1);
+
+                    // anchor
+                    auto apos = mooring_json.at("anchor_position").get<std::vector<double>>();
+                    auto anchor_relative_position = seahowl::Vector3d(apos[0], apos[1], apos[2]);
+                    seahowl::Vector3d anchor_position = rotation * anchor_relative_position;
+                    if (mooring_json.at("relative_anchor").get<bool>()) {
+                        anchor_position += floater.body_main->get_position();
+                    }
+                    turbine_floating.mooring_system->anchors.push_back(
+                        std::make_shared<seahowl::elasto::BodyElastoChrono>());
+                    auto& anchor_body = *turbine_floating.mooring_system->anchors.back();
+                    anchor_body.set_position(anchor_position);
+                    anchor_body.set_fixed(true);
+
+                    auto mooring_properties_json = get_json_from_file(
+                        (DATADIR / mooring_json.at("line_properties").get<std::string>()).generic_string());
+                    turbine_floating.mooring_system->moorings.push_back(
+                        std::make_shared<seahowl::elasto::MooringElastoFEA>(fairlead_body, anchor_body));
+                    auto& mooring = dynamic_cast<seahowl::elasto::MooringElastoFEA&>(
+                        *turbine_floating.mooring_system->moorings.back());
+
+                    mooring_json.at("length").get_to(mooring.length);
+                    mooring_json.at("discretization_elasto").get_to(mooring.discretization_fractions);
+                    mooring_properties_json.at("diameter").get_to(mooring.diameter);
+                    mooring_properties_json.at("stiffness_axial").get_to(mooring.stiffness_axial);
+                    mooring_properties_json.at("stiffness_bending").get_to(mooring.stiffness_bending);
+                    mooring_properties_json.at("density_linear").get_to(mooring.density_linear);
+                    mooring_properties_json.at("drag_coefficient_normal").get_to(mooring.drag_coefficient_normal);
+                    mooring_properties_json.at("drag_coefficient_tangential")
+                        .get_to(mooring.drag_coefficient_tangential);
+                    mooring_properties_json.at("added_mass_coefficient_normal")
+                        .get_to(mooring.added_mass_coefficient_normal);
+                    mooring_properties_json.at("added_mass_coefficient_tangential")
+                        .get_to(mooring.added_mass_coefficient_tangential);
                 }
-                auto& floater = *turbine_floating.floater;
-
-                // fairlead
-                auto body_name = mooring_json.at("connected_body_name").get<std::string>();
-                auto fpos = mooring_json.at("fairlead_position").get<std::vector<double>>();
-                auto fairlead_relative_position = seahowl::Vector3d(fpos[0], fpos[1], fpos[2]);
-                seahowl::Vector3d fairlead_position = rotation * fairlead_relative_position;
-                if (mooring_json.at("relative_fairlead").get<bool>()) {
-                    fairlead_position += floater.body_main->get_position();
-                }
-                floater.add_fairlead(fairlead_position, body_name);
-                auto& fairlead_body = floater.get_fairlead_body(body_name, floater.get_fairlead_count(body_name) - 1);
-
-                // anchor
-                auto apos = mooring_json.at("anchor_position").get<std::vector<double>>();
-                auto anchor_relative_position = seahowl::Vector3d(apos[0], apos[1], apos[2]);
-                seahowl::Vector3d anchor_position = rotation * anchor_relative_position;
-                if (mooring_json.at("relative_anchor").get<bool>()) {
-                    anchor_position += floater.body_main->get_position();
-                }
-                turbine_floating.mooring_system->anchors.push_back(
-                    std::make_shared<seahowl::elasto::BodyElastoChrono>());
-                auto& anchor_body = *turbine_floating.mooring_system->anchors.back();
-                anchor_body.set_position(anchor_position);
-                anchor_body.set_fixed(true);
-
-                auto mooring_properties_json = get_json_from_file(
-                    (DATADIR / mooring_json.at("line_properties").get<std::string>()).generic_string());
-                turbine_floating.mooring_system->moorings.push_back(
-                    std::make_shared<seahowl::elasto::MooringElastoFEA>(fairlead_body, anchor_body));
-                auto& mooring =
-                    dynamic_cast<seahowl::elasto::MooringElastoFEA&>(*turbine_floating.mooring_system->moorings.back());
-
-                mooring_json.at("length").get_to(mooring.length);
-                mooring_json.at("discretization_elasto").get_to(mooring.discretization_fractions);
-                mooring_properties_json.at("diameter").get_to(mooring.diameter);
-                mooring_properties_json.at("stiffness_axial").get_to(mooring.stiffness_axial);
-                mooring_properties_json.at("stiffness_bending").get_to(mooring.stiffness_bending);
-                mooring_properties_json.at("density_linear").get_to(mooring.density_linear);
-                mooring_properties_json.at("drag_coefficient_normal").get_to(mooring.drag_coefficient_normal);
-                mooring_properties_json.at("drag_coefficient_tangential").get_to(mooring.drag_coefficient_tangential);
-                mooring_properties_json.at("added_mass_coefficient_normal")
-                    .get_to(mooring.added_mass_coefficient_normal);
-                mooring_properties_json.at("added_mass_coefficient_tangential")
-                    .get_to(mooring.added_mass_coefficient_tangential);
+            } else {
+                throw std::runtime_error("Type of floater defined in turbine json file does not exist.");
             }
         } else {
-            throw std::runtime_error("Type of floater defined in turbine json file does not exist.");
+            spdlog::warn("Turbine has floater key but no floater file was defined.");
+            turbine_floating.floater = std::make_shared<seahowl::elasto::FloaterElasto>();
         }
     }
 }

--- a/src/io/write_csv.cpp
+++ b/src/io/write_csv.cpp
@@ -14,12 +14,12 @@
 
 using seahowl::PI;
 
-void write_turbine_info_to_csv(std::string fileprefix, const seahowl::core::System& ssystem) {
-    auto time = ssystem.get_time();
-    for (int idx_turbine = 0; idx_turbine < ssystem.turbines.size(); idx_turbine++) {
-        auto& turbine = *ssystem.turbines[idx_turbine];
+void write_turbine_info_to_csv(std::string fileprefix, const seahowl::core::System& system_core) {
+    auto time = system_core.get_time();
+    for (int idx_turbine = 0; idx_turbine < system_core.turbines.size(); idx_turbine++) {
+        auto& turbine = *system_core.turbines[idx_turbine];
         std::string filename;
-        if (ssystem.turbines.size() == 1) {
+        if (system_core.turbines.size() == 1) {
             filename = fileprefix + ".csv";
         } else {
             filename = fileprefix + "_turbine" + std::to_string(idx_turbine) + ".csv";
@@ -51,14 +51,23 @@ void write_turbine_info_to_csv(std::string fileprefix, const seahowl::core::Syst
         }
         myfile << std::to_string(time);
         myfile << ",";
-        auto wind_velocity_hub =
-            ssystem.fluid_model->get_fluid_velocity(turbine.rna.elasto.rotor->body_hub->get_position(), time);
-        myfile << std::to_string(wind_velocity_hub.x());
-        myfile << ",";
-        myfile << std::to_string(wind_velocity_hub.y());
-        myfile << ",";
-        myfile << std::to_string(wind_velocity_hub.z());
-        myfile << ",";
+        if (system_core.fluid_model) {
+            auto wind_velocity_hub =
+                system_core.fluid_model->get_fluid_velocity(turbine.rna.elasto.rotor->body_hub->get_position(), time);
+            myfile << std::to_string(wind_velocity_hub.x());
+            myfile << ",";
+            myfile << std::to_string(wind_velocity_hub.y());
+            myfile << ",";
+            myfile << std::to_string(wind_velocity_hub.z());
+            myfile << ",";
+        } else {
+            myfile << std::to_string(0.0);
+            myfile << ",";
+            myfile << std::to_string(0.0);
+            myfile << ",";
+            myfile << std::to_string(0.0);
+            myfile << ",";
+        }
         myfile << std::to_string(turbine.rna.elasto.get_rpm());
         myfile << ",";
         myfile << std::to_string(turbine.get_generated_power());

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -89,6 +89,8 @@ void seahowl::servo::ControllerDISCON::update_turbine_variables(double time,
 }
 
 void seahowl::servo::ControllerDISCON::initialize(double time, double dt, const seahowl::core::Turbine& turbine) {
+    spdlog::debug("Initialization of DISCON controller.");
+
     auto nblades = turbine.rna.blades.size();
     if (nblades == 0) {
         spdlog::warn(
@@ -103,6 +105,8 @@ void seahowl::servo::ControllerDISCON::initialize(double time, double dt, const 
     pImpl.SetAvrSWAP(27, 10.0);  // estimated wind speed (needs to be != 0 at init for it to work in ROSCO!)
 
     pImpl.Init(libfile);
+
+    spdlog::debug("Finished initialization of DISCON controller.");
 }
 
 double seahowl::servo::ControllerDISCON::get_torque_elec() const {

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -792,7 +792,7 @@ TEST(test_turbine, multiturbines) {
     }
 
     // assemble system
-    system_core.assemble();
+    system_core.elasto.assemble();
 
     // statics
     if (statics_prestep) {


### PR DESCRIPTION
In this PR:
- Possible to create a FOWT with an "empty" floater (e.g. to have a mooring system)
- Refactoring of some initialization and assembly workflow for safety and robustness
- Output manager can now handle several turbines (or none) instead of just one
- Added some Python examples