### PR TITLE
Updates for output headers, standalone floater, and logging

### DIFF
--- a/include/seahowl/elasto/floater_elasto.h
+++ b/include/seahowl/elasto/floater_elasto.h
@@ -121,6 +121,8 @@ class FloaterElasto : public FoundationElasto {
     std::map<std::string, std::deque<std::unique_ptr<seahowl::elasto::BodyElasto>>> fairlead_bodies;
     /** @brief Name of body for tower connection */
     std::string tower_connection_name = "";
+    /** @brief Whether floater is linked to entity or not. */
+    bool is_linked = false;
 
     virtual void assemble_this(seahowl::elasto::SystemElasto& system) override;
 };

--- a/include/seahowl/io/output_manager.h
+++ b/include/seahowl/io/output_manager.h
@@ -17,16 +17,48 @@ class System;
 
 namespace seahowl {
 namespace io {
+
+/** Class for managing simulation outputs (CSV, VTK, in situ, logs etc).
+ */
 class OutputManager {
   public:
+    /** @brief Whether manager outputs VTK files or not. */
     bool has_vtk = false;
+    /** @brief Whether manager displays in situ visualization or not. */
     bool has_gui = false;
+    /** @brief Whether manager outputs CSV files or not. */
     bool has_csv = true;
 
+    /**
+     * @brief Constructor.
+     *
+     * @param system_core System from which the output manager grabs information.
+     */
     OutputManager(seahowl::core::System& system_core);
+
+    /**
+     * @brief Sets main folder for outputs.
+     *
+     * @param output_folder Path to output folder.
+     */
     void set_output_folder(const std::string& output_folder);
+
+    /**
+     * @brief Initializes outputs.
+     */
     void initialize();
+
+    /**
+     * @brief Outputs everything at current time step.
+     *
+     * @param step Current step iteration (used for output names such as VTK).
+     */
     void output_all(int step);
+
+    /**
+     * @brief Outputs initial logs.
+     */
+    void output_initial_logs();
 
   private:
     bool is_initialized = false;

--- a/include/seahowl/io/output_manager.h
+++ b/include/seahowl/io/output_manager.h
@@ -30,7 +30,7 @@ class OutputManager {
 
   private:
     bool is_initialized = false;
-    std::string output_folder = ".";
+    std::string output_folder = "./output";
     seahowl::core::System& system_core;
 #ifdef HAVE_VTK
     std::unique_ptr<OutputSystemVTK> output_vtk;

--- a/src/commons/utils.cpp
+++ b/src/commons/utils.cpp
@@ -82,8 +82,8 @@ double seahowl::bilinear_interpolation(const Eigen::MatrixXd& dataMatrix,
 
     if (y0 == -99 || x0 == -99) {
         spdlog::error("x = {}, y = {},", x, y);
-        spdlog::error("x_list = {},", x_list.transpose());
-        spdlog::error("y_list = {}.", y_list.transpose());
+        spdlog::error("x_list between {} and {},", x_list[0], x_list[x_list.size() - 1]);
+        spdlog::error("y_list between {} and {}.", y_list[0], y_list[y_list.size() - 1]);
         throw std::runtime_error("Bilinear interpolation failed: x or y not found in the coefficients list.");
     };
 

--- a/src/core/simulation.cpp
+++ b/src/core/simulation.cpp
@@ -69,14 +69,11 @@ void Simulation::initialize() {
     }
     spdlog::stopwatch sw_setup;
 
-    // initialize outputs
-    outputs->initialize();
-
     // initialize system
     system_core->initialize(system_core->get_time(), dt);
 
-    // output everything at step iteration 0 (creates files and CSV headers)
-    outputs->output_all(0);
+    // initialize outputs
+    outputs->initialize();
 
     t_output_next = dt_output;
     is_initialized = true;
@@ -89,14 +86,11 @@ void Simulation::initialize_from_file(const std::string& filepath) {
     }
     spdlog::stopwatch sw_setup;
 
-    // initialize outputs
-    outputs->initialize();
-
     // initialize system
     initialize_system_from_json(filepath, *system_core);
 
-    // output everything at step iteration 0 (creates files and CSV headers)
-    outputs->output_all(0);
+    // initialize outputs
+    outputs->initialize();
 
     t_output_next = dt_output;
     is_initialized = true;

--- a/src/core/simulation.cpp
+++ b/src/core/simulation.cpp
@@ -67,12 +67,20 @@ void Simulation::initialize() {
     if (is_initialized) {
         throw std::runtime_error("Simulation was already initialized.");
     }
+    spdlog::stopwatch sw_setup;
 
+    // initialize outputs
     outputs->initialize();
 
+    // initialize system
     system_core->initialize(system_core->get_time(), dt);
 
+    // output everything at step iteration 0 (creates files and CSV headers)
+    outputs->output_all(0);
+
+    t_output_next = dt_output;
     is_initialized = true;
+    spdlog::info("Simulation initialized in {:.3}s.", sw_setup);
 }
 
 void Simulation::initialize_from_file(const std::string& filepath) {
@@ -81,15 +89,18 @@ void Simulation::initialize_from_file(const std::string& filepath) {
     }
     spdlog::stopwatch sw_setup;
 
+    // initialize outputs
     outputs->initialize();
 
+    // initialize system
     initialize_system_from_json(filepath, *system_core);
 
+    // output everything at step iteration 0 (creates files and CSV headers)
     outputs->output_all(0);
 
     t_output_next = dt_output;
     is_initialized = true;
-    spdlog::info("Initial setup time: {:.3}s.", sw_setup);
+    spdlog::info("Simulation initialized in {:.3}s.", sw_setup);
 };
 
 void Simulation::step() {

--- a/src/elasto/floater_elasto.cpp
+++ b/src/elasto/floater_elasto.cpp
@@ -16,6 +16,7 @@ FloaterElasto::FloaterElasto() {
 void FloaterElasto::link_to_entity(const Entity& entity) {
     link_floater_entity->initialize(*body_main, entity);
     link_floater_entity->set_constraints(true, true, true, true, true, true);
+    is_linked = true;
 };
 
 void FloaterElasto::build() {
@@ -141,7 +142,9 @@ void FloaterElasto::assemble_this(seahowl::elasto::SystemElasto& system) {
         }
     }
 
-    system.add(*(link_floater_entity.get()));
+    if (is_linked) {
+        system.add(*(link_floater_entity.get()));
+    }
 
     // moorings
     mooring_system->assemble(system);

--- a/src/elasto/turbine_elasto.cpp
+++ b/src/elasto/turbine_elasto.cpp
@@ -15,7 +15,6 @@ void TurbineElasto::assemble_this(SystemElasto& system) {
     // assemble foundation
     if (foundation) {
         foundation->assemble(system);
-        foundation->link_to_entity(*(tower.nodes.front().get()));
     }
     // assemble RNA
     rna.assemble(system);
@@ -36,14 +35,15 @@ void TurbineElasto::link_rna_tower(SystemElasto& system) {
 }
 
 void TurbineElasto::build() {
-    // build foundation
-    if (foundation) {
-        foundation->build();
-    }
     // build RNA
     rna.build();
     // build tower
     tower.build();
+    // build foundation
+    if (foundation) {
+        foundation->build();
+        foundation->link_to_entity(*(tower.nodes.front().get()));
+    }
 }
 
 void TurbineElasto::presetup(double fraction) {

--- a/src/io/output_manager.cpp
+++ b/src/io/output_manager.cpp
@@ -50,7 +50,11 @@ void OutputManager::initialize() {
     }
     is_initialized = true;
 
+    // output initial logs
     output_initial_logs();
+
+    // output everything at step iteration 0 (creates files and CSV headers)
+    output_all(0);
 }
 
 void OutputManager::output_all(int step) {

--- a/src/io/output_manager.cpp
+++ b/src/io/output_manager.cpp
@@ -13,6 +13,7 @@
 
 #include <filesystem>  // C++17
 #include <sstream>
+#include <fstream>
 #include <iomanip>
 #include <spdlog/spdlog.h>
 
@@ -48,6 +49,8 @@ void OutputManager::initialize() {
         output_insitu->draw();
     }
     is_initialized = true;
+
+    output_initial_logs();
 }
 
 void OutputManager::output_all(int step) {
@@ -88,5 +91,61 @@ void OutputManager::output_all(int step) {
         }
 
         turbine_id += 1;
+    }
+}
+
+void OutputManager::output_initial_logs() {
+    std::string logs_folder = output_folder + "/logs";
+    spdlog::debug("Creating directory {} for logs.", logs_folder);
+    fs::create_directories(logs_folder);
+    // output
+    int turbine_id = 1;
+    for (auto& turbine_ptr : system_core.turbines) {
+        auto& turbine = *turbine_ptr;
+
+        /// @todo output tower points info from a method within TowerElasto object rather than here
+        std::ofstream tower_log_reference(logs_folder + "/turbine" + std::to_string(turbine_id) +
+                                          "_tower_points_reference.csv");  // Create and open the file
+        std::ofstream tower_log_discretized(logs_folder + "/turbine" + std::to_string(turbine_id) +
+                                            "_tower_points_discretized.csv");  // Create and open the file
+
+        // csv header
+        std::string tower_log_header =
+            "fraction,density_linear,stiffness_foreaft,stiffness_sideside,stiffness_axial,stiffness_torsion,stiffness_"
+            "foreaft_shear,stiffness_sideside_shear,inertia_foreaft,inertia_sideside,\n";
+        tower_log_reference << tower_log_header;
+        tower_log_discretized << tower_log_header;
+        // loop through reference points and log their properties
+        for (auto& point : turbine.elasto.tower.reference_points) {
+            tower_log_reference << point.fraction << ",";
+            tower_log_reference << point.density << ",";
+            tower_log_reference << point.stiffness_foreaft << ",";
+            tower_log_reference << point.stiffness_sideside << ",";
+            tower_log_reference << point.stiffness_axial << ",";
+            tower_log_reference << point.stiffness_torsion << ",";
+            tower_log_reference << point.stiffness_foreaft_shear << ",";
+            tower_log_reference << point.stiffness_sideside_shear << ",";
+            tower_log_reference << point.inertia_foreaft << ",";
+            tower_log_reference << point.inertia_sideside << ",";
+            tower_log_reference << "\n";
+        }
+        // loop through discretized point and log their properties
+        for (auto& point : turbine.elasto.tower.discretized_points) {
+            tower_log_discretized << point.fraction << ",";
+            tower_log_discretized << point.density << ",";
+            tower_log_discretized << point.stiffness_foreaft << ",";
+            tower_log_discretized << point.stiffness_sideside << ",";
+            tower_log_discretized << point.stiffness_axial << ",";
+            tower_log_discretized << point.stiffness_torsion << ",";
+            tower_log_discretized << point.stiffness_foreaft_shear << ",";
+            tower_log_discretized << point.stiffness_sideside_shear << ",";
+            tower_log_discretized << point.inertia_foreaft << ",";
+            tower_log_discretized << point.inertia_sideside << ",";
+            tower_log_discretized << "\n";
+        }
+
+        // close files
+        tower_log_reference.close();
+        tower_log_discretized.close();
     }
 }

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -344,46 +344,6 @@ std::vector<seahowl::elasto::TowerReferencePointElasto> get_tower_elasto_referen
         reference_points.push_back(reference_point);
     }
 
-    std::ofstream log_file("tower.log");  // Create and open the file
-
-    if (!log_file.is_open()) {
-        std::cout << "Error: Could not open or create log file: "
-                  << "tower.log" << std::endl;
-    }
-
-    log_file << "Log Report of Discretized Points:\n";
-    log_file << "---------------------------------\n";
-    log_file << "Point, "
-             << "Fraction, "
-             << "Young modulus, "
-             << "Poisson modulus, "
-             << "stiffness_foreaft, "
-             << "stiffness_sideside, "
-             << "stiffness_axial, "
-             << "stiffness_torsion, "
-             << "density, "
-             << "\n";
-    // Loop through each discretized point and log its properties
-    for (size_t ii = 0; ii < reference_points.size(); ++ii) {
-        const auto& point = reference_points[ii];
-
-        log_file << ii + 1 << ", ";
-        log_file << point.coordinates[0] << ", ";
-        log_file << point.coordinates[1] << ", ";
-        log_file << point.coordinates[2] << ",";
-        log_file << point.fraction << ",";
-        log_file << young_modulus_list[ii] << ", ";
-        log_file << poisson_ratio_list[ii] << ", ";
-
-        log_file << point.stiffness_foreaft << ", ";
-        log_file << point.stiffness_sideside << ", ";
-        log_file << point.stiffness_axial << ", ";
-        log_file << point.stiffness_torsion << ", ";
-        log_file << point.density << "\n";
-    }
-
-    log_file.close();  // Close the file after writing
-
     return reference_points;
 }
 

--- a/src/io/viz_insitu_irrlicht.cpp
+++ b/src/io/viz_insitu_irrlicht.cpp
@@ -37,7 +37,12 @@ void VisualizationInSituIrrlicht::initialize_elasto(seahowl::elasto::SystemElast
     // initialize default
     application_irrlicht->AddTypicalLights();
     application_irrlicht->AddSkyBox();
-    application_irrlicht->AddCamera(Vector3d(-150, -150, 150), Vector3d(0, 0, 150.));
+    if (system_elasto.turbines.size() > 0) {
+        auto zpos = system_elasto.turbines[0]->rna.rotor->body_hub->get_position().z();
+        application_irrlicht->AddCamera(Vector3d(-zpos, -zpos, zpos), Vector3d(0, 0, zpos));
+    } else {
+        application_irrlicht->AddCamera(Vector3d(-150, -150, 150), Vector3d(0, 0, 150.));
+    }
 
     // meshes
     for (auto mesh : system_chrono->Get_meshlist()) {

--- a/src/io/write_vtk.cpp
+++ b/src/io/write_vtk.cpp
@@ -140,6 +140,8 @@ OutputSystemVTK::OutputSystemVTK(seahowl::core::System& system_core, const std::
 
 void OutputSystemVTK::initialize() {
     vtk_meshes.clear();
+
+    // iterate turbines
     for (auto [turbine_ptr, idx_turbine] = std::tuple{system_core.turbines.begin(), 0};
          turbine_ptr != system_core.turbines.end(); turbine_ptr++, idx_turbine++) {
         auto& turbine = *turbine_ptr;
@@ -147,13 +149,31 @@ void OutputSystemVTK::initialize() {
         for (auto [blade_ptr, idx_blade] = std::tuple{turbine->rna.blades.begin(), 0};
              blade_ptr != turbine->rna.blades.end(); blade_ptr++, idx_blade++) {
             auto& blade = *blade_ptr;
-            auto& post_blade = vtk_meshes.emplace_back(dynamic_cast<seahowl::elasto::BladeElastoFEA&>(blade->elasto));
-            post_blade.initialize(
-                (output_folder + "/turbine" + std::to_string(idx_turbine) + "_blade" + std::to_string(idx_blade))
-                    .c_str());
+            try {
+                auto& post_blade =
+                    vtk_meshes.emplace_back(dynamic_cast<seahowl::elasto::BladeElastoFEA&>(blade->elasto));
+                post_blade.initialize(
+                    (output_folder + "/turbine" + std::to_string(idx_turbine) + "_blade" + std::to_string(idx_blade))
+                        .c_str());
+            } catch (const std::exception& e) {
+                // do nothing if node blade EFA
+            }
         }
         auto& post_tower = vtk_meshes.emplace_back(turbine->tower.elasto);
         post_tower.initialize((output_folder + "/turbine" + std::to_string(idx_turbine) + "_tower").c_str());
+    }
+
+    // iterate elasto components
+    for (auto [component_ptr, idx_component] = std::tuple{system_core.elasto.components.begin(), 0};
+         component_ptr != system_core.elasto.components.end(); component_ptr++, idx_component++) {
+        auto& component = *component_ptr;
+        try {
+            auto& post_component =
+                vtk_meshes.emplace_back(dynamic_cast<seahowl::elasto::ComponentElastoFEA&>(*component));
+            post_component.initialize((output_folder + "/component" + std::to_string(idx_component)).c_str());
+        } catch (const std::exception& e) {
+            // do nothing if node component elasto EFA
+        }
     }
 }
 


### PR DESCRIPTION
A few minor updates bundled in this PR:
- Make sure that output_all is called at initialization of simulation for generating header of .csv file
- Add floater link only if a tower (or other component) was linked to the floater --> allows for floater without turbines to be tested
- Reformat some logging in utils.cpp that broke install with spdlog version on Ubuntu 24 (installed with apt)
- Add components to VTK output + fix issue when not using FEA blades
- Default output folder of OutputManager as "./output"