### PR TITLE
Allow ComponentDynamic to be attached to System + fixes

### DIFF
--- a/data/IEA15MW/floater.json
+++ b/data/IEA15MW/floater.json
@@ -1,7 +1,7 @@
 ﻿{
   "type": "HydroChrono",
   "options": {
-    "file": "./VolturnUS.h5"
+    "file": "./iea15.h5"
   },
   "position": [0.0, 0.0, -14.94],
   "mass": 17839e3,
@@ -21,7 +21,7 @@
   "bodies": [
     {
       "name": "body1",
-      "position": [0.0, 0.0, -14.94],
+      "position": [0.0, 0.0, 0.0],
       "mass": 0.0,
       "inertia": [
         [0.0, 0.0, 0.0],

--- a/data/IEA15MW/main_floating.json
+++ b/data/IEA15MW/main_floating.json
@@ -21,7 +21,7 @@
     "folder": "./output",
     "VTK": false,
     "log_level": "info",
-    "gui": false
+    "gui": true
   },
   "environment": {
     "file": "./environment_hydrochrono.json"

--- a/include/seahowl/commons/entities.h
+++ b/include/seahowl/commons/entities.h
@@ -47,6 +47,21 @@ class Entity {
      * @param[in] rotation Rotation matrix of entity.
      */
     void set_rotation_matrix(Eigen::Matrix<double, 3, 3> rotation) { set_rotation(Quaternion(rotation)); };
+
+    /**
+     * @brief Rotates the entity.
+     *
+     * @param[in] translation_vector The angle of rotation (in radians).
+     * @param[in] axis The axis of rotation (3D vector).
+     */
+    void rotate(double angle, const Vector3d& axis);
+
+    /**
+     * @brief Translates the entity.
+     *
+     * @param[in] translation_vector The 3D translation vector.
+     */
+    void translate(const Vector3d& translation_vector);
 };
 
 /**

--- a/include/seahowl/commons/entities.h
+++ b/include/seahowl/commons/entities.h
@@ -37,6 +37,11 @@ class Entity {
     virtual Quaternion get_rotation() const = 0;
 
     /**
+     * @brief Returns direction of entity (local Z-axis projected in global frame).
+     */
+    virtual Vector3d get_direction() const { return get_rotation() * Vector3d(0.0, 0.0, 1.0); };
+
+    /**
      * @brief Returns rotation matrix of entity.
      */
     Eigen::Matrix<double, 3, 3> get_rotation_matrix() const { return get_rotation().toRotationMatrix(); };

--- a/include/seahowl/core/blade.h
+++ b/include/seahowl/core/blade.h
@@ -71,6 +71,8 @@ class Blade : public ComponentDynamic {
      */
     void poststep(double time, double dt) override;
 
+    void apply_fluid_model(seahowl::env::FluidModel& fluid_model, double time) override;
+
     /**
      * @brief Builds the blade (aero and elasto part).
      *

--- a/include/seahowl/core/blade.h
+++ b/include/seahowl/core/blade.h
@@ -79,7 +79,7 @@ class Blade : public ComponentDynamic {
      * Sets the nodes and elements for elasto and aero components of the blade, as well as the aero->elasto mapping and
      * elasto->aero mapping.
      */
-    void build();
+    virtual void build();
 
     /**
      * @brief Sets the discretization fractions to use when building the elasto part of the blade.

--- a/include/seahowl/core/component.h
+++ b/include/seahowl/core/component.h
@@ -4,6 +4,16 @@
 #include <stdexcept>
 #include <algorithm>
 
+#include "seahowl/commons/entities.h"
+
+// forward declarations
+namespace seahowl {
+namespace env {
+class FluidModel;
+class SoilModel;
+}  // namespace env
+}  // namespace seahowl
+
 namespace seahowl {
 namespace core {
 
@@ -35,6 +45,22 @@ class ComponentDynamic {
      * @param[in] dt Time step length.
      */
     virtual void poststep(double time, double dt) = 0;
+
+    /**
+     * @brief Applies fluid model to component.
+     *
+     * @param[in] fluid_model Fluid model affecting component.
+     * @param[in] time Time of simulation.
+     */
+    virtual void apply_fluid_model(seahowl::env::FluidModel& fluid_model, double time){};
+
+    /**
+     * @brief Applies soil model to component.
+     *
+     * @param[in] fluid_model Fluid model affecting component.
+     * @param[in] time Time of simulation.
+     */
+    virtual void apply_soil_model(seahowl::env::SoilModel& soil_model, double time){};
 
   protected:
     bool is_initialized = false;

--- a/include/seahowl/core/component.h
+++ b/include/seahowl/core/component.h
@@ -23,6 +23,11 @@ namespace core {
 class ComponentDynamic {
   public:
     /**
+     * @brief Builds the component, called before initializing the simulation.
+     */
+    virtual void build() = 0;
+
+    /**
      * @brief Initializes the component, called before starting the simulation.
      *
      * @param[in] time Time of the simulation (usually 0 at init).

--- a/include/seahowl/core/rotor.h
+++ b/include/seahowl/core/rotor.h
@@ -66,6 +66,8 @@ class RotorNacelleAssembly : public ComponentDynamic {
      */
     void poststep(double time, double dt) override;
 
+    void apply_fluid_model(seahowl::env::FluidModel& fluid_model, double time) override;
+
     /**
      * @brief Updates aero positions, rotations, velocities and accelerations from elasto component of the RNA.
      */

--- a/include/seahowl/core/rotor.h
+++ b/include/seahowl/core/rotor.h
@@ -76,7 +76,7 @@ class RotorNacelleAssembly : public ComponentDynamic {
     /**
      * @brief Builds the RNA and blades associated to it.
      */
-    void build();
+    void build() override;
 
   private:
     /**

--- a/include/seahowl/core/system.h
+++ b/include/seahowl/core/system.h
@@ -34,6 +34,8 @@ class System : public ComponentDynamic {
   public:
     /** @brief Wind turbines. */
     std::deque<std::shared_ptr<Turbine>> turbines{};
+    /** @brief Other dynamics components. */
+    std::deque<std::shared_ptr<ComponentDynamic>> components{};
     /** @brief Fluid model. */
     std::shared_ptr<seahowl::env::FluidModel> fluid_model;
     /** @brief Soil model. */
@@ -75,6 +77,9 @@ class System : public ComponentDynamic {
      */
     virtual void poststep(double time, double dt) override;
 
+    void apply_fluid_model(seahowl::env::FluidModel& fluid_model, double time) override;
+    void apply_soil_model(seahowl::env::SoilModel& fluid_model, double time) override;
+
     /**
      * @brief Returns time of simulation.
      */
@@ -111,6 +116,13 @@ class System : public ComponentDynamic {
      * @param[in] turbine Turbine to add to system.
      */
     void add_turbine(std::shared_ptr<seahowl::core::Turbine> turbine);
+
+    /**
+     * @brief Adds component to system.
+     *
+     * @param[in] component Component to add to system.
+     */
+    void add_component(std::shared_ptr<seahowl::core::ComponentDynamic> component);
 
   private:
     /**

--- a/include/seahowl/core/system.h
+++ b/include/seahowl/core/system.h
@@ -54,6 +54,8 @@ class System : public ComponentDynamic {
      */
     System(seahowl::elasto::SystemElasto& elasto, seahowl::aero::SystemAero& aero);
 
+    void build() override;
+
     /**
      * @brief Prestep for system, called before elastodynamic stepping.
      *

--- a/include/seahowl/core/tower.h
+++ b/include/seahowl/core/tower.h
@@ -71,6 +71,8 @@ class Tower : public ComponentDynamic {
      */
     void poststep(double time, double dt) override;
 
+    void apply_fluid_model(seahowl::env::FluidModel& fluid_model, double time) override;
+
     /**
      * @brief Builds the tower (aero and elasto part).
      *

--- a/include/seahowl/core/tower.h
+++ b/include/seahowl/core/tower.h
@@ -79,7 +79,7 @@ class Tower : public ComponentDynamic {
      * Sets the nodes and elements for elasto and aero components of the tower, as well as the aero->elasto mapping and
      * elasto->aero mapping.
      */
-    void build();
+    void build() override;
 
     /**
      * @brief Sets the discretization fractions to use when building the elasto part of the tower.

--- a/include/seahowl/core/turbine.h
+++ b/include/seahowl/core/turbine.h
@@ -99,7 +99,7 @@ class Turbine : public ComponentDynamic {
      *
      * Calls build for each of the components of the turbine.
      */
-    void build();
+    virtual void build() override;
 
     /**
      * @brief Translates the turbine.

--- a/include/seahowl/core/turbine.h
+++ b/include/seahowl/core/turbine.h
@@ -102,21 +102,6 @@ class Turbine : public ComponentDynamic {
     virtual void build() override;
 
     /**
-     * @brief Translates the turbine.
-     *
-     * @param[in] translation_vector The 3D translation vector.
-     */
-    void translate(Vector3d translation_vector);
-
-    /**
-     * @brief Rotates the turbine.
-     *
-     * @param[in] translation_vector The angle of rotation (in radians).
-     * @param[in] axis The axis of rotation (3D vector).
-     */
-    void rotate(double angle, Vector3d axis);
-
-    /**
      * @brief Returns shaft power.
      */
     double get_shaft_power() const;

--- a/include/seahowl/core/turbine_floating.h
+++ b/include/seahowl/core/turbine_floating.h
@@ -57,7 +57,7 @@ class TurbineFloating : public Turbine {
      *
      * Calls build for each of the components of the turbine.
      */
-    void build();
+    void build() override;
 
     /**
      * @brief Applies fluid model to turbine components.

--- a/include/seahowl/elasto/entities_elasto.h
+++ b/include/seahowl/elasto/entities_elasto.h
@@ -122,11 +122,6 @@ class BodyElasto : public virtual EntityLoadable {
 class NodeElasto : public virtual EntityLoadable {
   public:
     /**
-     * @brief Returns main direction of node.
-     */
-    virtual Vector3d get_direction() const = 0;
-
-    /**
      * @brief Fix node in space.
      *
      * param[in] is_fixed Fixed if true, free if false.

--- a/include/seahowl/elasto/floater_elasto.h
+++ b/include/seahowl/elasto/floater_elasto.h
@@ -3,6 +3,7 @@
 #include "seahowl/commons/numerics.h"
 #include "seahowl/elasto/entities_elasto.h"
 #include "seahowl/elasto/system_elasto.h"
+#include "seahowl/elasto/mooring_elasto.h"
 
 #include <deque>
 #include <map>
@@ -12,14 +13,19 @@ namespace elasto {
 
 class FloaterElasto : public ComponentElasto {
   public:
-    /* @brief Damping matrix of floater.*/
+    /** @brief Floater of the turbine. */
+    std::unique_ptr<seahowl::elasto::MooringSystem> mooring_system;
+    /** @brief Damping matrix of floater.*/
     Eigen::Matrix<double, 6, 6> damping_matrix;
+    /** @brief Main body of floater.*/
     std::unique_ptr<seahowl::elasto::BodyElasto> body_main;
 
     /**
      * @brief Constructor.
      */
     FloaterElasto();
+
+    virtual void build();
 
     virtual void prestep(double time, double dt);
 

--- a/include/seahowl/elasto/mooring_elasto.h
+++ b/include/seahowl/elasto/mooring_elasto.h
@@ -66,6 +66,7 @@ struct MooringSystem : public ComponentElasto {
     MooringSystem();
 
     virtual void build() override;
+    virtual void prestep(double time, double dt);
     virtual void rotate(double angle, const Vector3d& axis) const override;
     virtual void translate(const Vector3d& translation_vector) const override;
     virtual double get_mass() const override;

--- a/include/seahowl/elasto/turbine_floating_elasto.h
+++ b/include/seahowl/elasto/turbine_floating_elasto.h
@@ -31,8 +31,6 @@ class TurbineFloatingElasto : public TurbineElasto {
     std::shared_ptr<seahowl::elasto::FloaterElasto> floater;
     /** @brief Link between floater and tower of the turbine. */
     std::unique_ptr<seahowl::elasto::Link> link_floater_tower;
-    /** @brief Floater of the turbine. */
-    std::unique_ptr<seahowl::elasto::MooringSystem> mooring_system;
 
     /**
      * @brief Constructor.

--- a/src/bindings/python/pyseahowl.cpp
+++ b/src/bindings/python/pyseahowl.cpp
@@ -25,7 +25,9 @@ PYBIND11_MODULE(seahowl, m) {
         //.def("get_rotation", &seahowl::Entity::get_rotation)
         .def("get_rotation_matrix", &seahowl::Entity::get_rotation_matrix)
         //.def("set_rotation", &seahowl::Entity::set_rotation)
-        .def("set_rotation_matrix", &seahowl::Entity::set_rotation_matrix);
+        .def("set_rotation_matrix", &seahowl::Entity::set_rotation_matrix)
+        .def("rotate", &seahowl::Entity::rotate)
+        .def("translate", &seahowl::Entity::translate);
     py::class_<seahowl::EntityDynamic, std::shared_ptr<seahowl::EntityDynamic>, seahowl::Entity>(m, "EntityDynamic")
         .def("get_velocity", &seahowl::EntityDynamic::get_velocity)
         .def("set_velocity", &seahowl::EntityDynamic::set_velocity)

--- a/src/bindings/python/pyseahowl.cpp
+++ b/src/bindings/python/pyseahowl.cpp
@@ -27,7 +27,8 @@ PYBIND11_MODULE(seahowl, m) {
         //.def("set_rotation", &seahowl::Entity::set_rotation)
         .def("set_rotation_matrix", &seahowl::Entity::set_rotation_matrix)
         .def("rotate", &seahowl::Entity::rotate)
-        .def("translate", &seahowl::Entity::translate);
+        .def("translate", &seahowl::Entity::translate)
+        .def("get_direction", &seahowl::Entity::get_direction);
     py::class_<seahowl::EntityDynamic, std::shared_ptr<seahowl::EntityDynamic>, seahowl::Entity>(m, "EntityDynamic")
         .def("get_velocity", &seahowl::EntityDynamic::get_velocity)
         .def("set_velocity", &seahowl::EntityDynamic::set_velocity)

--- a/src/bindings/python/pyseahowl_core.cpp
+++ b/src/bindings/python/pyseahowl_core.cpp
@@ -30,9 +30,12 @@ void initialize_pyseahowl_core(py::module& m) {
     // core/utils.h
     py::class_<seahowl::core::ComponentDynamic, std::shared_ptr<seahowl::core::ComponentDynamic>>(m_core,
                                                                                                   "ComponentDynamic")
+        .def("build", &seahowl::core::ComponentDynamic::build)
         .def("initialize", &seahowl::core::ComponentDynamic::initialize)
         .def("prestep", &seahowl::core::ComponentDynamic::prestep)
-        .def("poststep", &seahowl::core::ComponentDynamic::poststep);
+        .def("poststep", &seahowl::core::ComponentDynamic::poststep)
+        .def("apply_fluid_model", &seahowl::core::ComponentDynamic::apply_fluid_model)
+        .def("apply_soil_model", &seahowl::core::ComponentDynamic::apply_soil_model);
 
     // core/simulation.h
     py::class_<seahowl::core::Simulation, std::shared_ptr<seahowl::core::Simulation>>(m_core, "Simulation")
@@ -58,7 +61,6 @@ void initialize_pyseahowl_core(py::module& m) {
         .def(py::init<seahowl::elasto::TurbineElasto&, seahowl::aero::TurbineAero&>())
         .def("get_generated_power", &seahowl::core::Turbine::get_generated_power)
         .def("get_generator_rpm", &seahowl::core::Turbine::get_generator_rpm)
-        .def("build", &seahowl::core::Turbine::build)
         .def_property_readonly("elasto", [](seahowl::core::Turbine& turbine) { return &turbine.elasto; })
         .def_property_readonly("aero", [](seahowl::core::Turbine& turbine) { return &turbine.aero; })
         .def_readonly("controller", &seahowl::core::Turbine::controller)
@@ -112,6 +114,7 @@ void initialize_pyseahowl_core(py::module& m) {
         .def("run_presimulation", &seahowl::core::System::run_presimulation)
         .def("add_turbine", &seahowl::core::System::add_turbine)
         .def_readonly("turbines", &seahowl::core::System::turbines)
+        .def_readonly("components", &seahowl::core::System::components)
         .def_readwrite("fluid_model", &seahowl::core::System::fluid_model)
         .def_property_readonly("elasto", [](seahowl::core::System& system) { return &system.elasto; })
         .def_property_readonly("aero", [](seahowl::core::System& system) { return &system.aero; });

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -258,6 +258,9 @@ void initialize_pyseahowl_elasto(py::module& m) {
     py::class_<seahowl::elasto::FloaterElasto, std::shared_ptr<seahowl::elasto::FloaterElasto>,
                seahowl::elasto::ComponentElasto>(m_elasto, "FloaterElasto")
         .def_property_readonly(
+            "mooring_system", [](seahowl::elasto::FloaterElasto& floater) { return floater.mooring_system.get(); },
+            py::return_value_policy::reference_internal)
+        .def_property_readonly(
             "body_main", [](seahowl::elasto::FloaterElasto& floater) { return floater.body_main.get(); },
             py::return_value_policy::reference_internal)
         .def_readwrite("damping_matrix", &seahowl::elasto::FloaterElasto::damping_matrix)
@@ -310,10 +313,6 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def_property_readonly(
             "link_floater_tower",
             [](seahowl::elasto::TurbineFloatingElasto& turbine) { return turbine.link_floater_tower.get(); },
-            py::return_value_policy::reference_internal)
-        .def_property_readonly(
-            "mooring_system",
-            [](seahowl::elasto::TurbineFloatingElasto& turbine) { return turbine.mooring_system.get(); },
             py::return_value_policy::reference_internal)
         .def(py::init<>());
 }

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -42,7 +42,6 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("set_fixed", &seahowl::elasto::BodyElasto::set_fixed);
     py::class_<seahowl::elasto::NodeElasto, std::shared_ptr<seahowl::elasto::NodeElasto>,
                seahowl::elasto::EntityLoadable>(m_elasto, "NodeElasto", pybind11::multiple_inheritance())
-        .def("get_direction", &seahowl::elasto::NodeElasto::get_direction)
         .def("set_fixed", &seahowl::elasto::NodeElasto::set_fixed);
     py::class_<seahowl::elasto::ElementElasto, std::shared_ptr<seahowl::elasto::ElementElasto>>(m_elasto,
                                                                                                 "ElementElasto")

--- a/src/commons/entities.cpp
+++ b/src/commons/entities.cpp
@@ -4,6 +4,18 @@
 
 using namespace seahowl;
 
+void Entity::rotate(double angle, const Vector3d& axis) {
+    auto rotation = AngleAxisd(angle, axis);
+    auto new_position = rotation * get_position();
+    auto new_rotation = (rotation * get_rotation()).normalized();
+    set_position(new_position);
+    set_rotation(new_rotation);
+}
+
+void Entity::translate(const Vector3d& translation_vector) {
+    set_position(get_position() + translation_vector);
+}
+
 void EntityEigen::set_position(const Vector3d& position) {
     this->position = position;
 }

--- a/src/core/blade.cpp
+++ b/src/core/blade.cpp
@@ -35,6 +35,10 @@ void Blade::poststep(double time, double dt) {
     update_positions_aero();
 }
 
+void Blade::apply_fluid_model(seahowl::env::FluidModel& fluid_model, double time) {
+    spdlog::warn("Fluid model must be applied from Rotor instead of Blade directly.");
+}
+
 void Blade::build() {
     // build aero & elasto
     elasto.build();

--- a/src/core/rotor.cpp
+++ b/src/core/rotor.cpp
@@ -49,6 +49,10 @@ void RotorNacelleAssembly::poststep(double time, double dt) {
     update_positions_aero();
 }
 
+void RotorNacelleAssembly::apply_fluid_model(seahowl::env::FluidModel& fluid_model, double time) {
+    aero.rotor->compute_aero_loads(fluid_model, time);
+}
+
 void RotorNacelleAssembly::update_positions_aero() {
     // pitch collective
     aero.rotor->pitch_collective = elasto.rotor->pitch_collective;

--- a/src/core/simulation.cpp
+++ b/src/core/simulation.cpp
@@ -33,13 +33,13 @@ void Simulation::populate_from_file(const std::string& filepath) {
     spdlog::info("INITIAL SIMULATION SETUP.");
     spdlog::info("**************************************************************");
 
+    populate_system_from_json(filepath, *system_core);
+
     // get main file info
     std::ifstream json_file(filepath);
     json json_obj;
     json_file >> json_obj;
     json_file.close();
-
-    populate_system_from_json(filepath, *system_core);
 
     // NUMERICS options
     auto num_json = json_obj.at("numerics");
@@ -85,12 +85,6 @@ void Simulation::initialize_from_file(const std::string& filepath) {
         throw std::runtime_error("Simulation was already initialized.");
     }
     spdlog::stopwatch sw_setup;
-
-    // get main file info
-    std::ifstream json_file(filepath);
-    json json_obj;
-    json_file >> json_obj;
-    json_file.close();
 
     outputs->initialize();
 

--- a/src/core/simulation.cpp
+++ b/src/core/simulation.cpp
@@ -67,6 +67,14 @@ void Simulation::initialize() {
     if (is_initialized) {
         throw std::runtime_error("Simulation was already initialized.");
     }
+
+    // need to do tiny time step before system initialization if statics not done
+    // this is necessary for moorings for example (needed for Chrono to set element length element)
+    double tiny_dt = 1e-6;
+    spdlog::debug("Making small time step before initializing system.");
+    system_core->step(tiny_dt);
+    system_core->set_time(system_core->get_time() - tiny_dt);
+
     outputs->initialize();
     system_core->initialize(system_core->get_time(), dt);
     is_initialized = true;

--- a/src/core/simulation.cpp
+++ b/src/core/simulation.cpp
@@ -68,15 +68,10 @@ void Simulation::initialize() {
         throw std::runtime_error("Simulation was already initialized.");
     }
 
-    // need to do tiny time step before system initialization if statics not done
-    // this is necessary for moorings for example (needed for Chrono to set element length element)
-    double tiny_dt = 1e-6;
-    spdlog::debug("Making small time step before initializing system.");
-    system_core->step(tiny_dt);
-    system_core->set_time(system_core->get_time() - tiny_dt);
-
     outputs->initialize();
+
     system_core->initialize(system_core->get_time(), dt);
+
     is_initialized = true;
 }
 

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -29,6 +29,10 @@ void System::initialize_this(double time, double dt) {
     for (auto& turbine : turbines) {
         turbine->initialize(time, dt);
     }
+    // initialize all extra components
+    for (auto& component : components) {
+        component->initialize(time, dt);
+    }
 
     // check if fluid model exists
     if (!fluid_model) {
@@ -44,19 +48,29 @@ void System::initialize_this(double time, double dt) {
 }
 
 void System::prestep(double time, double dt) {
+    // apply control first
     for (auto& turbine : turbines) {
         turbine->apply_control(time, dt);
+    }
 
-        // compute forces from fluid model
-        if (fluid_model) {
-            turbine->apply_fluid_model(*fluid_model, time);
-        }
-        // compute forces from soil model
-        if (soil_model) {
-            turbine->apply_soil_model(*soil_model, time);
-        }
-        // turbine prestep (accumulates loads from aero to elasto)
+    // compute forces from fluid model
+    if (fluid_model) {
+        apply_fluid_model(*fluid_model, time);
+    }
+
+    // compute forces from soil model
+    if (soil_model) {
+        apply_soil_model(*soil_model, time);
+    }
+
+    // prestep (accumulates loads from aero to elasto)
+    for (auto& turbine : turbines) {
+        // turbine prestep
         turbine->prestep(time, dt);
+    }
+    for (auto& component : components) {
+        // component poststep
+        component->prestep(time, dt);
     }
 }
 
@@ -68,6 +82,32 @@ void System::poststep(double time, double dt) {
     for (auto& turbine : turbines) {
         // turbine poststep
         turbine->poststep(time, dt);
+    }
+    for (auto& component : components) {
+        // component poststep
+        component->poststep(time, dt);
+    }
+}
+
+void System::apply_fluid_model(seahowl::env::FluidModel& fluid_model, double time) {
+    for (auto& turbine : turbines) {
+        // compute forces from fluid model
+        turbine->apply_fluid_model(fluid_model, time);
+    }
+    for (auto& component : components) {
+        // compute forces from fluid model
+        component->apply_fluid_model(fluid_model, time);
+    }
+}
+
+void System::apply_soil_model(seahowl::env::SoilModel& soil_model, double time) {
+    for (auto& turbine : turbines) {
+        // compute forces from fluid model
+        turbine->apply_soil_model(soil_model, time);
+    }
+    for (auto& component : components) {
+        // compute forces from fluid model
+        component->apply_soil_model(soil_model, time);
     }
 }
 
@@ -259,4 +299,8 @@ void System::run_presimulation(double presim_duration, double presim_dt, bool fi
 
 void System::add_turbine(std::shared_ptr<Turbine> turbine) {
     turbines.push_back(turbine);
+}
+
+void System::add_component(std::shared_ptr<ComponentDynamic> component) {
+    components.push_back(component);
 }

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -19,6 +19,17 @@ using namespace seahowl::core;
 
 System::System(seahowl::elasto::SystemElasto& elasto, seahowl::aero::SystemAero& aero) : elasto(elasto), aero(aero) {}
 
+void System::build() {
+    // build all turbines
+    for (auto& turbine : turbines) {
+        turbine->build();
+    }
+    // build all extra components
+    for (auto& component : components) {
+        component->build();
+    }
+}
+
 void System::initialize_this(double time, double dt) {
     // assemble elasto system if it hasn't been already
     if (!elasto.is_assembled) {

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -152,7 +152,7 @@ void System::run_presetup(double presetup_duration, double presetup_dt) {
             turbine_floating.tower.elasto.nodes.front()->set_fixed(true);
             turbine_floating.rna.elasto.rotor->body_hub->set_fixed(true);
 
-            for (auto& mooring_ptr : turbine_floating.elasto.mooring_system->moorings) {
+            for (auto& mooring_ptr : turbine_floating.elasto.floater->mooring_system->moorings) {
                 auto& mooring_elasto = *mooring_ptr;
                 auto& mooring = dynamic_cast<seahowl::elasto::MooringElastoFEA&>(mooring_elasto);
 
@@ -206,9 +206,9 @@ void System::run_presetup(double presetup_duration, double presetup_dt) {
             auto& turbine = *turbines[idx_turbine];
             try {
                 auto& turbine_floating = dynamic_cast<TurbineFloating&>(turbine);
-                for (int idx_mooring = 0; idx_mooring < turbine_floating.elasto.mooring_system->moorings.size();
-                     idx_mooring++) {
-                    auto& mooring_elasto = *turbine_floating.elasto.mooring_system->moorings[idx_mooring];
+                for (int idx_mooring = 0;
+                     idx_mooring < turbine_floating.elasto.floater->mooring_system->moorings.size(); idx_mooring++) {
+                    auto& mooring_elasto = *turbine_floating.elasto.floater->mooring_system->moorings[idx_mooring];
                     auto& mooring = dynamic_cast<seahowl::elasto::MooringElastoFEA&>(mooring_elasto);
                     auto lengths_initial = lengths_initial_moorings[idx_turbine][idx_mooring];
                     auto lengths_delta = lengths_delta_moorings[idx_turbine][idx_mooring];

--- a/src/core/tower.cpp
+++ b/src/core/tower.cpp
@@ -33,6 +33,10 @@ void Tower::poststep(double time, double dt) {
     update_positions_aero();
 }
 
+void Tower::apply_fluid_model(seahowl::env::FluidModel& fluid_model, double time) {
+    aero.compute_aero_loads(fluid_model, time);
+}
+
 void Tower::build() {
     // build
     elasto.build();

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -87,16 +87,6 @@ void Turbine::build() {
     aero.build();
 }
 
-void Turbine::translate(Vector3d translation_vector) {
-    rna.elasto.translate(translation_vector);
-    tower.elasto.translate(translation_vector);
-}
-
-void Turbine::rotate(double angle, Vector3d axis) {
-    rna.elasto.rotate(angle, axis);
-    tower.elasto.rotate(angle, axis);
-}
-
 double Turbine::get_shaft_power() const {
     // get generator rotation in rad/s scaled by gearbox ratio and efficiency
     auto rot_rads = rna.elasto.get_rpm() * (2.0 * PI / 60.0) * gearbox_ratio;

--- a/src/core/turbine_floating.cpp
+++ b/src/core/turbine_floating.cpp
@@ -26,11 +26,7 @@ void TurbineFloating::prestep(double time, double dt) {
     // parent class prestep
     Turbine::prestep(time, dt);
 
-    // prestep for moorings
-    for (auto& mooring : elasto.mooring_system->moorings) {
-        mooring->prestep(time, dt);
-    }
-
+    // floater
     if (elasto.floater) {
         elasto.floater->prestep(time, dt);
     }
@@ -48,21 +44,25 @@ void TurbineFloating::build() {
 
 void TurbineFloating::apply_fluid_model(seahowl::env::FluidModel& fluid_model, double time) {
     Turbine::apply_fluid_model(fluid_model, time);
-    for (auto& mooring : elasto.mooring_system->moorings) {
-        try {
-            dynamic_cast<seahowl::elasto::MooringElastoFEA&>(*mooring).compute_hydro_loads(fluid_model, time);
-        } catch (const std::bad_cast& e) {
-            // do nothing
+    if (elasto.floater) {
+        for (auto& mooring : elasto.floater->mooring_system->moorings) {
+            try {
+                dynamic_cast<seahowl::elasto::MooringElastoFEA&>(*mooring).compute_hydro_loads(fluid_model, time);
+            } catch (const std::bad_cast& e) {
+                // do nothing
+            }
         }
     }
 }
 
 void TurbineFloating::apply_soil_model(seahowl::env::SoilModel& soil_model, double time) {
-    for (auto& mooring : elasto.mooring_system->moorings) {
-        try {
-            dynamic_cast<seahowl::elasto::MooringElastoFEA&>(*mooring).compute_seabed_loads(soil_model);
-        } catch (const std::bad_cast& e) {
-            // do nothing
+    if (elasto.floater) {
+        for (auto& mooring : elasto.floater->mooring_system->moorings) {
+            try {
+                dynamic_cast<seahowl::elasto::MooringElastoFEA&>(*mooring).compute_seabed_loads(soil_model);
+            } catch (const std::bad_cast& e) {
+                // do nothing
+            }
         }
     }
 }

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -241,23 +241,17 @@ void BladeElastoRigid::assemble_this(SystemElasto& system) {
 }
 
 void BladeElastoRigid::rotate(double angle, const Vector3d& axis) const {
-    auto rotation = AngleAxisd(angle, axis);
     // blade root
-    auto new_position_root = rotation * body_root->get_position();
-    auto new_rotation_root = (rotation * body_root->get_rotation()).normalized();
-    body_root->set_position(new_position_root);
-    body_root->set_rotation(new_rotation_root);
+    body_root->rotate(angle, axis);
     // blade cog
-    auto new_position_cog = rotation * body_cog->get_position();
-    auto new_rotation_cog = (rotation * body_cog->get_rotation()).normalized();
-    body_cog->set_position(new_position_cog);
-    body_cog->set_rotation(new_rotation_cog);
+    body_cog->rotate(angle, axis);
 }
 
 void BladeElastoRigid::translate(const Vector3d& translation_vector) const {
     // blade root
-    body_root->set_position(body_root->get_position() + translation_vector);
-    body_cog->set_position(body_cog->get_position() + translation_vector);
+    body_root->translate(translation_vector);
+    // blade cog
+    body_cog->translate(translation_vector);
 }
 
 double BladeElastoRigid::get_mass() const {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -788,6 +788,10 @@ void SystemElastoChrono::assemble() {
         turbine->assemble(*this);
     }
     is_assembled = true;
+
+    // needed for some Chrono (e.g. for moorings or HydroChrono floater)
+    chobj->Update();
+
     spdlog::debug("Finished assembly of system.");
 }
 
@@ -836,6 +840,8 @@ void SystemElastoChrono::do_statics(bool linear, int nonlinear_steps) {
         // tower
         turbine->tower.nodes.front()->set_fixed(tower_fixed[idx_turbine]);
     }
+
+    spdlog::debug("Performed statics prestep with linear step as {} and {} nonlinear steps.", linear, nonlinear_steps);
 };
 
 Vector3d SystemElastoChrono::get_gravitational_acceleration() const {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -408,10 +408,15 @@ NodeElastoChronoD::NodeElastoChronoD(const Vector3d& position, const Vector3d& d
     NodeElastoChronoBase::chobj = chobj;
 }
 
-void NodeElastoChronoD::set_rotation(const Quaternion& rotation) {}
+void NodeElastoChronoD::set_rotation(const Quaternion& rotation) {
+    // set rotation assuming direction of node to be local Z
+    chobj->SetD(vec2ch(rotation * Vector3d(0.0, 0.0, 1.0)));
+}
 
 Quaternion NodeElastoChronoD::get_rotation() const {
-    return Quaternion(1.0, 0.0, 0.0, 0.0);
+    // get rotation assuming direction of node to be local Z
+    // note: ChNodeFEAxyzD does not have a true rotation, only a direction
+    return Quaternion::FromTwoVectors(Vector3d(0.0, 0.0, 1.0), get_direction());
 }
 
 Vector3d NodeElastoChronoD::get_direction() const {

--- a/src/elasto/component_elasto.cpp
+++ b/src/elasto/component_elasto.cpp
@@ -67,18 +67,14 @@ void ComponentElastoFEA::assemble_this(SystemElasto& system) {
 }
 
 void ComponentElastoFEA::rotate(double angle, const Vector3d& axis) const {
-    auto rotation = AngleAxisd(angle, axis);
     for (auto& node : nodes) {
-        auto new_position = rotation * node->get_position();
-        node->set_position(new_position);
-        auto new_rotation = (rotation * node->get_rotation()).normalized();
-        node->set_rotation(new_rotation);
+        node->rotate(angle, axis);
     }
 }
 
 void ComponentElastoFEA::translate(const Vector3d& translation_vector) const {
     for (auto& node : nodes) {
-        node->set_position(node->get_position() + translation_vector);
+        node->translate(translation_vector);
     }
 }
 double ComponentElastoFEA::get_mass() const {

--- a/src/elasto/floater_elasto.cpp
+++ b/src/elasto/floater_elasto.cpp
@@ -1,6 +1,7 @@
 #include "seahowl/elasto/floater_elasto.h"
 
 #include "seahowl/elasto/chrono_adapters.h"
+#include "seahowl/elasto/mooring_elasto.h"
 
 #include <spdlog/spdlog.h>
 
@@ -8,7 +9,12 @@ using namespace seahowl::elasto;
 
 FloaterElasto::FloaterElasto() {
     body_main = std::make_unique<seahowl::elasto::BodyElastoChrono>();
+    mooring_system = std::make_unique<seahowl::elasto::MooringSystem>();
 };
+
+void FloaterElasto::build() {
+    mooring_system->build();
+}
 
 void FloaterElasto::prestep(double time, double dt) {
     auto& floater_body = *body_main;
@@ -32,6 +38,9 @@ void FloaterElasto::prestep(double time, double dt) {
     // apply damping
     floater_body.accumulate_force(damping_force, false);
     floater_body.accumulate_torque(damping_torque, false);
+
+    // mooring system prestep
+    mooring_system->prestep(time, dt);
 }
 
 void FloaterElasto::add_body(const std::string& name) {
@@ -96,10 +105,12 @@ seahowl::elasto::Link& FloaterElasto::get_fairlead_link(const std::string& body_
 }
 
 void FloaterElasto::assemble_this(seahowl::elasto::SystemElasto& system) {
+    // first add hydro bodies
     for (auto& bodymap : floater_bodies) {
         auto& body = *bodymap.second;
         system.add(body);
     }
+
     // link hydro bodies to body_main
     // needs to happen after adding hydro bodies to system (HydroChrono requirement)
     system.add(*body_main);
@@ -119,6 +130,9 @@ void FloaterElasto::assemble_this(seahowl::elasto::SystemElasto& system) {
             system.add(*link);
         }
     }
+
+    // moorings
+    mooring_system->assemble(system);
 }
 
 void FloaterElasto::translate(const Vector3d& translation_vector) const {
@@ -131,6 +145,8 @@ void FloaterElasto::translate(const Vector3d& translation_vector) const {
     for (auto& fairleadmap : floater_bodies) {
         fairleadmap.second->translate(translation_vector);
     }
+    // mooring system translate
+    mooring_system->translate(translation_vector);
 }
 
 void FloaterElasto::rotate(double angle, const Vector3d& axis) const {
@@ -143,6 +159,8 @@ void FloaterElasto::rotate(double angle, const Vector3d& axis) const {
     for (auto& fairleadmap : floater_bodies) {
         fairleadmap.second->rotate(angle, axis);
     }
+    // mooring system rotate
+    mooring_system->rotate(angle, axis);
 }
 
 double FloaterElasto::get_mass() const {
@@ -156,5 +174,7 @@ double FloaterElasto::get_mass() const {
             total_mass += fairlead->get_mass();
         }
     }
+    // mooring system
+    total_mass += mooring_system->get_mass();
     return total_mass;
 }

--- a/src/elasto/floater_elasto.cpp
+++ b/src/elasto/floater_elasto.cpp
@@ -124,20 +124,23 @@ void FloaterElasto::assemble_this(seahowl::elasto::SystemElasto& system) {
 void FloaterElasto::translate(const Vector3d& translation_vector) const {
     // translate all bodies
     for (auto& bodymap : floater_bodies) {
-        auto& body = *bodymap.second;
-        body.set_position(body.get_position() + translation_vector);
+        bodymap.second->translate(translation_vector);
+    }
+    // translate all fairleads
+    for (auto& fairleadmap : floater_bodies) {
+        fairleadmap.second->translate(translation_vector);
     }
 }
 
 void FloaterElasto::rotate(double angle, const Vector3d& axis) const {
     // rotate all bodies
-    auto rotation = AngleAxisd(angle, axis);
+    body_main->rotate(angle, axis);
     for (auto& bodymap : floater_bodies) {
-        auto& body = *bodymap.second;
-        auto new_position_body = rotation * body.get_position();
-        auto new_rotation_body = (rotation * body.get_rotation()).normalized();
-        body.set_position(new_position_body);
-        body.set_rotation(new_rotation_body);
+        bodymap.second->rotate(angle, axis);
+    }
+    // rotate all fairleads
+    for (auto& fairleadmap : floater_bodies) {
+        fairleadmap.second->rotate(angle, axis);
     }
 }
 

--- a/src/elasto/floater_elasto.cpp
+++ b/src/elasto/floater_elasto.cpp
@@ -123,6 +123,7 @@ void FloaterElasto::assemble_this(seahowl::elasto::SystemElasto& system) {
 
 void FloaterElasto::translate(const Vector3d& translation_vector) const {
     // translate all bodies
+    body_main->translate(translation_vector);
     for (auto& bodymap : floater_bodies) {
         bodymap.second->translate(translation_vector);
     }

--- a/src/elasto/mooring_elasto.cpp
+++ b/src/elasto/mooring_elasto.cpp
@@ -31,14 +31,9 @@ void MooringSystem::rotate(double angle, const Vector3d& axis) const {
     for (auto& mooring : moorings) {
         mooring->rotate(angle, axis);
     }
-
     // anchors
-    auto rotation = AngleAxisd(angle, axis);
     for (auto& anchor : anchors) {
-        auto new_position_anchor = rotation * anchor->get_position();
-        auto new_rotation_anchor = (rotation * anchor->get_rotation()).normalized();
-        anchor->set_position(new_position_anchor);
-        anchor->set_rotation(new_rotation_anchor);
+        anchor->rotate(angle, axis);
     }
 }
 
@@ -47,10 +42,9 @@ void MooringSystem::translate(const Vector3d& translation_vector) const {
     for (auto& mooring : moorings) {
         mooring->translate(translation_vector);
     }
-
     // anchors
     for (auto& anchor : anchors) {
-        anchor->set_position(anchor->get_position() + translation_vector);
+        anchor->translate(translation_vector);
     }
 }
 

--- a/src/elasto/mooring_elasto.cpp
+++ b/src/elasto/mooring_elasto.cpp
@@ -11,6 +11,12 @@ using namespace seahowl::elasto;
 
 MooringSystem::MooringSystem() {}
 
+void MooringSystem::prestep(double time, double dt) {
+    for (auto& mooring : moorings) {
+        mooring->prestep(time, dt);
+    }
+}
+
 void MooringSystem::build() {
     for (auto& mooring : moorings) {
         mooring->build();

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -78,12 +78,8 @@ void RotorElasto::rotate(double angle, const Vector3d& axis) const {
     for (auto& blade : blades) {
         blade->rotate(angle, axis);
     }
-    auto rotation = AngleAxisd(angle, axis);
     // hub
-    auto new_position_hub = rotation * body_hub->get_position();
-    auto new_rotation_hub = (rotation * body_hub->get_rotation()).normalized();
-    body_hub->set_position(new_position_hub);
-    body_hub->set_rotation(new_rotation_hub);
+    body_hub->rotate(angle, axis);
 }
 
 void RotorElasto::translate(const Vector3d& translation_vector) const {
@@ -92,7 +88,7 @@ void RotorElasto::translate(const Vector3d& translation_vector) const {
         blade->translate(translation_vector);
     }
     // hub
-    body_hub->set_position(body_hub->get_position() + translation_vector);
+    body_hub->translate(translation_vector);
 }
 
 double RotorElasto::get_mass() const {
@@ -181,31 +177,22 @@ void RotorNacelleAssemblyElasto::rotate(double angle, const Vector3d& axis) cons
     rotor->rotate(angle, axis);
     auto rotation = AngleAxisd(angle, axis);
     // shaft
-    auto new_position_shaft = rotation * body_shaft->get_position();
-    auto new_rotation_shaft = (rotation * body_shaft->get_rotation()).normalized();
-    body_shaft->set_position(new_position_shaft);
-    body_shaft->set_rotation(new_rotation_shaft);
+    body_shaft->rotate(angle, axis);
     // nacelle
-    auto new_position_nacelle = rotation * body_nacelle->get_position();
-    auto new_rotation_nacelle = (rotation * body_nacelle->get_rotation()).normalized();
-    body_nacelle->set_position(new_position_nacelle);
-    body_nacelle->set_rotation(new_rotation_nacelle);
+    body_nacelle->rotate(angle, axis);
     // yaw bearing
-    auto new_position_yaw_bearing = rotation * body_yaw_bearing->get_position();
-    auto new_rotation_yaw_bearing = (rotation * body_yaw_bearing->get_rotation()).normalized();
-    body_yaw_bearing->set_position(new_position_yaw_bearing);
-    body_yaw_bearing->set_rotation(new_rotation_yaw_bearing);
+    body_yaw_bearing->rotate(angle, axis);
 }
 
 void RotorNacelleAssemblyElasto::translate(const Vector3d& translation_vector) const {
     // rotor
     rotor->translate(translation_vector);
     // shaft
-    body_shaft->set_position(body_shaft->get_position() + translation_vector);
+    body_shaft->translate(translation_vector);
     // nacelle
-    body_nacelle->set_position(body_nacelle->get_position() + translation_vector);
+    body_nacelle->translate(translation_vector);
     // yaw_bearing
-    body_yaw_bearing->set_position(body_yaw_bearing->get_position() + translation_vector);
+    body_yaw_bearing->translate(translation_vector);
 }
 
 double RotorNacelleAssemblyElasto::get_mass() const {

--- a/src/elasto/turbine_floating_elasto.cpp
+++ b/src/elasto/turbine_floating_elasto.cpp
@@ -46,6 +46,8 @@ void TurbineFloatingElasto::build() {
 void TurbineFloatingElasto::translate(const Vector3d& translation_vector) const {
     // parent class translate
     TurbineElasto::translate(translation_vector);
+    // mooring system translate
+    mooring_system->translate(translation_vector);
     // floater translate
     if (floater) {
         floater->translate(translation_vector);
@@ -55,6 +57,8 @@ void TurbineFloatingElasto::translate(const Vector3d& translation_vector) const 
 void TurbineFloatingElasto::rotate(double angle, const Vector3d& axis) const {
     // parent class rotate
     TurbineElasto::rotate(angle, axis);
+    // mooring system rotate
+    mooring_system->rotate(angle, axis);
     // floater rotate
     if (floater) {
         floater->rotate(angle, axis);
@@ -65,6 +69,8 @@ double TurbineFloatingElasto::get_mass() const {
     double total_mass = 0.0;
     // turbine
     total_mass += TurbineElasto::get_mass();
+    // mooring system
+    total_mass += mooring_system->get_mass();
     // floater
     if (floater) {
         total_mass += floater->get_mass();

--- a/src/elasto/turbine_floating_elasto.cpp
+++ b/src/elasto/turbine_floating_elasto.cpp
@@ -9,7 +9,6 @@ using namespace seahowl::elasto;
 
 TurbineFloatingElasto::TurbineFloatingElasto() : TurbineElasto() {
     link_floater_tower = std::make_unique<seahowl::elasto::LinkChrono>();
-    mooring_system = std::make_unique<MooringSystem>();
 }
 
 void TurbineFloatingElasto::assemble_this(SystemElasto& system) {
@@ -28,16 +27,12 @@ void TurbineFloatingElasto::assemble_this(SystemElasto& system) {
 
     // assemble parent class
     TurbineElasto::assemble_this(system);
-
-    // moorings
-    mooring_system->assemble(system);
 }
 
 void TurbineFloatingElasto::build() {
     if (floater) {
         floater->build();
     }
-    mooring_system->build();
 
     // parent class build
     TurbineElasto::build();
@@ -46,8 +41,6 @@ void TurbineFloatingElasto::build() {
 void TurbineFloatingElasto::translate(const Vector3d& translation_vector) const {
     // parent class translate
     TurbineElasto::translate(translation_vector);
-    // mooring system translate
-    mooring_system->translate(translation_vector);
     // floater translate
     if (floater) {
         floater->translate(translation_vector);
@@ -57,8 +50,6 @@ void TurbineFloatingElasto::translate(const Vector3d& translation_vector) const 
 void TurbineFloatingElasto::rotate(double angle, const Vector3d& axis) const {
     // parent class rotate
     TurbineElasto::rotate(angle, axis);
-    // mooring system rotate
-    mooring_system->rotate(angle, axis);
     // floater rotate
     if (floater) {
         floater->rotate(angle, axis);
@@ -69,8 +60,6 @@ double TurbineFloatingElasto::get_mass() const {
     double total_mass = 0.0;
     // turbine
     total_mass += TurbineElasto::get_mass();
-    // mooring system
-    total_mass += mooring_system->get_mass();
     // floater
     if (floater) {
         total_mass += floater->get_mass();

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -1152,8 +1152,11 @@ void initialize_system_from_json(const std::string& filepath, seahowl::core::Sys
         spdlog::debug("Performed statics prestep with linear step as {} and {} nonlinear steps.", linear_step,
                       nonlinear_steps);
     } else {
+        // need to do tiny time step before system initialization if statics not done
+        // this is necessary for moorings for example (needed for Chrono to set element length element)
         double tiny_dt = 1e-6;
-        system_core.step(tiny_dt);  // need to do tiny time step before system initialization if statics not done
+        spdlog::debug("Making small time step before initializing system.");
+        system_core.step(tiny_dt);
         system_core.set_time(system_core.get_time() - tiny_dt);
     }
 

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -988,6 +988,7 @@ std::shared_ptr<seahowl::env::FluidSoilModel> get_environmental_model_from_json(
             soil_options.at("stiffness_normal").get_to(soil_model.stiffness_normal);
             soil_options.at("stiffness_shear").get_to(soil_model.stiffness_shear);
             soil_model.soil_normal = -gravity_direction;
+            env_model->soil_model = std::move(soil_model_shared);
         } else {
             throw std::runtime_error("The input soil type is unknown. Please use the existing soil types: linear.");
         }

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -1150,15 +1150,6 @@ void initialize_system_from_json(const std::string& filepath, seahowl::core::Sys
     auto nonlinear_steps = statics_json.at("nonlinear_steps").get<int>();
     if (linear_step && nonlinear_steps > 0) {
         system_core.elasto.do_statics(linear_step, nonlinear_steps);
-        spdlog::debug("Performed statics prestep with linear step as {} and {} nonlinear steps.", linear_step,
-                      nonlinear_steps);
-    } else {
-        // need to do tiny time step before system initialization if statics not done
-        // this is necessary for moorings for example (needed for Chrono to set element length element)
-        double tiny_dt = 1e-6;
-        spdlog::debug("Making small time step before initializing system.");
-        system_core.step(tiny_dt);
-        system_core.set_time(system_core.get_time() - tiny_dt);
     }
 
     system_core.initialize(system_core.get_time(), dt);

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -803,18 +803,18 @@ void populate_turbine_from_json(const std::string& filepath,
                     if (mooring_json.at("relative_anchor").get<bool>()) {
                         anchor_position += floater.body_main->get_position();
                     }
-                    turbine_floating.mooring_system->anchors.push_back(
+                    turbine_floating.floater->mooring_system->anchors.push_back(
                         std::make_shared<seahowl::elasto::BodyElastoChrono>());
-                    auto& anchor_body = *turbine_floating.mooring_system->anchors.back();
+                    auto& anchor_body = *turbine_floating.floater->mooring_system->anchors.back();
                     anchor_body.set_position(anchor_position);
                     anchor_body.set_fixed(true);
 
                     auto mooring_properties_json = get_json_from_file(
                         (DATADIR / mooring_json.at("line_properties").get<std::string>()).generic_string());
-                    turbine_floating.mooring_system->moorings.push_back(
+                    turbine_floating.floater->mooring_system->moorings.push_back(
                         std::make_shared<seahowl::elasto::MooringElastoFEA>(fairlead_body, anchor_body));
                     auto& mooring = dynamic_cast<seahowl::elasto::MooringElastoFEA&>(
-                        *turbine_floating.mooring_system->moorings.back());
+                        *turbine_floating.floater->mooring_system->moorings.back());
 
                     mooring_json.at("length").get_to(mooring.length);
                     mooring_json.at("discretization_elasto").get_to(mooring.discretization_fractions);

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -1109,13 +1109,13 @@ void populate_system_from_json(const std::string& filepath, seahowl::core::Syste
                       .normalized();
         auto rot_axis = v2.cross(v1);
         auto rot_angle = acos(v1.dot(v2));
-        turbine.rotate(rot_angle, rot_axis);
+        turbine.elasto.rotate(rot_angle, rot_axis);
         // rotation around axis opposite to gravity (yaw)
-        turbine.rotate(turbine_json.at("rotation").get<double>(),
-                       Vector3d(-system_core.elasto.get_gravitational_acceleration()).normalized());
+        turbine.elasto.rotate(turbine_json.at("rotation").get<double>() * PI / 180.0,
+                              Vector3d(-system_core.elasto.get_gravitational_acceleration()).normalized());
         // translate turbine
         auto trans = turbine_json.at("translation").get<std::vector<double>>();
-        turbine.translate(Vector3d(trans[0], trans[1], trans[2]));
+        turbine.elasto.translate(Vector3d(trans[0], trans[1], trans[2]));
 
         try {
             // if floating: do not fix tower

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -786,7 +786,7 @@ TEST(test_turbine, multiturbines) {
         turbine.controller = std::make_shared<seahowl::servo::Controller>();
         // translate
         turbine.build();
-        turbine.translate(Vector3d(0.0 + ii * 150.0, 0.0 + ii * (-150.0), 0.0));
+        turbine.elasto.translate(Vector3d(0.0 + ii * 150.0, 0.0 + ii * (-150.0), 0.0));
         // fix
         turbine.tower.elasto.nodes.front()->set_fixed(true);
     }


### PR DESCRIPTION
This PR makes it possible to attach any ComponentDynamic (Blade, Tower, etc) to a System (previously only Turbine types could be attached directly).
In addition, it does the following:
- mutualize rotation/translation workflow of components/entities
- make `get_direction()` method for entity (returns local z direction in global frame)
- attach mooring system to floater
- ~~make small time step when calling `Simulation::initialize` (needed for setting some mooring properties through Chrono)~~ this requirement was removed by using Update() on ChSystem
- fix issue where soil model was not attached to environment model when using read_json