### PR TITLE
Fix issue with TurbSim when z<0.0 InflowWind adapter

### DIFF
--- a/data/IEA15MW/environment_inflowwind.json
+++ b/data/IEA15MW/environment_inflowwind.json
@@ -3,7 +3,8 @@
   "wind": {
     "type": "inflowwind",
     "options": {
-       "file_inflowwind": "./aerodyn/IEA-15-240-RWT_InflowWind.dat"
+       "file_inflowwind": "./aerodyn/IEA-15-240-RWT_InflowWind.dat",
+       "zmin": 5.0
     }
   },
   "sea": {

--- a/include/seahowl/env/inflowwind_adapter.h
+++ b/include/seahowl/env/inflowwind_adapter.h
@@ -86,6 +86,9 @@ struct InflowWindLib {
 
 class InflowWindAdapter : public WindModel {
   public:
+    /** @brief Level below which returned velocity is (0.0, 0.0, 0.0), used for z<0 when using TurbSim for example. */
+    double zmin = 0.0;
+
     std::unique_ptr<InflowWindLib> pImpl;
 
     InflowWindAdapter(std::string InflowInfile);

--- a/src/bindings/python/pyseahowl_env.cpp
+++ b/src/bindings/python/pyseahowl_env.cpp
@@ -50,7 +50,8 @@ void initialize_pyseahowl_env(py::module& m) {
     // env/infflowwind_adapter.h
     py::class_<seahowl::env::InflowWindAdapter, std::shared_ptr<seahowl::env::InflowWindAdapter>,
                seahowl::env::WindModel>(m_env, "InflowWindAdapter")
-        .def(py::init<std::string&>());
+        .def(py::init<std::string&>())
+        .def_readwrite("zmin", &seahowl::env::InflowWindAdapter::zmin);
 #endif
 
     // env/wave_models.h

--- a/src/env/inflowwind_adapter.cpp
+++ b/src/env/inflowwind_adapter.cpp
@@ -37,6 +37,11 @@ void InflowWindAdapter::end() {
 }
 
 seahowl::Vector3d InflowWindAdapter::get_fluid_velocity(const seahowl::Vector3d& position, double time) const {
+    if (position.z() < zmin) {
+        // zmin is set for cases such as TurbSim that cannot generate wind field close or below z=0
+        return Vector3d(0.0, 0.0, 0.0);
+    }
+
     float* Pos_C = new float[3];
     for (int i = 0; i < 3; i++) {
         Pos_C[i] = position[i];

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -972,7 +972,15 @@ std::shared_ptr<seahowl::env::FluidSoilModel> get_environmental_model_from_json(
         } else {
             throw std::runtime_error("InflowWind file not defined.");
         }
-        wind_model_ptr = std::make_shared<seahowl::env::InflowWindAdapter>(inflowwind_filepath);
+        auto ifw_model = std::make_shared<seahowl::env::InflowWindAdapter>(inflowwind_filepath);
+        wind_model_ptr = ifw_model;
+        if (wind_options.contains("zmin")) {
+            wind_options.at("zmin").get_to(ifw_model->zmin);
+        } else {
+            spdlog::warn(
+                "Minimum height for wind speed calculation not defined for InflowWind model, using default zmin={}.",
+                ifw_model->zmin);
+        }
 #else
         throw std::runtime_error(
             "InflowWind module in CMAKE options should be enabled if wind type 'inflowwind' selected.");


### PR DESCRIPTION
Add a minimum level (default z=0) where returned wind velocity is (0.0, 0.0, 0.0) when using InflowWindAdapter.
This is needed when using TurbSim and when aero points are close or below z=0 (TurbSim currently cannot generate wind field for z<=0).