### PR TITLE
Fix InflowWindAdapter relative path issue

### DIFF
--- a/src/bindings/python/pyseahowl_env.cpp
+++ b/src/bindings/python/pyseahowl_env.cpp
@@ -49,7 +49,7 @@ void initialize_pyseahowl_env(py::module& m) {
 #ifdef HAVE_INFLOWWIND
     // env/infflowwind_adapter.h
     py::class_<seahowl::env::InflowWindAdapter, std::shared_ptr<seahowl::env::InflowWindAdapter>,
-               seahowl::env::FluidModel>(m_env, "InflowWindAdapter")
+               seahowl::env::WindModel>(m_env, "InflowWindAdapter")
         .def(py::init<std::string&>());
 #endif
 

--- a/src/env/inflowwind_adapter.cpp
+++ b/src/env/inflowwind_adapter.cpp
@@ -65,6 +65,13 @@ void InflowWindLib::SetIFWINFILE(std::string name) {
             std::transform(type_lowercase.begin(), type_lowercase.end(), type_lowercase.begin(), ::tolower);
 
             if (type_lowercase.find("filename") != std::string::npos) {
+                if (words[0].find(" ") != std::string::npos || IFWDIR.string().find(" ") != std::string::npos) {
+                    throw std::runtime_error(
+                        "InflowWind will not work with spaces in the path. There is a space in the relative path of "
+                        "the folder containing the input file of InflowWind "
+                        "('" +
+                        IFWDIR.string() + "') or file defined within the input file ('" + words[0] + "').");
+                }
                 size_t insertoffset = 0;
                 if (words[0].front() == '"') {
                     insertoffset = 1;

--- a/src/env/inflowwind_adapter.cpp
+++ b/src/env/inflowwind_adapter.cpp
@@ -56,6 +56,7 @@ void InflowWindLib::SetIFWINFILE(std::string name) {
     if (!file.is_open()) {
         throw std::runtime_error("Failed to open inflowwind input file.");
     }
+    auto IFWDIR = fs::path(name).parent_path();
     std::string line;
     while (std::getline(file, line)) {
         std::vector<std::string> words = splitString(line);
@@ -68,6 +69,14 @@ void InflowWindLib::SetIFWINFILE(std::string name) {
                 if (words[0].front() == '"') {
                     insertoffset = 1;
                 }
+
+                auto pos = line.find(words[0].front());
+                std::string line_before = line;
+                line.insert(pos + insertoffset, (IFWDIR).string() + "/");
+                spdlog::trace("InflowWind: modified path to file to be relative:");
+                spdlog::trace("    from: {}", line_before);
+                spdlog::trace("    to: {}", line);
+
                 if (type_lowercase == "filename_uni") {
                     // add wnd file if filename_uni
                     if (insertoffset == 1) {
@@ -75,7 +84,6 @@ void InflowWindLib::SetIFWINFILE(std::string name) {
                         words[0].erase(words[0].length() - 1, 1);
                         words[0].erase(0, 1);
                     }
-                    auto IFWDIR = fs::path(name).parent_path();
                     SetWNDINFILE((IFWDIR / words[0]).string());
                 }
             };

--- a/src/env/inflowwind_adapter.cpp
+++ b/src/env/inflowwind_adapter.cpp
@@ -68,13 +68,6 @@ void InflowWindLib::SetIFWINFILE(std::string name) {
                 if (words[0].front() == '"') {
                     insertoffset = 1;
                 }
-                auto pos = line.find(words[0].front());
-                std::string line_before = line;
-                auto DATADIR = fs::absolute(fs::path(name)).parent_path();
-                line.insert(pos + insertoffset, (DATADIR).string() + "/");
-                spdlog::trace("InflowWind: modified path to file to be relative:");
-                spdlog::trace("    from: {}", line_before);
-                spdlog::trace("    to: {}", line);
                 if (type_lowercase == "filename_uni") {
                     // add wnd file if filename_uni
                     if (insertoffset == 1) {
@@ -82,7 +75,8 @@ void InflowWindLib::SetIFWINFILE(std::string name) {
                         words[0].erase(words[0].length() - 1, 1);
                         words[0].erase(0, 1);
                     }
-                    SetWNDINFILE((DATADIR / words[0]).string());
+                    auto IFWDIR = fs::path(name).parent_path();
+                    SetWNDINFILE((IFWDIR / words[0]).string());
                 }
             };
         }


### PR DESCRIPTION
Fixes issue #112 for InflowWindAdapter when absolute paths of files in .dat contained spaces in their paths.
Note that this does not fix the issue if there is a space in the file path inside the ".dat" file (this is an InflowWind issue).

Also changed parent class of InflowWindAdapter in Python bindings from FluidModel to WindModel.