### PR TITLE
Add properties and test for towers + Chrono defaults

### DIFF
--- a/include/seahowl/elasto/chrono_adapters.h
+++ b/include/seahowl/elasto/chrono_adapters.h
@@ -240,6 +240,7 @@ class SpringLinearChrono : public SpringLinear {
     virtual void set_rest_length(double rest_length) override;
     virtual void set_spring_coefficient(double spring_coefficient) override;
     virtual void set_damping_coefficient(double damping_coefficient) override;
+    virtual double get_force() override;
 };
 
 /**

--- a/include/seahowl/elasto/entities_elasto.h
+++ b/include/seahowl/elasto/entities_elasto.h
@@ -287,6 +287,11 @@ class SpringLinear {
      * @param[in] damping_coefficient Damping coefficient (D).
      */
     virtual void set_damping_coefficient(double damping_coefficient) = 0;
+
+    /**
+     * @brief Returns force.
+     */
+    virtual double get_force() = 0;
 };
 
 /**

--- a/include/seahowl/elasto/reference_point_elasto.h
+++ b/include/seahowl/elasto/reference_point_elasto.h
@@ -71,6 +71,10 @@ struct TowerReferencePointElasto : ReferencePointElasto {
     double stiffness_sideside = 0.0;
     /** @brief Torsional stiffness of tower at reference point. */
     double stiffness_torsion = 0.0;
+    /** @brief Fore-aft inertia of tower at reference point. */
+    double inertia_foreaft = 0.0;
+    /** @brief Side-side inertia of tower at reference point. */
+    double inertia_sideside = 0.0;
     /** @brief Damping coefficients at reference point {along x, along y, along z, about x, mass-proportional}.*/
     std::vector<double> damping_coefficients{0.03, 0.03, 0.03, 0.06, 0.0};
 

--- a/include/seahowl/elasto/reference_point_elasto.h
+++ b/include/seahowl/elasto/reference_point_elasto.h
@@ -89,6 +89,23 @@ struct TowerReferencePointElasto : ReferencePointElasto {
 
     TowerReferencePointElasto operator*(const double factor) const;
     TowerReferencePointElasto operator+(const TowerReferencePointElasto& other) const;
+
+    /**
+     * @brief Set properties for hollow cylinder.
+     *
+     * @param[in] density Density of material (kg/m3).
+     * @param[in] young_modulus Young's modulus of material (Pa).
+     * @param[in] poisson_ratio Poisson ratio of material (-).
+     * @param[in] outer_diameter Outer diameter of cylinder (m).
+     * @param[in] thickness Thickness of cylinder (m).
+     * @param[in] shear Whether to include shear or not.
+     */
+    void set_properties_cylinder(double density,
+                                 double young_modulus,
+                                 double poisson_ratio,
+                                 double outer_diameter,
+                                 double thickness,
+                                 bool shear = false);
 };
 
 }  // namespace elasto

--- a/include/seahowl/elasto/reference_point_elasto.h
+++ b/include/seahowl/elasto/reference_point_elasto.h
@@ -71,6 +71,10 @@ struct TowerReferencePointElasto : ReferencePointElasto {
     double stiffness_sideside = 0.0;
     /** @brief Torsional stiffness of tower at reference point. */
     double stiffness_torsion = 0.0;
+    /** @brief Fore-aft shear stiffness of tower at reference point. */
+    double stiffness_foreaft_shear = 0.0;
+    /** @brief Side-side shear stiffness of tower at reference point. */
+    double stiffness_sideside_shear = 0.0;
     /** @brief Fore-aft inertia of tower at reference point. */
     double inertia_foreaft = 0.0;
     /** @brief Side-side inertia of tower at reference point. */

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -67,6 +67,7 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("set_rest_length", &seahowl::elasto::SpringLinear::set_rest_length)
         .def("set_spring_coefficient", &seahowl::elasto::SpringLinear::set_spring_coefficient)
         .def("set_damping_coefficient", &seahowl::elasto::SpringLinear::set_damping_coefficient)
+        .def("get_force", &seahowl::elasto::SpringLinear::get_force)
         .def("initialize", &seahowl::elasto::SpringLinear::initialize)
         .def("initialize_with_anchors", &seahowl::elasto::SpringLinear::initialize_with_anchors);
     py::class_<seahowl::elasto::LinkMatrixStiffnessDamping,

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -168,6 +168,9 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def_readwrite("stiffness_foreaft", &seahowl::elasto::TowerReferencePointElasto::stiffness_foreaft)
         .def_readwrite("stiffness_sideside", &seahowl::elasto::TowerReferencePointElasto::stiffness_sideside)
         .def_readwrite("stiffness_torsion", &seahowl::elasto::TowerReferencePointElasto::stiffness_torsion)
+        .def_readwrite("stiffness_foreaft_shear", &seahowl::elasto::TowerReferencePointElasto::stiffness_foreaft_shear)
+        .def_readwrite("stiffness_sideside_shear",
+                       &seahowl::elasto::TowerReferencePointElasto::stiffness_sideside_shear)
         .def_readwrite("inertia_foreaft", &seahowl::elasto::TowerReferencePointElasto::inertia_foreaft)
         .def_readwrite("inertia_sideside", &seahowl::elasto::TowerReferencePointElasto::inertia_sideside)
         .def_readwrite("damping_coefficients", &seahowl::elasto::TowerReferencePointElasto::damping_coefficients)

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -174,7 +174,8 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def_readwrite("inertia_foreaft", &seahowl::elasto::TowerReferencePointElasto::inertia_foreaft)
         .def_readwrite("inertia_sideside", &seahowl::elasto::TowerReferencePointElasto::inertia_sideside)
         .def_readwrite("damping_coefficients", &seahowl::elasto::TowerReferencePointElasto::damping_coefficients)
-        .def(py::init<>());
+        .def(py::init<>())
+        .def("set_properties_cylinder", &seahowl::elasto::TowerReferencePointElasto::set_properties_cylinder);
 
     // elasto/component_elasto.h
     py::class_<seahowl::elasto::ComponentElasto, std::shared_ptr<seahowl::elasto::ComponentElasto>>(m_elasto,

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -168,6 +168,8 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def_readwrite("stiffness_foreaft", &seahowl::elasto::TowerReferencePointElasto::stiffness_foreaft)
         .def_readwrite("stiffness_sideside", &seahowl::elasto::TowerReferencePointElasto::stiffness_sideside)
         .def_readwrite("stiffness_torsion", &seahowl::elasto::TowerReferencePointElasto::stiffness_torsion)
+        .def_readwrite("inertia_foreaft", &seahowl::elasto::TowerReferencePointElasto::inertia_foreaft)
+        .def_readwrite("inertia_sideside", &seahowl::elasto::TowerReferencePointElasto::inertia_sideside)
         .def_readwrite("damping_coefficients", &seahowl::elasto::TowerReferencePointElasto::damping_coefficients)
         .def(py::init<>());
 

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -366,14 +366,19 @@ void NodeElastoChrono::set_properties(const BladeReferencePointElasto& ref, bool
         section->SetCentroidY(ref.offset_elastic.y());
         section->SetCentroidZ(-ref.offset_elastic.x());
         // material properties
+        // see ChBeamSectionTimoshenkoAdvancedGenericFPM methods: SetMassMatrixFPM, SetStiffnessMatrixFPM
         section->SetMassPerUnitLength(mm(0, 0));
+        // inertias per unit length in this order: mIyy, mIzz, mIyz, mQy, mQz
+        section->SetInertiasPerUnitLength(mm(4, 4), mm(5, 5), -mm(4, 5), mm(0, 4), -mm(0, 5));
         // axial
-        section->SetAxialRigidity(sm(0, 0));
         section->SetXtorsionRigidity(sm(3, 3));
+        section->SetAxialRigidity(sm(0, 0));
         // flap
         section->SetYbendingRigidity(sm(4, 4));
+        section->SetYshearRigidity(sm(1, 1));
         // edge
         section->SetZbendingRigidity(sm(5, 5));
+        section->SetZshearRigidity(sm(2, 2));
         // damping
         chrono::fea::DampingCoefficients damping_coefficients;
         // damping coefficients: IEC -> Chrono convention
@@ -391,6 +396,7 @@ void NodeElastoChrono::set_properties(const TowerReferencePointElasto& ref) {
     section = chrono_types::make_shared<chrono::fea::ChBeamSectionTimoshenkoAdvancedGeneric>();
     // material properties
     section->SetMassPerUnitLength(ref.density);
+    section->SetInertiasPerUnitLength(ref.inertia_foreaft, ref.inertia_sideside, 0.0, 0.0, 0.0);
     // axial
     section->SetAxialRigidity(ref.stiffness_axial);
     section->SetXtorsionRigidity(ref.stiffness_torsion);

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -853,6 +853,18 @@ void SystemElastoChrono::assemble() {
     // needed for some Chrono (e.g. for moorings or HydroChrono floater)
     chobj->Update();
 
+    // warnings for properties that were not set
+    int body_idx = 0;
+    for (auto& body : chobj->Get_bodylist()) {
+        if (body->GetMass() == 0) {
+            spdlog::warn("Body with mass 0.0 in elasto system (index of body: {}).", body_idx);
+        }
+        if (body->GetInertia().sum() == 0) {
+            spdlog::warn("Body with empty inertia matrix (sum 0.0) in elasto system (index of body: {}).", body_idx);
+        }
+        body_idx += 1;
+    }
+
     spdlog::debug("Finished assembly of system.");
 }
 

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -165,6 +165,8 @@ Vector3d EntityDynamicChrono::get_rotational_acceleration(bool is_local) const {
 BodyElastoChrono::BodyElastoChrono() {
     chobj = chrono_types::make_shared<chrono::ChBody>();
     EntityDynamicChrono::chobj = chobj;
+    set_mass(0.0);
+    set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
 }
 
 void BodyElastoChrono::set_mass(double mass) {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -402,8 +402,10 @@ void NodeElastoChrono::set_properties(const TowerReferencePointElasto& ref) {
     section->SetXtorsionRigidity(ref.stiffness_torsion);
     // foreaft
     section->SetYbendingRigidity(ref.stiffness_foreaft);
+    section->SetYshearRigidity(ref.stiffness_foreaft_shear);
     // sideside
     section->SetZbendingRigidity(ref.stiffness_sideside);
+    section->SetZshearRigidity(ref.stiffness_sideside_shear);
     // damping
     if (ref.damping_coefficients.size() != 5) {
         throw std::runtime_error("Damping coefficients for tower must be a vector of length 5 (got " +

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -684,6 +684,10 @@ void SpringLinearChrono::set_damping_coefficient(double damping_coefficient) {
     chobj->SetDampingCoefficient(damping_coefficient);
 }
 
+double SpringLinearChrono::get_force() {
+    return chobj->GetForce();
+}
+
 LinkChrono::LinkChrono() {
     chobj = chrono_types::make_shared<chrono::ChLinkMateGeneric>();
     chobj->SetConstrainedCoords(true, true, true, true, true, true);

--- a/src/elasto/reference_point_elasto.cpp
+++ b/src/elasto/reference_point_elasto.cpp
@@ -1,5 +1,7 @@
 #include "seahowl/elasto/reference_point_elasto.h"
 
+#include <spdlog/spdlog.h>
+
 using namespace seahowl::elasto;
 
 BladeReferencePointElasto::BladeReferencePointElasto() {}
@@ -81,6 +83,43 @@ TowerReferencePointElasto TowerReferencePointElasto::operator+(const TowerRefere
     new_point.damping_coefficients[4] += other.damping_coefficients[4];
     return new_point;
 };
+
+void TowerReferencePointElasto::set_properties_cylinder(double density_volume,
+                                                        double young_modulus,
+                                                        double poisson_ratio,
+                                                        double outer_diameter,
+                                                        double thickness,
+                                                        bool shear) {
+    auto shear_modulus = 0.5 * young_modulus / (1.0 + poisson_ratio);
+
+    // geometry info
+    auto d1 = outer_diameter;
+    auto d2 = outer_diameter - 2.0 * thickness;
+    auto area = PI * (pow(d1, 2) - pow(d2, 2)) / 4.0;
+    // linear density
+    auto density_linear = density_volume * area;
+    // stiffnesses
+    auto EI = young_modulus * PI * (pow(d1, 4) - pow(d2, 4)) / 64.;  // bending
+    auto EA = young_modulus * area;                                  // axial
+    auto kt = shear_modulus * PI * (pow(d1, 4) - pow(d2, 4)) / 32.;  // torsion
+
+    // populate reference point
+    stiffness_foreaft = EI;
+    stiffness_sideside = EI;
+    stiffness_axial = EA;
+    stiffness_torsion = kt;
+    density = density_linear;
+    inertia_foreaft = EI / young_modulus * density_volume;
+    inertia_sideside = EI / young_modulus * density_volume;
+
+    if (shear) {
+        stiffness_foreaft_shear = shear_modulus * area;
+        stiffness_sideside_shear = shear_modulus * area;
+    } else {
+        stiffness_foreaft_shear = 0.0;
+        stiffness_sideside_shear = 0.0;
+    }
+}
 
 ReferencePointElasto::ReferencePointElasto() {}
 

--- a/src/elasto/reference_point_elasto.cpp
+++ b/src/elasto/reference_point_elasto.cpp
@@ -49,6 +49,8 @@ TowerReferencePointElasto TowerReferencePointElasto::operator*(const double fact
     new_point.stiffness_foreaft *= factor;
     new_point.stiffness_sideside *= factor;
     new_point.stiffness_torsion *= factor;
+    new_point.stiffness_foreaft_shear *= factor;
+    new_point.stiffness_sideside_shear *= factor;
     new_point.inertia_foreaft *= factor;
     new_point.inertia_sideside *= factor;
     new_point.damping_coefficients[0] *= factor;
@@ -68,6 +70,8 @@ TowerReferencePointElasto TowerReferencePointElasto::operator+(const TowerRefere
     new_point.stiffness_foreaft += other.stiffness_foreaft;
     new_point.stiffness_sideside += other.stiffness_sideside;
     new_point.stiffness_torsion += other.stiffness_torsion;
+    new_point.stiffness_foreaft_shear += other.stiffness_foreaft_shear;
+    new_point.stiffness_sideside_shear += other.stiffness_sideside_shear;
     new_point.inertia_foreaft += other.inertia_foreaft;
     new_point.inertia_sideside += other.inertia_sideside;
     new_point.damping_coefficients[0] += other.damping_coefficients[0];

--- a/src/elasto/reference_point_elasto.cpp
+++ b/src/elasto/reference_point_elasto.cpp
@@ -49,6 +49,8 @@ TowerReferencePointElasto TowerReferencePointElasto::operator*(const double fact
     new_point.stiffness_foreaft *= factor;
     new_point.stiffness_sideside *= factor;
     new_point.stiffness_torsion *= factor;
+    new_point.inertia_foreaft *= factor;
+    new_point.inertia_sideside *= factor;
     new_point.damping_coefficients[0] *= factor;
     new_point.damping_coefficients[1] *= factor;
     new_point.damping_coefficients[2] *= factor;
@@ -66,6 +68,8 @@ TowerReferencePointElasto TowerReferencePointElasto::operator+(const TowerRefere
     new_point.stiffness_foreaft += other.stiffness_foreaft;
     new_point.stiffness_sideside += other.stiffness_sideside;
     new_point.stiffness_torsion += other.stiffness_torsion;
+    new_point.inertia_foreaft += other.inertia_foreaft;
+    new_point.inertia_sideside += other.inertia_sideside;
     new_point.damping_coefficients[0] += other.damping_coefficients[0];
     new_point.damping_coefficients[1] += other.damping_coefficients[1];
     new_point.damping_coefficients[2] += other.damping_coefficients[2];

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -142,7 +142,8 @@ void RotorNacelleAssemblyElasto::build() {
     // align rotation
     body_shaft->set_rotation(rotor->body_hub->get_rotation());
     // massless body
-    body_shaft->set_mass(0.0);
+    body_shaft->set_mass(1e-6);
+    body_shaft->set_inertia_diagonal(Vector3d(1e-6, 1e-6, 1e-6));
     // link hub to shaft
     link_shaft_hub = std::make_unique<LinkChrono>();
     link_shaft_hub->initialize(*(rotor->body_hub.get()), *(body_shaft.get()));
@@ -166,6 +167,7 @@ void RotorNacelleAssemblyElasto::build() {
     body_yaw_bearing->set_position(Vector3d(0.0, 0.0, 0.0));
     body_yaw_bearing->set_rotation(rotation0);
     body_yaw_bearing->set_mass(nacelle.yaw_bearing_mass);
+    body_yaw_bearing->set_inertia_diagonal(Vector3d(1e-6, 1e-6, 1e-6));
     // link yaw bearing body to shaft body
     link_shaft_yaw_bearing = std::make_unique<LinkChrono>();
     link_shaft_yaw_bearing->initialize(*(body_shaft.get()), *(body_yaw_bearing.get()));

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -325,38 +325,11 @@ std::vector<seahowl::elasto::TowerReferencePointElasto> get_tower_elasto_referen
         auto density = input_data->get("density", ii);
         auto young_modulus = input_data->get("young_modulus", ii);
         auto poisson_ratio = input_data->get("poisson_ratio", ii);
-        auto shear_modulus = 0.5 * young_modulus / (1.0 + poisson_ratio);
-
-        // point-specific properties
         auto diameter = input_data->get("diameter", ii);
         auto thickness = input_data->get("thickness", ii);
-
-        // geometry info
-        auto d1 = diameter;
-        auto d2 = diameter - 2.0 * thickness;
-        auto area = PI * (pow(d1, 2) - pow(d2, 2)) / 4.0;
-        // linear density
-        auto density_linear = density * area;
-        // stiffnesses
-        auto EI = young_modulus * PI * (pow(d1, 4) - pow(d2, 4)) / 64.;  // bending
-        auto EA = young_modulus * area;                                  // axial
-        auto kt = shear_modulus * PI * (pow(d1, 4) - pow(d2, 4)) / 32.;  // torsion
-
-        // populate reference point
-        reference_point.stiffness_foreaft = EI;
-        reference_point.stiffness_sideside = EI;
-        reference_point.stiffness_axial = EA;
-        reference_point.stiffness_torsion = kt;
-        reference_point.density = density_linear;
-        reference_point.inertia_foreaft = EI / young_modulus * density_linear;
-        reference_point.inertia_sideside = EI / young_modulus * density_linear;
-
-        // shear leads to issues when tower is not finely discretized (wrong nat. freq.), and its effect is small enough
-        // to be neglected
-        reference_point.stiffness_foreaft_shear = 0.0;
-        reference_point.stiffness_sideside_shear = 0.0;
-        // reference_point.stiffness_foreaft_shear = shear_modulus * area;
-        // reference_point.stiffness_sideside_shear = shear_modulus * area;
+        // shear set to false as it leads to issues when tower is not finely discretized (wrong nat. freq.)
+        // its effect is usually small enough to be neglected here
+        reference_point.set_properties_cylinder(density, young_modulus, poisson_ratio, diameter, thickness, false);
 
         reference_point.damping_coefficients[0] = input_data->get("damping_z", ii);
         reference_point.damping_coefficients[1] = input_data->get("damping_y", ii);

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -351,6 +351,13 @@ std::vector<seahowl::elasto::TowerReferencePointElasto> get_tower_elasto_referen
         reference_point.inertia_foreaft = EI / young_modulus * density_linear;
         reference_point.inertia_sideside = EI / young_modulus * density_linear;
 
+        // shear leads to issues when tower is not finely discretized (wrong nat. freq.), and its effect is small enough
+        // to be neglected
+        reference_point.stiffness_foreaft_shear = 0.0;
+        reference_point.stiffness_sideside_shear = 0.0;
+        // reference_point.stiffness_foreaft_shear = shear_modulus * area;
+        // reference_point.stiffness_sideside_shear = shear_modulus * area;
+
         reference_point.damping_coefficients[0] = input_data->get("damping_z", ii);
         reference_point.damping_coefficients[1] = input_data->get("damping_y", ii);
         reference_point.damping_coefficients[2] = input_data->get("damping_x", ii);

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -348,6 +348,8 @@ std::vector<seahowl::elasto::TowerReferencePointElasto> get_tower_elasto_referen
         reference_point.stiffness_axial = EA;
         reference_point.stiffness_torsion = kt;
         reference_point.density = density_linear;
+        reference_point.inertia_foreaft = EI / young_modulus * density_linear;
+        reference_point.inertia_sideside = EI / young_modulus * density_linear;
 
         reference_point.damping_coefficients[0] = input_data->get("damping_z", ii);
         reference_point.damping_coefficients[1] = input_data->get("damping_y", ii);

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -141,6 +141,7 @@ TEST(test_blade, edgewise) {
 
     // blade
     auto blade = seahowl::elasto::BladeElastoFEA();
+    blade.fpm_mode = true;
     populate_blade_elasto_from_json((DATADIR / "blade.json").generic_string(), blade);
     // make 50 elements
     blade.discretization_fractions.clear();
@@ -157,12 +158,12 @@ TEST(test_blade, edgewise) {
 
     // test deflection
     system_elasto.do_statics(true, 10);
-    double deflection_edge = -0.954337;
+    double deflection_edge = -1.093264;
     ASSERT_NEAR(deflection_edge, blade.nodes.back()->get_position().z(), 1e-4);
     // flip blade
     blade.rotate(PI, Vector3d(0.0, 1.0, 0.0));
     system_elasto.do_statics(true, 10);
-    double deflection_edge2 = -1.197823;
+    double deflection_edge2 = -1.336049;
     ASSERT_NEAR(deflection_edge2, blade.nodes.back()->get_position().z(), 1e-4);
 
     // static position of blade tip
@@ -182,7 +183,7 @@ TEST(test_blade, edgewise) {
         if (time > 0.5) {
             blade.nodes.back()->reset_loads();
             if (blade.nodes.back()->get_position().z() < pos0 && pos_y > pos0) {
-                if (start_time == 0.0) {
+                if (start_time == 0.0 && npeaks == 0) {
                     start_time = time;
                 } else {
                     npeaks += 1;
@@ -197,7 +198,7 @@ TEST(test_blade, edgewise) {
     }
 
     // literature edgewise natural frequency for IEA15MW: 0.642Hz (1.558s)
-    double natural_period_ref = 1.343;
+    double natural_period_ref = 1.436667;
     ASSERT_NEAR(natural_period_ref, natural_period, 0.01);
 }
 
@@ -208,6 +209,7 @@ TEST(test_blade, flapwise) {
 
     // blade
     auto blade = seahowl::elasto::BladeElastoFEA();
+    blade.fpm_mode = true;
     populate_blade_elasto_from_json((DATADIR / "blade.json").generic_string(), blade);
     // make 50 elements
     blade.discretization_fractions.clear();
@@ -224,12 +226,12 @@ TEST(test_blade, flapwise) {
 
     // test deflection
     system_elasto.do_statics(true, 10);
-    double deflection_flap = 1.676042;
+    double deflection_flap = 1.628503;
     ASSERT_NEAR(deflection_flap, blade.nodes.back()->get_position().z(), 1e-4);
     // flip blade
     blade.rotate(PI, Vector3d(1.0, 0.0, 0.0));
     system_elasto.do_statics(true, 10);
-    double deflection_flap2 = -6.012171;
+    double deflection_flap2 = -6.059450;
     ASSERT_NEAR(deflection_flap2, blade.nodes.back()->get_position().z(), 1e-4);
 
     // static position of blade tip
@@ -249,7 +251,7 @@ TEST(test_blade, flapwise) {
         if (time > 0.5) {
             blade.nodes.back()->reset_loads();
             if (blade.nodes.back()->get_position().z() < pos0 && pos_y > pos0) {
-                if (start_time == 0.0) {
+                if (start_time == 0.0 && npeaks == 0) {
                     start_time = time;
                 } else {
                     npeaks += 1;
@@ -264,7 +266,7 @@ TEST(test_blade, flapwise) {
     }
 
     // literature flapwise natural frequency for IEA15MW: 0.555Hz (1.802s)
-    double natural_period_ref = 1.92;
+    double natural_period_ref = 1.980000;
     ASSERT_NEAR(natural_period_ref, natural_period, 0.01);
 }
 
@@ -413,7 +415,7 @@ TEST(test_turbine, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.696608, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.697277, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_fpm) {
@@ -745,7 +747,7 @@ TEST(test_aerodyn, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.715747, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.716130, 1e-4);
 }
 #endif
 
@@ -879,6 +881,6 @@ TEST(test_inflowwind, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.686469, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.686779, 1e-4);
 }
 #endif

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -134,6 +134,80 @@ TEST(test_tower, mass) {
     ASSERT_NEAR(tower_mass, tower.get_mass(), 1.0);
 }
 
+TEST(test_tower, frequency) {
+    // system
+    auto system_elasto = SystemElastoChrono();
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
+
+    // tower
+    auto tower = seahowl::elasto::TowerElasto();
+    // properties
+    auto density = 7850.0;
+    auto young_modulus = 2.11e11;
+    auto poisson_ratio = 0.3;
+    auto diameter = 4.0;
+    auto thickness = 0.03;
+    // bottom
+    auto ref_point1 = seahowl::elasto::TowerReferencePointElasto();
+    ref_point1.set_properties_cylinder(density, young_modulus, poisson_ratio, diameter, thickness, false);
+    ref_point1.coordinates = seahowl::Vector3d(0.0, 0.0, 0.0);
+    ref_point1.fraction = 0.0;
+    // top
+    auto ref_point2 = seahowl::elasto::TowerReferencePointElasto();
+    ref_point2.set_properties_cylinder(density, young_modulus, poisson_ratio, diameter, thickness, false);
+    ref_point2.coordinates = seahowl::Vector3d(0.0, 0.0, 100.0);
+    ref_point2.fraction = 1.0;
+    //
+    tower.reference_points = {ref_point1, ref_point2};
+    tower.discretization_fractions = {20};
+    tower.build();
+    tower.assemble(system_elasto);
+    tower.nodes.front()->set_fixed(true);
+
+    system_elasto.do_statics(true, 0);
+
+    // check mass
+    double tower_mass = 293718.5;
+    ASSERT_NEAR(tower_mass, tower.get_mass(), 1.0);
+
+    // static position of tower top
+    double pos0 = tower.nodes.back()->get_position().x();
+
+    // check zero-crossings (static position of tower top)
+    int step = 0;
+    double pos_y = 0.0;
+    double dt = 0.01;
+    int npeaks = 0;
+    double natural_period = 0.0;
+    double time = 0.0;
+    double end_time = 10.0;
+    double start_time = 0.0;
+    tower.nodes.back()->set_force(Vector3d(100000.0, 0.0, 0.0), false);
+    while (time < end_time) {
+        if (time > 0.5) {
+            tower.nodes.back()->set_force(Vector3d(0.0, 0.0, 0.0), false);
+            tower.nodes.back()->reset_loads();
+            if (tower.nodes.back()->get_position().x() < pos0 && pos_y > pos0) {
+                if (start_time == 0.0 && npeaks == 0) {
+                    start_time = time;
+                } else {
+                    npeaks += 1;
+                    natural_period = (time - start_time) / npeaks;
+                }
+            }
+        } else {
+            tower.nodes.back()->set_force(Vector3d(100000.0, 0.0, 0.0), false);
+        }
+        pos_y = tower.nodes.back()->get_position().x();
+        system_elasto.step(dt);
+        time += dt;
+        step += 1;
+    }
+
+    double natural_period_ref = 2.493333;  // theory: 0.4062Hz (2.4618s), f1=1.875^2/2pi*sqrt(EI/(rho*A*L^4))
+    ASSERT_NEAR(natural_period_ref, natural_period, 0.01);
+}
+
 TEST(test_blade, edgewise) {
     // system
     auto system_elasto = SystemElastoChrono();

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -141,6 +141,60 @@ TEST(test_tower, frequency) {
 
     // tower
     auto tower = seahowl::elasto::TowerElasto();
+    populate_tower_elasto_from_json((DATADIR / "tower.csv").generic_string(), tower);
+    tower.discretization_fractions = {};
+    tower.build();
+    tower.assemble(system_elasto);
+    tower.nodes.front()->set_fixed(true);
+
+    system_elasto.do_statics(true, 0);
+
+    // check mass
+    double tower_mass = 853459.747;
+    ASSERT_NEAR(tower_mass, tower.get_mass(), 1.0);
+
+    // static position of tower top
+    double pos0 = tower.nodes.back()->get_position().x();
+
+    // check zero-crossings (static position of tower top)
+    int step = 0;
+    double pos_y = 0.0;
+    double dt = 0.01;
+    int npeaks = 0;
+    double natural_period = 0.0;
+    double time = 0.0;
+    double end_time = 10.0;
+    double start_time = 0.0;
+    tower.nodes.back()->set_force(Vector3d(100000.0, 0.0, 0.0), false);
+    while (time < end_time) {
+        if (time > 0.5) {
+            tower.nodes.back()->reset_loads();
+            if (tower.nodes.back()->get_position().x() < pos0 && pos_y > pos0) {
+                if (start_time == 0.0 && npeaks == 0) {
+                    start_time = time;
+                } else {
+                    npeaks += 1;
+                    natural_period = (time - start_time) / npeaks;
+                }
+            }
+        }
+        pos_y = tower.nodes.back()->get_position().x();
+        system_elasto.step(dt);
+        time += dt;
+        step += 1;
+    }
+
+    double natural_period_ref = 1.306667;
+    ASSERT_NEAR(natural_period_ref, natural_period, 0.01);
+}
+
+TEST(test_tower, cylinder_frequency) {
+    // system
+    auto system_elasto = SystemElastoChrono();
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
+
+    // tower
+    auto tower = seahowl::elasto::TowerElasto();
     // properties
     auto density = 7850.0;
     auto young_modulus = 2.11e11;
@@ -185,7 +239,6 @@ TEST(test_tower, frequency) {
     tower.nodes.back()->set_force(Vector3d(100000.0, 0.0, 0.0), false);
     while (time < end_time) {
         if (time > 0.5) {
-            tower.nodes.back()->set_force(Vector3d(0.0, 0.0, 0.0), false);
             tower.nodes.back()->reset_loads();
             if (tower.nodes.back()->get_position().x() < pos0 && pos_y > pos0) {
                 if (start_time == 0.0 && npeaks == 0) {
@@ -195,8 +248,6 @@ TEST(test_tower, frequency) {
                     natural_period = (time - start_time) / npeaks;
                 }
             }
-        } else {
-            tower.nodes.back()->set_force(Vector3d(100000.0, 0.0, 0.0), false);
         }
         pos_y = tower.nodes.back()->get_position().x();
         system_elasto.step(dt);
@@ -208,7 +259,7 @@ TEST(test_tower, frequency) {
     ASSERT_NEAR(natural_period_ref, natural_period, 0.01);
 }
 
-TEST(test_tower, frequency2) {
+TEST(test_tower, conical_frequency) {
     // system
     auto system_elasto = SystemElastoChrono();
     system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
@@ -257,7 +308,6 @@ TEST(test_tower, frequency2) {
     tower.nodes.back()->set_force(Vector3d(100000.0, 0.0, 0.0), false);
     while (time < end_time) {
         if (time > 0.5) {
-            tower.nodes.back()->set_force(Vector3d(0.0, 0.0, 0.0), false);
             tower.nodes.back()->reset_loads();
             if (tower.nodes.back()->get_position().x() < pos0 && pos_y > pos0) {
                 if (start_time == 0.0 && npeaks == 0) {
@@ -267,8 +317,6 @@ TEST(test_tower, frequency2) {
                     natural_period = (time - start_time) / npeaks;
                 }
             }
-        } else {
-            tower.nodes.back()->set_force(Vector3d(100000.0, 0.0, 0.0), false);
         }
         pos_y = tower.nodes.back()->get_position().x();
         system_elasto.step(dt);

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -208,6 +208,78 @@ TEST(test_tower, frequency) {
     ASSERT_NEAR(natural_period_ref, natural_period, 0.01);
 }
 
+TEST(test_tower, frequency2) {
+    // system
+    auto system_elasto = SystemElastoChrono();
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
+
+    // tower
+    auto tower = seahowl::elasto::TowerElasto();
+    // properties
+    auto density = 7850.0;
+    auto young_modulus = 2.11e11;
+    auto poisson_ratio = 0.3;
+    // bottom
+    auto ref_point1 = seahowl::elasto::TowerReferencePointElasto();
+    ref_point1.set_properties_cylinder(density, young_modulus, poisson_ratio, 4.0, 0.030, false);
+    ref_point1.coordinates = seahowl::Vector3d(0.0, 0.0, 0.0);
+    ref_point1.fraction = 0.0;
+    // top
+    auto ref_point2 = seahowl::elasto::TowerReferencePointElasto();
+    ref_point2.set_properties_cylinder(density, young_modulus, poisson_ratio, 3.0, 0.015, false);
+    ref_point2.coordinates = seahowl::Vector3d(0.0, 0.0, 100.0);
+    ref_point2.fraction = 1.0;
+    //
+    tower.reference_points = {ref_point1, ref_point2};
+    tower.discretization_fractions = {20};
+    tower.build();
+    tower.assemble(system_elasto);
+    tower.nodes.front()->set_fixed(true);
+
+    system_elasto.do_statics(true, 0);
+
+    // check mass
+    double tower_mass = 202070.2;
+    ASSERT_NEAR(tower_mass, tower.get_mass(), 1.0);
+
+    // static position of tower top
+    double pos0 = tower.nodes.back()->get_position().x();
+
+    // check zero-crossings (static position of tower top)
+    int step = 0;
+    double pos_y = 0.0;
+    double dt = 0.01;
+    int npeaks = 0;
+    double natural_period = 0.0;
+    double time = 0.0;
+    double end_time = 10.0;
+    double start_time = 0.0;
+    tower.nodes.back()->set_force(Vector3d(100000.0, 0.0, 0.0), false);
+    while (time < end_time) {
+        if (time > 0.5) {
+            tower.nodes.back()->set_force(Vector3d(0.0, 0.0, 0.0), false);
+            tower.nodes.back()->reset_loads();
+            if (tower.nodes.back()->get_position().x() < pos0 && pos_y > pos0) {
+                if (start_time == 0.0 && npeaks == 0) {
+                    start_time = time;
+                } else {
+                    npeaks += 1;
+                    natural_period = (time - start_time) / npeaks;
+                }
+            }
+        } else {
+            tower.nodes.back()->set_force(Vector3d(100000.0, 0.0, 0.0), false);
+        }
+        pos_y = tower.nodes.back()->get_position().x();
+        system_elasto.step(dt);
+        time += dt;
+        step += 1;
+    }
+
+    double natural_period_ref = 1.912500;  // theory (modal inventor): 0.515Hz (1.9417s)
+    ASSERT_NEAR(natural_period_ref, natural_period, 0.01);
+}
+
 TEST(test_blade, edgewise) {
     // system
     auto system_elasto = SystemElastoChrono();


### PR DESCRIPTION
In this PR for tower workflow:
- New test for generic tower (natural frequency)
- Convenience function for setting properties of hollow cylinder for Tower
- Add extra properties for hollow cylinders (inertia, shear)
- Add shear (X, Y IEC; Y, Z Chrono) for simplified FEA blades

Note that by default, shear is deactivated for towers as activating it requires finer discretization to get the right natural frequency (and effect should be negligible here).

In this PR for Chrono workflow:
- Exposed spring force getter
- Set default mass and inertia of SEAHOWL bodies to 0.0 instead of Chrono's default 1.0