### PR TITLE
Overhaul of blade pitch system

### DIFF
--- a/include/seahowl/aero/blade_aero.h
+++ b/include/seahowl/aero/blade_aero.h
@@ -5,6 +5,8 @@
 #include "seahowl/aero/reference_point_aero.h"
 #include "seahowl/commons/component_fluid.h"
 
+#include <memory>
+
 namespace seahowl {
 
 /**@brief Aerodynamic module */
@@ -126,6 +128,8 @@ class BladeAero {
     double azimuth0 = 0.0;
     /** @brief Pitch of the blade (in radians). */
     double pitch = 0.0;
+    /** @brief Body at the root of the blade. */
+    std::unique_ptr<EntityDynamic> body_root;
 
     /**
      * @brief Constructor.

--- a/include/seahowl/core/blade.h
+++ b/include/seahowl/core/blade.h
@@ -82,6 +82,13 @@ class Blade : public ComponentDynamic {
     virtual void build();
 
     /**
+     * @brief Applies pitch increment to the blade (i.e. rotates the blade around its longitudinal axis).
+     *
+     * @param pitch_increment Pitch increment value (in radians).
+     */
+    void apply_pitch_increment(double pitch_increment);
+
+    /**
      * @brief Sets the discretization fractions to use when building the elasto part of the blade.
      *
      * @param[in] fractions Normalized discretization fractions within [0, 1].

--- a/include/seahowl/elasto/blade_elasto.h
+++ b/include/seahowl/elasto/blade_elasto.h
@@ -47,6 +47,11 @@ class BladeElasto : public virtual ComponentElasto {
     virtual void apply_pitch_increment(double pitch_increment);
 
     /**
+     * @brief Returns current pitch of blade.
+     */
+    double get_pitch() const;
+
+    /**
      * @brief Returns blade root moment.
      */
     virtual Vector3d get_blade_root_moment() const = 0;

--- a/include/seahowl/elasto/blade_elasto.h
+++ b/include/seahowl/elasto/blade_elasto.h
@@ -54,12 +54,12 @@ class BladeElasto : public virtual ComponentElasto {
     /**
      * @brief Returns blade root moment.
      */
-    virtual Vector3d get_blade_root_moment() const = 0;
+    virtual Vector3d get_blade_root_moment() const;
 
     /**
      * @brief Returns blade root force.
      */
-    virtual Vector3d get_blade_root_force() const = 0;
+    virtual Vector3d get_blade_root_force() const;
 
     virtual EntityDynamicEigen get_entity_along_blade(double eta, int element_index = 0) const = 0;
 
@@ -112,8 +112,6 @@ class BladeElastoFEA : public BladeElasto, public ComponentElastoFEA {
                                             int element_index,
                                             double eta) const override;
 
-    virtual Vector3d get_blade_root_moment() const override;
-    virtual Vector3d get_blade_root_force() const override;
     virtual EntityDynamicEigen get_entity_along_blade(double eta, int element_index = 0) const override;
     virtual void accumulate_load_along_blade(const Vector3d& load,
                                              const seahowl::Vector3d& moment,
@@ -154,8 +152,6 @@ class BladeElastoRigid : public BladeElasto {
     virtual void translate(const Vector3d& translation_vector) const override;
     virtual double get_mass() const override;
 
-    virtual Vector3d get_blade_root_moment() const override;
-    virtual Vector3d get_blade_root_force() const override;
     virtual EntityDynamicEigen get_entity_along_blade(double eta, int element_index = 0) const override;
     virtual void reset_loads() override;
     virtual void accumulate_load_along_blade(const Vector3d& load,

--- a/include/seahowl/elasto/blade_elasto.h
+++ b/include/seahowl/elasto/blade_elasto.h
@@ -12,8 +12,12 @@ namespace elasto {
  */
 class BladeElasto : public virtual ComponentElasto {
   public:
-    /** @brief Link between blade and body (usually hub). */
+    /** @brief Body at the root of the blade. */
+    std::unique_ptr<BodyElastoChrono> body_root;
+    /** @brief Link between blade and pitch axis body. */
     std::unique_ptr<Link> link_root;
+    /** @brief Link between blade and body (usually hub). */
+    std::unique_ptr<Link> link_blade;
     /** @brief Pitch of the blade (in radians). */
     double pitch = 0.0;
     /** @brief Initial azimuth of the blade relative to rotor azimuth (in radians). */
@@ -26,6 +30,10 @@ class BladeElasto : public virtual ComponentElasto {
     std::vector<double> discretization_fractions;
 
     BladeElasto();
+
+    virtual void rotate(double angle, const Vector3d& axis) const override;
+    virtual void translate(const Vector3d& translation_vector) const override;
+    virtual double get_mass() const override;
 
     /**
      * @brief Applies pitch increment to the blade (i.e. rotates the blade around its longitudinal axis).
@@ -52,7 +60,7 @@ class BladeElasto : public virtual ComponentElasto {
                                              double eta,
                                              const Vector3d& offset) = 0;
 
-    virtual void attach_root_to_body(const BodyElasto& body) = 0;
+    virtual void attach_blade_to_body(const BodyElasto& body);
 
   protected:
     /** @brief Whether the blade is mounted (e.g. on a rotor) or not. */
@@ -82,9 +90,9 @@ class BladeElastoFEA : public BladeElasto, public ComponentElastoFEA {
     BladeElastoFEA();
 
     virtual void build() override;
-    using ComponentElastoFEA::rotate;
-    using ComponentElastoFEA::translate;
-    using ComponentElastoFEA::get_mass;
+    virtual void rotate(double angle, const Vector3d& axis) const override;
+    virtual void translate(const Vector3d& translation_vector) const override;
+    virtual double get_mass() const override;
 
     virtual void evaluate_position_rotation(Vector3d& position,
                                             Quaternion& rotation,
@@ -100,7 +108,6 @@ class BladeElastoFEA : public BladeElasto, public ComponentElastoFEA {
                                              int element_index,
                                              double eta,
                                              const Vector3d& offset) override;
-    virtual void attach_root_to_body(const BodyElasto& body) override;
 
   private:
     virtual void assemble_this(SystemElasto& system) override;
@@ -143,17 +150,12 @@ class BladeElastoRigid : public BladeElasto {
                                              int element_index,
                                              double eta,
                                              const Vector3d& offset) override;
-    virtual void attach_root_to_body(const BodyElasto& body) override;
 
   private:
     /** @brief Length of the blade. */
     double length = 0.0;
-    /** @brief Body at the root of the blade. */
-    std::unique_ptr<BodyElastoChrono> body_root;
     /** @brief Body at the COG of the blade. */
     std::unique_ptr<BodyElastoChrono> body_cog;
-    /** @brief Link between bodies at the root and COG of the blade. */
-    std::unique_ptr<Link> link_cog_root;
 
     virtual void assemble_this(SystemElasto& system) override;
 };

--- a/include/seahowl/elasto/blade_elasto.h
+++ b/include/seahowl/elasto/blade_elasto.h
@@ -14,8 +14,12 @@ class BladeElasto : public virtual ComponentElasto {
   public:
     /** @brief Body at the root of the blade. */
     std::unique_ptr<BodyElastoChrono> body_root;
+    /** @brief Body for mounting point of blade (to link to other structures, e.g. hub). */
+    std::unique_ptr<BodyElastoChrono> body_mount;
     /** @brief Link between blade and pitch axis body. */
     std::unique_ptr<Link> link_root;
+    /** @brief Link between blade root and mounting point. */
+    std::unique_ptr<Link> link_root_mount;
     /** @brief Link between blade and body (usually hub). */
     std::unique_ptr<Link> link_blade;
     /** @brief Pitch of the blade (in radians). */

--- a/include/seahowl/elasto/blade_elasto.h
+++ b/include/seahowl/elasto/blade_elasto.h
@@ -40,7 +40,7 @@ class BladeElasto : public virtual ComponentElasto {
      *
      * @param pitch_increment Pitch increment value (in radians).
      */
-    virtual void apply_pitch_increment(double pitch_increment) = 0;
+    virtual void apply_pitch_increment(double pitch_increment);
 
     /**
      * @brief Returns blade root moment.
@@ -67,6 +67,8 @@ class BladeElasto : public virtual ComponentElasto {
     bool is_mounted = false;
 
     virtual void assemble_this(SystemElasto& system) override;
+
+    virtual void update_root_constraint() = 0;
 };
 
 /**
@@ -99,7 +101,6 @@ class BladeElastoFEA : public BladeElasto, public ComponentElastoFEA {
                                             int element_index,
                                             double eta) const override;
 
-    virtual void apply_pitch_increment(double pitch_increment) override;
     virtual Vector3d get_blade_root_moment() const override;
     virtual Vector3d get_blade_root_force() const override;
     virtual EntityDynamicEigen get_entity_along_blade(double eta, int element_index = 0) const override;
@@ -121,6 +122,8 @@ class BladeElastoFEA : public BladeElasto, public ComponentElastoFEA {
      * @brief Builds the blade with FPM Timoshenko elements (6x6 mass and stiffness matrices).
      */
     void build_elements_tapered_timoshenko_fpm();
+
+    virtual void update_root_constraint() override;
 };
 
 /**
@@ -140,7 +143,6 @@ class BladeElastoRigid : public BladeElasto {
     virtual void translate(const Vector3d& translation_vector) const override;
     virtual double get_mass() const override;
 
-    virtual void apply_pitch_increment(double pitch_increment) override;
     virtual Vector3d get_blade_root_moment() const override;
     virtual Vector3d get_blade_root_force() const override;
     virtual EntityDynamicEigen get_entity_along_blade(double eta, int element_index = 0) const override;
@@ -158,6 +160,8 @@ class BladeElastoRigid : public BladeElasto {
     std::unique_ptr<BodyElastoChrono> body_cog;
 
     virtual void assemble_this(SystemElasto& system) override;
+
+    virtual void update_root_constraint() override;
 };
 
 }  // namespace elasto

--- a/include/seahowl/elasto/blade_elasto.h
+++ b/include/seahowl/elasto/blade_elasto.h
@@ -22,8 +22,8 @@ class BladeElasto : public virtual ComponentElasto {
     std::unique_ptr<Link> link_root_mount;
     /** @brief Link between blade and body (usually hub). */
     std::unique_ptr<Link> link_blade;
-    /** @brief Pitch of the blade (in radians). */
-    double pitch = 0.0;
+    /** @brief Initial pitch of the blade (in radians). */
+    double pitch0 = 0.0;
     /** @brief Initial azimuth of the blade relative to rotor azimuth (in radians). */
     double azimuth0 = 0.0;
     /** @brief Precone of the blade (in radians). */
@@ -78,6 +78,8 @@ class BladeElasto : public virtual ComponentElasto {
     virtual void assemble_this(SystemElasto& system) override;
 
     virtual void update_root_constraint() = 0;
+
+    void reset_bodies();
 };
 
 /**

--- a/src/aero/aerodyn_adapter.cpp
+++ b/src/aero/aerodyn_adapter.cpp
@@ -71,12 +71,13 @@ void seahowl::aero::AeroDynAdapter::setMotionHub(seahowl::aero::TurbineAero& tur
     float* hubAcc_C = new float[6];
 
     // Get the information about hub
-    auto hubPos = turbine.rna.rotor->body_hub.get_position();
-    auto hubOri = turbine.rna.rotor->body_hub.get_rotation().toRotationMatrix();  // get a rotation matrix 3x3
-    auto hubTranVel = turbine.rna.rotor->body_hub.get_velocity();
-    auto hubRotVel = turbine.rna.rotor->body_hub.get_rotational_velocity(false);  // in global frame
-    auto hubTranAcc = turbine.rna.rotor->body_hub.get_acceleration();
-    auto hubRotAcc = turbine.rna.rotor->body_hub.get_rotational_acceleration(false);  // in global frame
+    auto& hub = turbine.rna.rotor->body_hub;
+    auto hubPos = hub.get_position();
+    auto hubOri = hub.get_rotation().toRotationMatrix();  // get a rotation matrix 3x3
+    auto hubTranVel = hub.get_velocity();
+    auto hubRotVel = hub.get_rotational_velocity(false);  // in global frame
+    auto hubTranAcc = hub.get_acceleration();
+    auto hubRotAcc = hub.get_rotational_acceleration(false);  // in global frame
 
     for (int i = 0; i < 3; i++) {
         hubPos_C[i] = hubPos[i];
@@ -109,12 +110,13 @@ void seahowl::aero::AeroDynAdapter::setMotionNac(seahowl::aero::TurbineAero& tur
     float* nacAcc_C = new float[6];
 
     // Get the information about nacelle
-    auto nacPos = turbine.rna.body_nacelle.get_position();
-    auto nacOri = turbine.rna.body_nacelle.get_rotation().toRotationMatrix();  // get a rotation matrix 3x3
-    auto nacTranVel = turbine.rna.body_nacelle.get_velocity();
-    auto nacRotVel = turbine.rna.body_nacelle.get_rotational_velocity(false);  // in global frame
-    auto nacTranAcc = turbine.rna.body_nacelle.get_acceleration();
-    auto nacRotAcc = turbine.rna.body_nacelle.get_rotational_acceleration(false);  // in global frame
+    auto& nac = turbine.rna.body_nacelle;
+    auto nacPos = nac.get_position();
+    auto nacOri = nac.get_rotation().toRotationMatrix();  // get a rotation matrix 3x3
+    auto nacTranVel = nac.get_velocity();
+    auto nacRotVel = nac.get_rotational_velocity(false);  // in global frame
+    auto nacTranAcc = nac.get_acceleration();
+    auto nacRotAcc = nac.get_rotational_acceleration(false);  // in global frame
 
     for (int i = 0; i < 3; i++) {
         nacPos_C[i] = nacPos[i];
@@ -148,13 +150,19 @@ void seahowl::aero::AeroDynAdapter::setMotionRoot(seahowl::aero::TurbineAero& tu
     float* bldRootAcc_C = new float[6 * nblades];
 
     for (int i = 0; i < nblades; i++) {
-        auto bldRootPos = turbine.rna.rotor->blades[i]->nodes[0].get_position();
-        auto bldRootOri = turbine.rna.rotor->blades[i]->nodes[0].get_rotation().toRotationMatrix();
-        auto bldRootTranVel = turbine.rna.rotor->blades[i]->nodes[0].get_velocity();
-        auto bldRootRotVel = turbine.rna.rotor->blades[i]->nodes[0].get_rotational_velocity(false);  // in global frame
-        auto bldRootTranAcc = turbine.rna.rotor->blades[i]->nodes[0].get_acceleration();
-        auto bldRootRotAcc =
-            turbine.rna.rotor->blades[i]->nodes[0].get_rotational_acceleration(false);  // in global frame
+        auto& bldRoot = turbine.rna.rotor->blades[i]->nodes[0];
+        auto bldRootPos = bldRoot.get_position();
+
+        // remove twist at blade root (as required by AeroDyn)
+        auto bldRoot_twist = turbine.rna.rotor->blades[i]->reference_points[0].structural_twist;
+        auto bldRoot_axis = bldRoot.get_direction();
+        auto bldRoot_twist_matrix = AngleAxisd(bldRoot_twist, bldRoot_axis);
+        auto bldRootOri = bldRoot_twist_matrix * bldRoot.get_rotation().toRotationMatrix();
+
+        auto bldRootTranVel = bldRoot.get_velocity();
+        auto bldRootRotVel = bldRoot.get_rotational_velocity(false);  // in global frame
+        auto bldRootTranAcc = bldRoot.get_acceleration();
+        auto bldRootRotAcc = bldRoot.get_rotational_acceleration(false);  // in global frame
         for (int j = 0; j < 3; j++) {
             int p = i * 3 + j;
             int q = i * 6 + j;
@@ -194,13 +202,13 @@ void seahowl::aero::AeroDynAdapter::setMotionMesh(seahowl::aero::TurbineAero& tu
 
     for (int i = 0; i < nblades; i++) {
         for (int j = 0; j < nMeshPerBlade; j++) {
-            auto meshPos = turbine.rna.rotor->blades[i]->nodes[j].get_position();
-            auto meshOri = turbine.rna.rotor->blades[i]->nodes[j].get_rotation().toRotationMatrix();
-            auto meshTranVel = turbine.rna.rotor->blades[i]->nodes[j].get_velocity();
-            auto meshRotVel = turbine.rna.rotor->blades[i]->nodes[j].get_rotational_velocity(false);  // in global frame
-            auto meshTranAcc = turbine.rna.rotor->blades[i]->nodes[j].get_acceleration();
-            auto meshRotAcc =
-                turbine.rna.rotor->blades[i]->nodes[j].get_rotational_acceleration(false);  // in global frame
+            auto& bldMesh = turbine.rna.rotor->blades[i]->nodes[j];
+            auto meshPos = bldMesh.get_position();
+            auto meshOri = bldMesh.get_rotation().toRotationMatrix();
+            auto meshTranVel = bldMesh.get_velocity();
+            auto meshRotVel = bldMesh.get_rotational_velocity(false);  // in global frame
+            auto meshTranAcc = bldMesh.get_acceleration();
+            auto meshRotAcc = bldMesh.get_rotational_acceleration(false);  // in global frame
 
             auto ii = i * nMeshPerBlade + j;
             for (int k = 0; k < 3; k++) {

--- a/src/aero/aerodyn_adapter.cpp
+++ b/src/aero/aerodyn_adapter.cpp
@@ -150,19 +150,15 @@ void seahowl::aero::AeroDynAdapter::setMotionRoot(seahowl::aero::TurbineAero& tu
     float* bldRootAcc_C = new float[6 * nblades];
 
     for (int i = 0; i < nblades; i++) {
-        auto& bldRoot = turbine.rna.rotor->blades[i]->nodes[0];
-        auto bldRootPos = bldRoot.get_position();
+        auto& blade = turbine.rna.rotor->blades[i];
+        auto& bldRoot = blade->body_root;
+        auto bldRootPos = bldRoot->get_position();
+        auto bldRootOri = bldRoot->get_rotation().toRotationMatrix();
+        auto bldRootTranVel = bldRoot->get_velocity();
+        auto bldRootRotVel = bldRoot->get_rotational_velocity(false);  // in global frame
+        auto bldRootTranAcc = bldRoot->get_acceleration();
+        auto bldRootRotAcc = bldRoot->get_rotational_acceleration(false);  // in global frame
 
-        // remove twist at blade root (as required by AeroDyn)
-        auto bldRoot_twist = turbine.rna.rotor->blades[i]->reference_points[0].structural_twist;
-        auto bldRoot_axis = bldRoot.get_direction();
-        auto bldRoot_twist_matrix = AngleAxisd(bldRoot_twist, bldRoot_axis);
-        auto bldRootOri = bldRoot_twist_matrix * bldRoot.get_rotation().toRotationMatrix();
-
-        auto bldRootTranVel = bldRoot.get_velocity();
-        auto bldRootRotVel = bldRoot.get_rotational_velocity(false);  // in global frame
-        auto bldRootTranAcc = bldRoot.get_acceleration();
-        auto bldRootRotAcc = bldRoot.get_rotational_acceleration(false);  // in global frame
         for (int j = 0; j < 3; j++) {
             int p = i * 3 + j;
             int q = i * 6 + j;

--- a/src/aero/blade_aero.cpp
+++ b/src/aero/blade_aero.cpp
@@ -58,7 +58,9 @@ Vector3d BladeElementAero::get_offset_aero_absolute() const {
     return 0.5 * (node1.get_offset_aero_absolute() + node2.get_offset_aero_absolute());
 }
 
-BladeAero::BladeAero() {}
+BladeAero::BladeAero() {
+    body_root = std::make_unique<EntityDynamicEigen>();
+}
 
 void BladeAero::build() {
     // check that enough reference points were defined to create elements (at least 2)

--- a/src/bindings/python/pyseahowl_core.cpp
+++ b/src/bindings/python/pyseahowl_core.cpp
@@ -116,6 +116,7 @@ void initialize_pyseahowl_core(py::module& m) {
     // core/blade.h
     py::class_<seahowl::core::Blade, std::shared_ptr<seahowl::core::Blade>, seahowl::core::ComponentDynamic>(m_core,
                                                                                                              "Blade")
+        .def("apply_pitch_increment", &seahowl::core::Blade::apply_pitch_increment)
         .def("set_discretization_elasto", &seahowl::core::Blade::set_discretization_elasto)
         .def("set_discretization_aero", &seahowl::core::Blade::set_discretization_aero)
         .def_property_readonly("elasto", [](seahowl::core::Blade& blade) { return &blade.elasto; });

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -222,7 +222,6 @@ void initialize_pyseahowl_elasto(py::module& m) {
     // elasto/rotor_elasto.h
     py::class_<seahowl::elasto::RotorElasto, std::shared_ptr<seahowl::elasto::RotorElasto>>(m_elasto, "RotorElasto")
         .def("apply_collective_pitch_increment", &seahowl::elasto::RotorElasto::apply_collective_pitch_increment)
-        .def("apply_blade_pitch_increment", &seahowl::elasto::RotorElasto::apply_blade_pitch_increment)
         .def_readonly("blades", &seahowl::elasto::RotorElasto::blades)
         .def_property_readonly("body_hub", [](seahowl::elasto::RotorElasto& rotor) { return rotor.body_hub.get(); })
         .def_readonly("pitch_collective", &seahowl::elasto::RotorElasto::pitch_collective);

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -199,12 +199,12 @@ void initialize_pyseahowl_elasto(py::module& m) {
     // elasto/blade_elasto.h
     py::class_<seahowl::elasto::BladeElasto, std::shared_ptr<seahowl::elasto::BladeElasto>,
                seahowl::elasto::ComponentElasto>(m_elasto, "BladeElasto")
-        .def_readonly("pitch", &seahowl::elasto::BladeElasto::pitch)
         .def_readonly("azimuth0", &seahowl::elasto::BladeElasto::azimuth0)
         .def_readonly("precone", &seahowl::elasto::BladeElasto::precone)
         .def_readwrite("reference_points", &seahowl::elasto::BladeElasto::reference_points)
         .def_readwrite("discretization_fractions", &seahowl::elasto::BladeElasto::discretization_fractions)
         .def("apply_pitch_increment", &seahowl::elasto::BladeElasto::apply_pitch_increment)
+        .def("get_pitch", &seahowl::elasto::BladeElasto::get_pitch)
         .def("get_blade_root_moment", &seahowl::elasto::BladeElasto::get_blade_root_moment)
         .def("get_blade_root_force", &seahowl::elasto::BladeElasto::get_blade_root_force)
         .def("get_entity_along_blade", &seahowl::elasto::BladeElasto::get_entity_along_blade)

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -209,7 +209,7 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("get_blade_root_force", &seahowl::elasto::BladeElasto::get_blade_root_force)
         .def("get_entity_along_blade", &seahowl::elasto::BladeElasto::get_entity_along_blade)
         .def("accumulate_load_along_blade", &seahowl::elasto::BladeElasto::accumulate_load_along_blade)
-        .def("attach_root_to_body", &seahowl::elasto::BladeElasto::attach_root_to_body);
+        .def("attach_blade_to_body", &seahowl::elasto::BladeElasto::attach_blade_to_body);
     py::class_<seahowl::elasto::BladeElastoFEA, std::shared_ptr<seahowl::elasto::BladeElastoFEA>,
                seahowl::elasto::BladeElasto, seahowl::elasto::ComponentElastoFEA>(m_elasto, "BladeElastoFEA")
         .def_readonly("discretized_points", &seahowl::elasto::BladeElastoFEA::discretized_points)

--- a/src/core/blade.cpp
+++ b/src/core/blade.cpp
@@ -90,7 +90,7 @@ void Blade::update_positions_aero() {
     }
 
     // update pitch of blade for aero
-    aero.pitch = elasto.pitch;
+    aero.pitch = elasto.get_pitch();
 
     // update blade body root required by AeroDyn coupling
     aero.body_root->set_rotation(elasto.body_root->get_rotation());

--- a/src/core/blade.cpp
+++ b/src/core/blade.cpp
@@ -46,6 +46,13 @@ void Blade::build() {
     update_positions_aero();
 }
 
+void Blade::apply_pitch_increment(double pitch_increment) {
+    // pitch elasto part of blade
+    elasto.apply_pitch_increment(pitch_increment);
+    // update aero positions from pitched elasto blade
+    update_positions_aero();
+}
+
 void Blade::set_discretization_elasto(std::vector<double> fractions) {
     elasto.discretization_fractions = fractions;
 };

--- a/src/core/blade.cpp
+++ b/src/core/blade.cpp
@@ -91,6 +91,14 @@ void Blade::update_positions_aero() {
 
     // update pitch of blade for aero
     aero.pitch = elasto.pitch;
+
+    // update blade body root required by AeroDyn coupling
+    aero.body_root->set_rotation(elasto.body_root->get_rotation());
+    aero.body_root->set_position(elasto.body_root->get_position());
+    aero.body_root->set_velocity(elasto.body_root->get_velocity());
+    aero.body_root->set_rotational_velocity(elasto.body_root->get_rotational_velocity());
+    aero.body_root->set_acceleration(elasto.body_root->get_acceleration());
+    aero.body_root->set_rotational_acceleration(elasto.body_root->get_rotational_acceleration());
 }
 
 void Blade::update_loads_elasto() {

--- a/src/core/blade.cpp
+++ b/src/core/blade.cpp
@@ -43,6 +43,7 @@ void Blade::build() {
     // build aero & elasto
     elasto.build();
     aero.build();
+    update_positions_aero();
 }
 
 void Blade::set_discretization_elasto(std::vector<double> fractions) {

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -53,8 +53,8 @@ void Turbine::apply_control(double time, double dt) {
                 auto& blade = *rna.blades[idx_blade];
                 // individual pitch increment difference with collective pitch increment that was already applied
                 auto blade_pitch_increment =
-                    (controller->get_pitch_blade(idx_blade) - collective_pitch_increment) - blade.elasto.pitch;
-                rna.elasto.rotor->apply_blade_pitch_increment(blade_pitch_increment, idx_blade);
+                    (controller->get_pitch_blade(idx_blade) - collective_pitch_increment) - blade.elasto.get_pitch();
+                blade.elasto.apply_pitch_increment(blade_pitch_increment);
             }
         }
         // update positions aero after moving blades with pitch control

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -54,12 +54,8 @@ void Turbine::apply_control(double time, double dt) {
                 // individual pitch increment difference with collective pitch increment that was already applied
                 auto blade_pitch_increment =
                     (controller->get_pitch_blade(idx_blade) - collective_pitch_increment) - blade.elasto.get_pitch();
-                blade.elasto.apply_pitch_increment(blade_pitch_increment);
+                blade.apply_pitch_increment(blade_pitch_increment);
             }
-        }
-        // update positions aero after moving blades with pitch control
-        for (auto& blade : rna.blades) {
-            blade->update_positions_aero();
         }
     }
 }

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -91,6 +91,14 @@ void BladeElasto::reset_bodies() {
     body_root->set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
 }
 
+seahowl::Vector3d BladeElasto::get_blade_root_moment() const {
+    return link_root->get_reaction_torque() + body_root->get_torque(true);
+}
+
+seahowl::Vector3d BladeElasto::get_blade_root_force() const {
+    return link_root->get_reaction_force() + body_root->get_force(true);
+}
+
 BladeElastoFEA::BladeElastoFEA() {}
 
 void BladeElastoFEA::assemble_this(SystemElasto& system) {
@@ -236,32 +244,6 @@ void BladeElastoFEA::evaluate_position_rotation(Vector3d& position,
     elements[element_index]->evaluate_position_rotation(eta, position, rotation);
 }
 
-seahowl::Vector3d BladeElastoFEA::get_blade_root_moment() const {
-    auto root_moment = elements[0]->get_torque(-1.0);
-    auto root_twist = reference_points[0].structural_twist;
-
-    // remove twist from blade root moment
-    auto x1 = root_moment.x();
-    auto y1 = root_moment.y();
-    auto x2 = cos(-root_twist) * x1 - sin(-root_twist) * y1;
-    auto y2 = sin(-root_twist) * x1 + cos(-root_twist) * y1;
-
-    return Vector3d(x2, y2, root_moment.z());
-}
-
-seahowl::Vector3d BladeElastoFEA::get_blade_root_force() const {
-    auto root_force = elements[0]->get_force(-1.0);
-    auto root_twist = reference_points[0].structural_twist;
-
-    // remove twist from blade root moment
-    auto x1 = root_force.x();
-    auto y1 = root_force.y();
-    auto x2 = cos(-root_twist) * x1 - sin(-root_twist) * y1;
-    auto y2 = sin(-root_twist) * x1 + cos(-root_twist) * y1;
-
-    return Vector3d(x2, y2, root_force.z());
-}
-
 seahowl::EntityDynamicEigen BladeElastoFEA::get_entity_along_blade(double eta, int element_index) const {
     return get_entity_along_component(eta, element_index);
 }
@@ -348,14 +330,6 @@ void BladeElastoRigid::update_root_constraint() {
     link_root->initialize(*body_cog, *body_root);
     // attach root body to mounting point
     link_root_mount->initialize(*body_root, *body_mount);
-}
-
-seahowl::Vector3d BladeElastoRigid::get_blade_root_moment() const {
-    return link_root->get_reaction_torque() + body_root->get_torque(true);
-}
-
-seahowl::Vector3d BladeElastoRigid::get_blade_root_force() const {
-    return link_root->get_reaction_force() + body_root->get_force(true);
 }
 
 seahowl::EntityDynamicEigen BladeElastoRigid::get_entity_along_blade(double eta, int element_index) const {

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -25,12 +25,8 @@ void BladeElasto::apply_pitch_increment(double pitch_increment) {
     auto root_pos = body_root->get_position();
     translate(-root_pos);
     rotate(-pitch_increment, root_dir);
-    body_root->rotate(pitch_increment, root_dir);  // rotate body_root back to keep it in place
     translate(root_pos);
     pitch += pitch_increment;
-
-    // update blade-root constraint
-    update_root_constraint();
 }
 
 void BladeElasto::attach_blade_to_body(const BodyElasto& body) {
@@ -310,11 +306,11 @@ void BladeElastoRigid::update_root_constraint() {
 }
 
 seahowl::Vector3d BladeElastoRigid::get_blade_root_moment() const {
-    return link_root->get_reaction_torque() + body_root->get_torque();
+    return link_root->get_reaction_torque() + body_root->get_torque(true);
 }
 
 seahowl::Vector3d BladeElastoRigid::get_blade_root_force() const {
-    return link_root->get_reaction_force() + body_root->get_force();
+    return link_root->get_reaction_force() + body_root->get_force(true);
 }
 
 seahowl::EntityDynamicEigen BladeElastoRigid::get_entity_along_blade(double eta, int element_index) const {
@@ -332,8 +328,8 @@ seahowl::EntityDynamicEigen BladeElastoRigid::get_entity_along_blade(double eta,
     auto twist = seahowl::get_discretized_points(eta_vector, reference_points)[0].structural_twist;
 
     // rotation
-    auto twist_matrix = AngleAxisd(-twist, body_cog->get_rotation() * Vector3d(0.0, 0.0, 1.0));
-    auto rotation_matrix = twist_matrix * body_cog->get_rotation().toRotationMatrix();
+    auto twist_matrix = AngleAxisd(-twist, body_root->get_rotation() * Vector3d(0.0, 0.0, 1.0));
+    auto rotation_matrix = twist_matrix * body_root->get_rotation().toRotationMatrix();
     entity.set_rotation(Quaternion(rotation_matrix));
 
     // below has to be explicitly declared as Vector3d or there is an issue;

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -183,8 +183,8 @@ void BladeElastoFEA::evaluate_position_rotation(Vector3d& position,
 
 void BladeElastoFEA::apply_pitch_increment(double pitch_increment) {
     // apply pitch from root node direction and position
-    auto root_dir = nodes.front()->get_direction();
-    auto root_pos = nodes.front()->get_position();
+    auto root_dir = body_root->get_rotation() * Vector3d(0.0, 0.0, 1.0);
+    auto root_pos = body_root->get_position();
     translate(-root_pos);
     rotate(-pitch_increment, root_dir);
     translate(root_pos);
@@ -280,7 +280,6 @@ void BladeElastoRigid::build() {
 
 void BladeElastoRigid::assemble_this(SystemElasto& system) {
     BladeElasto::assemble_this(system);
-    system.add(*(body_root.get()));
     system.add(*(body_cog.get()));
 }
 

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -10,13 +10,25 @@
 using namespace seahowl::elasto;
 
 BladeElasto::BladeElasto() {
+    // body mount
+    body_mount = std::make_unique<BodyElastoChrono>();
+    body_mount->set_position(Vector3d(0.0, 0.0, 0.0));
+    body_mount->set_mass(0.0);
+    body_mount->set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
+    // body root
     body_root = std::make_unique<BodyElastoChrono>();
     body_root->set_position(Vector3d(0.0, 0.0, 0.0));
-    discretization_fractions = {0.0, 1.0};
+    body_root->set_mass(0.0);
+    body_root->set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
+    // links
     link_root = std::make_unique<LinkChrono>();
     link_root->set_constraints(true, true, true, true, true, true);
+    link_root_mount = std::make_unique<LinkChrono>();
+    link_root_mount->set_constraints(true, true, true, true, true, true);
     link_blade = std::make_unique<LinkChrono>();
     link_blade->set_constraints(true, true, true, true, true, true);
+    //
+    discretization_fractions = {0.0, 1.0};
 }
 
 void BladeElasto::apply_pitch_increment(double pitch_increment) {
@@ -25,18 +37,22 @@ void BladeElasto::apply_pitch_increment(double pitch_increment) {
     auto root_pos = body_root->get_position();
     translate(-root_pos);
     rotate(-pitch_increment, root_dir);
+    body_mount->rotate(pitch_increment, root_dir);  // rotate mounting point back
+    link_root_mount->initialize(*body_root, *body_mount);
     translate(root_pos);
     pitch += pitch_increment;
 }
 
 void BladeElasto::attach_blade_to_body(const BodyElasto& body) {
     is_mounted = true;
-    link_blade->initialize(*body_root, body);
+    link_blade->initialize(*body_mount, body);
 }
 
 void BladeElasto::assemble_this(SystemElasto& system) {
-    system.add(*(link_root.get()));
     system.add(*(body_root.get()));
+    system.add(*(link_root.get()));
+    system.add(*(body_mount.get()));
+    system.add(*(link_root_mount.get()));
     if (is_mounted) {
         system.add(*(link_blade.get()));
     }
@@ -45,16 +61,18 @@ void BladeElasto::assemble_this(SystemElasto& system) {
 void BladeElasto::rotate(double angle, const Vector3d& axis) const {
     // blade root
     body_root->rotate(angle, axis);
+    body_mount->rotate(angle, axis);
 }
 
 void BladeElasto::translate(const Vector3d& translation_vector) const {
     // blade root
     body_root->translate(translation_vector);
+    body_mount->translate(translation_vector);
 }
 
 double BladeElasto::get_mass() const {
     // adding body_root for consistency even if mass is supposed to be zero.
-    return body_root->get_mass();
+    return body_root->get_mass() + body_mount->get_mass();
 }
 
 BladeElastoFEA::BladeElastoFEA() {}
@@ -80,12 +98,14 @@ void BladeElastoFEA::translate(const Vector3d& translation_vector) const {
 
 double BladeElastoFEA::get_mass() const {
     // adding body_root for consistency even if mass is supposed to be zero.
-    return ComponentElastoFEA::get_mass() + body_root->get_mass();
+    return ComponentElastoFEA::get_mass() + BladeElasto::get_mass();
 }
 
 void BladeElastoFEA::update_root_constraint() {
     // attach node to root body
     link_root->initialize(*nodes[0], *body_root);
+    // attach root body to mounting point
+    link_root_mount->initialize(*body_root, *body_mount);
 }
 
 void BladeElastoFEA::build() {
@@ -268,9 +288,6 @@ void BladeElastoRigid::build() {
     body_cog->set_position(Vector3d(0., 0., z_pos));
     body_cog->set_mass(mass_total);
     body_cog->set_inertia_diagonal(Vector3d(0., 0., 0.));
-    // inertia of blade calculated from body root for rotation along local x and y
-    body_root->set_position(Vector3d(0., 0., 0.));
-    body_root->set_mass(0.);
     body_root->set_inertia_diagonal(Vector3d(inertia_total, inertia_total, 0.0));
 
     // link root and cog
@@ -297,12 +314,14 @@ void BladeElastoRigid::translate(const Vector3d& translation_vector) const {
 }
 
 double BladeElastoRigid::get_mass() const {
-    return body_cog->get_mass() + body_root->get_mass();
+    return BladeElasto::get_mass() + body_cog->get_mass();
 }
 
 void BladeElastoRigid::update_root_constraint() {
-    // attach node to root body
+    // attach COG body to root body
     link_root->initialize(*body_cog, *body_root);
+    // attach root body to mounting point
+    link_root_mount->initialize(*body_root, *body_mount);
 }
 
 seahowl::Vector3d BladeElastoRigid::get_blade_root_moment() const {

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -43,6 +43,15 @@ void BladeElasto::apply_pitch_increment(double pitch_increment) {
     pitch += pitch_increment;
 }
 
+double BladeElasto::get_pitch() const {
+    // get angle between quaternions
+    auto qq = (body_root->get_rotation().conjugate() * body_mount->get_rotation()).normalized();
+    double angle0 = 2 * std::atan2(qq.vec().z(), qq.w());
+    // get angle between 0 and 2pi
+    double angle1 = fmod(angle0, 2 * PI);
+    return angle1;
+}
+
 void BladeElasto::attach_blade_to_body(const BodyElasto& body) {
     is_mounted = true;
     link_blade->initialize(*body_mount, body);

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -19,6 +19,20 @@ BladeElasto::BladeElasto() {
     link_blade->set_constraints(true, true, true, true, true, true);
 }
 
+void BladeElasto::apply_pitch_increment(double pitch_increment) {
+    // apply pitch from root node direction and position
+    auto root_dir = body_root->get_rotation() * Vector3d(0.0, 0.0, 1.0);
+    auto root_pos = body_root->get_position();
+    translate(-root_pos);
+    rotate(-pitch_increment, root_dir);
+    body_root->rotate(pitch_increment, root_dir);  // rotate body_root back to keep it in place
+    translate(root_pos);
+    pitch += pitch_increment;
+
+    // update blade-root constraint
+    update_root_constraint();
+}
+
 void BladeElasto::attach_blade_to_body(const BodyElasto& body) {
     is_mounted = true;
     link_blade->initialize(*body_root, body);
@@ -71,6 +85,11 @@ void BladeElastoFEA::translate(const Vector3d& translation_vector) const {
 double BladeElastoFEA::get_mass() const {
     // adding body_root for consistency even if mass is supposed to be zero.
     return ComponentElastoFEA::get_mass() + body_root->get_mass();
+}
+
+void BladeElastoFEA::update_root_constraint() {
+    // attach node to root body
+    link_root->initialize(*nodes[0], *body_root);
 }
 
 void BladeElastoFEA::build() {
@@ -126,8 +145,7 @@ void BladeElastoFEA::build() {
         build_elements_tapered_timoshenko();
     }
 
-    // attach node to root body
-    link_root->initialize(*nodes[0], *body_root);
+    update_root_constraint();
 };
 
 void BladeElastoFEA::build_elements_tapered_timoshenko() {
@@ -179,19 +197,6 @@ void BladeElastoFEA::evaluate_position_rotation(Vector3d& position,
                                                 int element_index,
                                                 double eta) const {
     elements[element_index]->evaluate_position_rotation(eta, position, rotation);
-}
-
-void BladeElastoFEA::apply_pitch_increment(double pitch_increment) {
-    // apply pitch from root node direction and position
-    auto root_dir = body_root->get_rotation() * Vector3d(0.0, 0.0, 1.0);
-    auto root_pos = body_root->get_position();
-    translate(-root_pos);
-    rotate(-pitch_increment, root_dir);
-    translate(root_pos);
-    pitch += pitch_increment;
-
-    // update blade-root constraint
-    link_root->initialize(*nodes[0], *body_root);
 }
 
 seahowl::Vector3d BladeElastoFEA::get_blade_root_moment() const {
@@ -273,9 +278,7 @@ void BladeElastoRigid::build() {
     body_root->set_inertia_diagonal(Vector3d(inertia_total, inertia_total, 0.0));
 
     // link root and cog
-    link_root = std::make_unique<LinkChrono>();
-    link_root->set_constraints(true, true, true, true, true, true);
-    link_root->initialize(*body_cog, *body_root);
+    update_root_constraint();
 }
 
 void BladeElastoRigid::assemble_this(SystemElasto& system) {
@@ -301,16 +304,8 @@ double BladeElastoRigid::get_mass() const {
     return body_cog->get_mass() + body_root->get_mass();
 }
 
-void BladeElastoRigid::apply_pitch_increment(double pitch_increment) {
-    // update rotation around local Z-axis
-    auto root_dir = body_root->get_rotation() * Vector3d(0.0, 0.0, 1.0);
-    auto root_pos = body_root->get_position();
-    translate(-root_pos);
-    rotate(-pitch_increment, root_dir);
-    translate(root_pos);
-    pitch += pitch_increment;
-
-    // update blade-root constraint
+void BladeElastoRigid::update_root_constraint() {
+    // attach node to root body
     link_root->initialize(*body_cog, *body_root);
 }
 
@@ -337,8 +332,8 @@ seahowl::EntityDynamicEigen BladeElastoRigid::get_entity_along_blade(double eta,
     auto twist = seahowl::get_discretized_points(eta_vector, reference_points)[0].structural_twist;
 
     // rotation
-    auto twist_matrix = AngleAxisd(-twist, body_root->get_rotation() * Vector3d(0.0, 0.0, 1.0));
-    auto rotation_matrix = twist_matrix * body_root->get_rotation().toRotationMatrix();
+    auto twist_matrix = AngleAxisd(-twist, body_cog->get_rotation() * Vector3d(0.0, 0.0, 1.0));
+    auto rotation_matrix = twist_matrix * body_cog->get_rotation().toRotationMatrix();
     entity.set_rotation(Quaternion(rotation_matrix));
 
     // below has to be explicitly declared as Vector3d or there is an issue;

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -12,14 +12,8 @@ using namespace seahowl::elasto;
 BladeElasto::BladeElasto() {
     // body mount
     body_mount = std::make_unique<BodyElastoChrono>();
-    body_mount->set_position(Vector3d(0.0, 0.0, 0.0));
-    body_mount->set_mass(0.0);
-    body_mount->set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
     // body root
     body_root = std::make_unique<BodyElastoChrono>();
-    body_root->set_position(Vector3d(0.0, 0.0, 0.0));
-    body_root->set_mass(0.0);
-    body_root->set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
     // links
     link_root = std::make_unique<LinkChrono>();
     link_root->set_constraints(true, true, true, true, true, true);
@@ -29,6 +23,7 @@ BladeElasto::BladeElasto() {
     link_blade->set_constraints(true, true, true, true, true, true);
     //
     discretization_fractions = {0.0, 1.0};
+    reset_bodies();
 }
 
 void BladeElasto::apply_pitch_increment(double pitch_increment) {
@@ -40,7 +35,6 @@ void BladeElasto::apply_pitch_increment(double pitch_increment) {
     body_mount->rotate(pitch_increment, root_dir);  // rotate mounting point back
     link_root_mount->initialize(*body_root, *body_mount);
     translate(root_pos);
-    pitch += pitch_increment;
 }
 
 double BladeElasto::get_pitch() const {
@@ -84,6 +78,19 @@ double BladeElasto::get_mass() const {
     return body_root->get_mass() + body_mount->get_mass();
 }
 
+void BladeElasto::reset_bodies() {
+    // body mount
+    body_mount->set_position(Vector3d(0.0, 0.0, 0.0));
+    body_mount->set_rotation(Quaternion(1.0, 0.0, 0.0, 0.0));
+    body_mount->set_mass(0.0);
+    body_mount->set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
+    // body root
+    body_root->set_position(Vector3d(0.0, 0.0, 0.0));
+    body_root->set_rotation(Quaternion(1.0, 0.0, 0.0, 0.0));
+    body_root->set_mass(0.0);
+    body_root->set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
+}
+
 BladeElastoFEA::BladeElastoFEA() {}
 
 void BladeElastoFEA::assemble_this(SystemElasto& system) {
@@ -118,6 +125,8 @@ void BladeElastoFEA::update_root_constraint() {
 }
 
 void BladeElastoFEA::build() {
+    reset_bodies();
+
     // check that enough reference points were defined to create elements (at least 2)
     if (reference_points.size() < 2) {
         throw std::runtime_error("Not enough elasto reference points defined for blade (" +
@@ -169,6 +178,9 @@ void BladeElastoFEA::build() {
     } else {
         build_elements_tapered_timoshenko();
     }
+
+    // apply initial pitch
+    apply_pitch_increment(pitch0);
 
     update_root_constraint();
 };
@@ -265,6 +277,8 @@ void BladeElastoFEA::accumulate_load_along_blade(const seahowl::Vector3d& load,
 BladeElastoRigid::BladeElastoRigid() {}
 
 void BladeElastoRigid::build() {
+    reset_bodies();
+
     body_cog = std::make_unique<BodyElastoChrono>();
     length = reference_points.back().coordinates.z();
 
@@ -298,6 +312,9 @@ void BladeElastoRigid::build() {
     body_cog->set_mass(mass_total);
     body_cog->set_inertia_diagonal(Vector3d(0., 0., 0.));
     body_root->set_inertia_diagonal(Vector3d(inertia_total, inertia_total, 0.0));
+
+    // apply initial pitch
+    apply_pitch_increment(pitch0);
 
     // link root and cog
     update_root_constraint();

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -10,15 +10,41 @@
 using namespace seahowl::elasto;
 
 BladeElasto::BladeElasto() {
+    body_root = std::make_unique<BodyElastoChrono>();
+    body_root->set_position(Vector3d(0.0, 0.0, 0.0));
     discretization_fractions = {0.0, 1.0};
     link_root = std::make_unique<LinkChrono>();
     link_root->set_constraints(true, true, true, true, true, true);
+    link_blade = std::make_unique<LinkChrono>();
+    link_blade->set_constraints(true, true, true, true, true, true);
+}
+
+void BladeElasto::attach_blade_to_body(const BodyElasto& body) {
+    is_mounted = true;
+    link_blade->initialize(*body_root, body);
 }
 
 void BladeElasto::assemble_this(SystemElasto& system) {
+    system.add(*(link_root.get()));
+    system.add(*(body_root.get()));
     if (is_mounted) {
-        system.add(*(link_root.get()));
+        system.add(*(link_blade.get()));
     }
+}
+
+void BladeElasto::rotate(double angle, const Vector3d& axis) const {
+    // blade root
+    body_root->rotate(angle, axis);
+}
+
+void BladeElasto::translate(const Vector3d& translation_vector) const {
+    // blade root
+    body_root->translate(translation_vector);
+}
+
+double BladeElasto::get_mass() const {
+    // adding body_root for consistency even if mass is supposed to be zero.
+    return body_root->get_mass();
 }
 
 BladeElastoFEA::BladeElastoFEA() {}
@@ -26,6 +52,25 @@ BladeElastoFEA::BladeElastoFEA() {}
 void BladeElastoFEA::assemble_this(SystemElasto& system) {
     BladeElasto::assemble_this(system);
     ComponentElastoFEA::assemble_this(system);
+}
+
+void BladeElastoFEA::rotate(double angle, const Vector3d& axis) const {
+    // blade root
+    BladeElasto::rotate(angle, axis);
+    // blade nodes
+    ComponentElastoFEA::rotate(angle, axis);
+}
+
+void BladeElastoFEA::translate(const Vector3d& translation_vector) const {
+    // blade root
+    BladeElasto::translate(translation_vector);
+    // blade nodes
+    ComponentElastoFEA::translate(translation_vector);
+}
+
+double BladeElastoFEA::get_mass() const {
+    // adding body_root for consistency even if mass is supposed to be zero.
+    return ComponentElastoFEA::get_mass() + body_root->get_mass();
 }
 
 void BladeElastoFEA::build() {
@@ -80,6 +125,9 @@ void BladeElastoFEA::build() {
     } else {
         build_elements_tapered_timoshenko();
     }
+
+    // attach node to root body
+    link_root->initialize(*nodes[0], *body_root);
 };
 
 void BladeElastoFEA::build_elements_tapered_timoshenko() {
@@ -141,6 +189,9 @@ void BladeElastoFEA::apply_pitch_increment(double pitch_increment) {
     rotate(-pitch_increment, root_dir);
     translate(root_pos);
     pitch += pitch_increment;
+
+    // update blade-root constraint
+    link_root->initialize(*nodes[0], *body_root);
 }
 
 seahowl::Vector3d BladeElastoFEA::get_blade_root_moment() const {
@@ -181,15 +232,9 @@ void BladeElastoFEA::accumulate_load_along_blade(const seahowl::Vector3d& load,
     accumulate_element_load(load, moment, element_index, eta, offset);
 }
 
-void BladeElastoFEA::attach_root_to_body(const BodyElasto& body) {
-    is_mounted = true;
-    link_root->initialize(*(nodes.front().get()), body);
-};
-
 BladeElastoRigid::BladeElastoRigid() {}
 
 void BladeElastoRigid::build() {
-    body_root = std::make_unique<BodyElastoChrono>();
     body_cog = std::make_unique<BodyElastoChrono>();
     length = reference_points.back().coordinates.z();
 
@@ -228,28 +273,27 @@ void BladeElastoRigid::build() {
     body_root->set_inertia_diagonal(Vector3d(inertia_total, inertia_total, 0.0));
 
     // link root and cog
-    link_cog_root = std::make_unique<LinkChrono>();
-    link_cog_root->set_constraints(true, true, true, true, true, true);
-    link_cog_root->initialize(*body_cog, *body_root);
+    link_root = std::make_unique<LinkChrono>();
+    link_root->set_constraints(true, true, true, true, true, true);
+    link_root->initialize(*body_cog, *body_root);
 }
 
 void BladeElastoRigid::assemble_this(SystemElasto& system) {
     BladeElasto::assemble_this(system);
     system.add(*(body_root.get()));
     system.add(*(body_cog.get()));
-    system.add(*(link_cog_root.get()));
 }
 
 void BladeElastoRigid::rotate(double angle, const Vector3d& axis) const {
     // blade root
-    body_root->rotate(angle, axis);
+    BladeElasto::rotate(angle, axis);
     // blade cog
     body_cog->rotate(angle, axis);
 }
 
 void BladeElastoRigid::translate(const Vector3d& translation_vector) const {
     // blade root
-    body_root->translate(translation_vector);
+    BladeElasto::translate(translation_vector);
     // blade cog
     body_cog->translate(translation_vector);
 }
@@ -266,14 +310,17 @@ void BladeElastoRigid::apply_pitch_increment(double pitch_increment) {
     rotate(-pitch_increment, root_dir);
     translate(root_pos);
     pitch += pitch_increment;
+
+    // update blade-root constraint
+    link_root->initialize(*body_cog, *body_root);
 }
 
 seahowl::Vector3d BladeElastoRigid::get_blade_root_moment() const {
-    return link_cog_root->get_reaction_torque() + body_root->get_torque();
+    return link_root->get_reaction_torque() + body_root->get_torque();
 }
 
 seahowl::Vector3d BladeElastoRigid::get_blade_root_force() const {
-    return link_cog_root->get_reaction_force() + body_root->get_force();
+    return link_root->get_reaction_force() + body_root->get_force();
 }
 
 seahowl::EntityDynamicEigen BladeElastoRigid::get_entity_along_blade(double eta, int element_index) const {
@@ -331,8 +378,3 @@ void BladeElastoRigid::accumulate_load_along_blade(const seahowl::Vector3d& load
     auto distance = (entity.get_position() + offset - body_root->get_position());
     body_root->accumulate_torque(moment + distance.cross(load), false);
 }
-
-void BladeElastoRigid::attach_root_to_body(const BodyElasto& body) {
-    is_mounted = true;
-    link_root->initialize(*body_root, body);
-};

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -22,6 +22,9 @@
 #include <memory>
 #include <spdlog/spdlog.h>
 
+// default mass value for checking if ChBody mass was set.
+const double MASS_NOTSET_VALUE = -1.2345e-12;
+
 namespace seahowl {
 namespace elasto {
 
@@ -165,8 +168,8 @@ Vector3d EntityDynamicChrono::get_rotational_acceleration(bool is_local) const {
 BodyElastoChrono::BodyElastoChrono() {
     chobj = chrono_types::make_shared<chrono::ChBody>();
     EntityDynamicChrono::chobj = chobj;
-    set_mass(0.0);
-    set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
+    set_mass(MASS_NOTSET_VALUE);
+    set_inertia_diagonal(Vector3d(MASS_NOTSET_VALUE, MASS_NOTSET_VALUE, MASS_NOTSET_VALUE));
 }
 
 void BodyElastoChrono::set_mass(double mass) {
@@ -856,11 +859,16 @@ void SystemElastoChrono::assemble() {
     // warnings for properties that were not set
     int body_idx = 0;
     for (auto& body : chobj->Get_bodylist()) {
-        if (body->GetMass() == 0) {
-            spdlog::warn("Body with mass 0.0 in elasto system (index of body: {}).", body_idx);
+        if (body->GetMass() == MASS_NOTSET_VALUE) {
+            spdlog::warn("Body (index {} in elasto system) mass was not set, making it massless.", body_idx);
+            body->SetMass(0.0);
         }
-        if (body->GetInertia().sum() == 0) {
-            spdlog::warn("Body with empty inertia matrix (sum 0.0) in elasto system (index of body: {}).", body_idx);
+        auto inertia_matrix = body->GetInertia();
+        if (inertia_matrix(0, 0) == inertia_matrix(1, 1) && inertia_matrix(1, 1) == inertia_matrix(2, 2) &&
+            inertia_matrix(2, 2) == MASS_NOTSET_VALUE && inertia_matrix.sum() == 3 * MASS_NOTSET_VALUE) {
+            spdlog::warn("Body (index {} in elasto system) inertia matrix mass was not set, making a null matrix.",
+                         body_idx);
+            body->SetInertiaXX(chrono::ChVector<double>(0.0, 0.0, 0.0));
         }
         body_idx += 1;
     }

--- a/src/elasto/floater_elasto.cpp
+++ b/src/elasto/floater_elasto.cpp
@@ -72,6 +72,8 @@ void FloaterElasto::add_fairlead(const Vector3d& position, const std::string& co
     fairlead_bodies[connected_body_name].push_back(std::make_unique<seahowl::elasto::BodyElastoChrono>());
     auto& fairlead = *(fairlead_bodies[connected_body_name].back());
     fairlead.set_position(position);
+    fairlead.set_mass(0.0);
+    fairlead.set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
 
     // link
     fairlead_links[connected_body_name].push_back(std::make_unique<seahowl::elasto::LinkChrono>());

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -70,7 +70,7 @@ void RotorElasto::apply_blade_pitch_increment(double pitch_increment, int blade_
     auto blade = blades[blade_index];
     blade->apply_pitch_increment(pitch_increment);
     // update blade-hub constraint
-    blade->attach_root_to_body(*body_hub);
+    blade->attach_blade_to_body(*body_hub);
 }
 
 void RotorElasto::rotate(double angle, const Vector3d& axis) const {
@@ -246,7 +246,7 @@ double RotorNacelleAssemblyElasto::get_axial_torque() const {
     // those links are already in the hub body reference frame
     auto react_torque = Vector3d(0.0, 0.0, 0.0);
     for (auto& blade : rotor->blades) {
-        react_torque += blade->link_root->get_reaction_torque();
+        react_torque += blade->link_blade->get_reaction_torque();
     }
     return react_torque.x();
 }

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -52,6 +52,9 @@ void RotorElasto::build() {
 
         // apply initial pitch of blades
         apply_blade_pitch_increment(blade->pitch, ii);
+
+        // update blade-hub constraint
+        blade->attach_blade_to_body(*body_hub);
     }
 }
 
@@ -69,8 +72,6 @@ void RotorElasto::apply_blade_pitch_increment(double pitch_increment, int blade_
     }
     auto blade = blades[blade_index];
     blade->apply_pitch_increment(pitch_increment);
-    // update blade-hub constraint
-    blade->attach_blade_to_body(*body_hub);
 }
 
 void RotorElasto::rotate(double angle, const Vector3d& axis) const {

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -56,19 +56,10 @@ void RotorElasto::build() {
 }
 
 void RotorElasto::apply_collective_pitch_increment(double pitch_increment) {
-    for (int ii = 0; ii < blades.size(); ii++) {
-        apply_blade_pitch_increment(pitch_increment, ii);
+    for (auto& blade : blades) {
+        blade->apply_pitch_increment(pitch_increment);
     }
     pitch_collective += pitch_increment;
-}
-
-void RotorElasto::apply_blade_pitch_increment(double pitch_increment, int blade_index) {
-    if (blade_index >= blades.size()) {
-        throw std::runtime_error("Cannot find blade index " + std::to_string(blade_index) +
-                                 " (number of blades: " + std::to_string(blades.size()) + ".");
-    }
-    auto blade = blades[blade_index];
-    blade->apply_pitch_increment(pitch_increment);
 }
 
 void RotorElasto::rotate(double angle, const Vector3d& axis) const {

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -50,9 +50,6 @@ void RotorElasto::build() {
         blade->rotate(azimuth0,
                       Vector3d(1.0, 0.0, 0.0));  // X is the axis pointing towards nacelle for blade (IEC standard)
 
-        // apply initial pitch of blades
-        apply_blade_pitch_increment(blade->pitch, ii);
-
         // update blade-hub constraint
         blade->attach_blade_to_body(*body_hub);
     }

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -72,8 +72,6 @@ void RotorElasto::apply_blade_pitch_increment(double pitch_increment, int blade_
     }
     auto blade = blades[blade_index];
     blade->apply_pitch_increment(pitch_increment);
-    // update blade-hub constraint
-    blade->attach_blade_to_body(*body_hub);
 }
 
 void RotorElasto::rotate(double angle, const Vector3d& axis) const {

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -72,6 +72,8 @@ void RotorElasto::apply_blade_pitch_increment(double pitch_increment, int blade_
     }
     auto blade = blades[blade_index];
     blade->apply_pitch_increment(pitch_increment);
+    // update blade-hub constraint
+    blade->attach_blade_to_body(*body_hub);
 }
 
 void RotorElasto::rotate(double angle, const Vector3d& axis) const {

--- a/src/io/output_manager.cpp
+++ b/src/io/output_manager.cpp
@@ -82,7 +82,7 @@ void OutputManager::output_all(int step) {
         int nblades = turbine.rna.blades.size();
         if (nblades <= 3 && nblades > 0) {
             for (int ii = 0; ii < turbine.rna.blades.size(); ii++) {
-                output_sstring << ", pitch" << ii + 1 << ": " << turbine.rna.elasto.rotor->blades[ii]->pitch;
+                output_sstring << ", pitch" << ii + 1 << ": " << turbine.rna.elasto.rotor->blades[ii]->get_pitch();
             }
         } else {
             output_sstring << ", pitch: " << turbine.rna.elasto.rotor->pitch_collective;

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -47,6 +47,7 @@
 #include <typeinfo>
 #include <filesystem>
 #include <spdlog/spdlog.h>
+
 namespace fs = std::filesystem;
 using std::filesystem::path;
 using std::filesystem::absolute;
@@ -808,6 +809,8 @@ void populate_turbine_from_json(const std::string& filepath,
                 floater_elasto.mooring_system->anchors.push_back(std::make_shared<seahowl::elasto::BodyElastoChrono>());
                 auto& anchor_body = *floater_elasto.mooring_system->anchors.back();
                 anchor_body.set_position(anchor_position);
+                anchor_body.set_mass(0.0);
+                anchor_body.set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
                 anchor_body.set_fixed(true);
 
                 auto mooring_properties_json = get_json_from_file(

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -605,7 +605,7 @@ void populate_turbine_from_json(const std::string& filepath,
             auto blade = std::make_shared<seahowl::core::Blade>(*blade_elasto, *blade_aero);
             populate_blade_from_json(filepath_blade, *blade);
             rotor_json.at("discretization").at("aero").get_to(blade->aero.discretization_fractions);
-            blade_elasto->pitch = blade_json.at("initial_pitch").get<double>() * PI / 180.0;
+            blade_elasto->pitch0 = blade_json.at("initial_pitch").get<double>() * PI / 180.0;
             blade_elasto->precone = blade_json.at("precone").get<double>() * PI / 180.0;
             // no precone if blade is rigid (assumed that blade is on rotor disc)
             if (rotor_json.at("type").get<std::string>() == "rigid") {

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -1185,15 +1185,16 @@ void initialize_system_from_json(const std::string& filepath, seahowl::core::Sys
     // timestepping
     double dt = num_json.at("dt").get<double>();
 
+    system_core.initialize(system_core.get_time(), dt);
+
     // initialization
     // statics
     auto linear_step = statics_json.at("linear_step").get<bool>();
     auto nonlinear_steps = statics_json.at("nonlinear_steps").get<int>();
     if (linear_step && nonlinear_steps > 0) {
         system_core.elasto.do_statics(linear_step, nonlinear_steps);
+        system_core.poststep(system_core.get_time(), dt);  // poststep to update positions aero
     }
-
-    system_core.initialize(system_core.get_time(), dt);
 
     // apply presetup
     if (num_json.contains("presetup")) {

--- a/src/io/write_csv.cpp
+++ b/src/io/write_csv.cpp
@@ -140,7 +140,7 @@ void write_turbine_info_to_csv(std::string fileprefix, const seahowl::core::Syst
             }
             myfile << std::to_string(blade_azimuth);
             myfile << ",";
-            myfile << std::to_string(blade->elasto.pitch);
+            myfile << std::to_string(blade->elasto.get_pitch());
         }
         myfile << "\n";
         myfile.close();

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -59,7 +59,8 @@ void seahowl::servo::ControllerDISCON::update_turbine_variables(double time,
             pImpl.SetPitchBlade(index_blade, blade.get_pitch());
             // moment
             auto root_moment = blade.get_blade_root_moment();
-            pImpl.SetRootMomentBlade(index_blade, root_moment[0], root_moment[1]);
+            // pImpl.SetRootMomentBlade(index_blade, flap, edge);
+            pImpl.SetRootMomentBlade(index_blade, root_moment[1], root_moment[0]);
         }
     } else {
         pImpl.SetPitch(turbine.rna.elasto.rotor->pitch_collective);
@@ -102,7 +103,13 @@ void seahowl::servo::ControllerDISCON::initialize(double time, double dt, const 
 
     update_turbine_variables(time, dt, turbine);
 
-    pImpl.SetAvrSWAP(27, 10.0);  // estimated wind speed (needs to be != 0 at init for it to work in ROSCO!)
+    // estimated wind speed (needs to be != 0 at init for it to work in ROSCO!)
+    pImpl.SetAvrSWAP(27, 10.0);
+
+    // Switch IPC on by default (seems to work for CPC as well).
+    // Switching it off leads to problems with ROSCO when IPC is used (individual blade pitch returned by ROSCO but no
+    // electrical torque anymore) Keeping it on works for CPC mode also (tested on ROSCO v2.9.0).
+    pImpl.SetAvrSWAP(28, 1.0);
 
     pImpl.Init(libfile);
 

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -56,7 +56,7 @@ void seahowl::servo::ControllerDISCON::update_turbine_variables(double time,
         for (int index_blade = 0; index_blade < nblades; index_blade++) {
             auto& blade = *turbine.rna.elasto.rotor->blades[index_blade];
             // pitch
-            pImpl.SetPitchBlade(index_blade, blade.pitch);
+            pImpl.SetPitchBlade(index_blade, blade.get_pitch());
             // moment
             auto root_moment = blade.get_blade_root_moment();
             pImpl.SetRootMomentBlade(index_blade, root_moment[0], root_moment[1]);

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -618,7 +618,7 @@ TEST(test_turbine, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.697277, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.698450, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_fpm) {
@@ -677,7 +677,7 @@ TEST(test_turbine, rpm_initial_pitch_fpm) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.700212, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.701380, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
@@ -950,7 +950,7 @@ TEST(test_aerodyn, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.716130, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.719950, 1e-4);
 }
 #endif
 
@@ -1084,7 +1084,7 @@ TEST(test_inflowwind, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.686779, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.687975, 1e-4);
 }
 #endif
 

--- a/tests/unit_tests/test_components.cpp
+++ b/tests/unit_tests/test_components.cpp
@@ -573,6 +573,7 @@ TEST(test_turbine, rpm_initial_pitch) {
     // wind
     auto wind_model = seahowl::env::ConstantWind();
     wind_model.set_wind_velocity(Vector3d(8.0, 0.0, 0.0));
+    wind_model.shear_coefficient = 0.12;
     // turbine
     double initial_pitch = seahowl::PI / 8.0;
 
@@ -618,7 +619,7 @@ TEST(test_turbine, rpm_initial_pitch) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.698450, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.687975, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_fpm) {
@@ -632,6 +633,7 @@ TEST(test_turbine, rpm_initial_pitch_fpm) {
     // wind
     auto wind_model = seahowl::env::ConstantWind();
     wind_model.set_wind_velocity(Vector3d(8.0, 0.0, 0.0));
+    wind_model.shear_coefficient = 0.12;
     // turbine
     double initial_pitch = seahowl::PI / 8.0;
 
@@ -677,7 +679,7 @@ TEST(test_turbine, rpm_initial_pitch_fpm) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.701380, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.691299, 1e-4);
 }
 
 TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
@@ -691,6 +693,7 @@ TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
     // wind
     auto wind_model = seahowl::env::ConstantWind();
     wind_model.set_wind_velocity(Vector3d(8.0, 0.0, 0.0));
+    wind_model.shear_coefficient = 0.12;
     // turbine
     double initial_pitch = seahowl::PI / 8.0;
 
@@ -736,7 +739,7 @@ TEST(test_turbine, rpm_initial_pitch_rigid_rotor) {
         turbine.poststep(time, dt);
     }
 
-    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.728150, 1e-4);
+    ASSERT_NEAR(turbine.rna.elasto.get_rpm(), 2.709388, 1e-4);
 }
 
 TEST(test_turbine, controller_target_rpm) {
@@ -750,6 +753,7 @@ TEST(test_turbine, controller_target_rpm) {
     // wind
     auto wind_model = seahowl::env::ConstantWind();
     wind_model.set_wind_velocity(Vector3d(8.0, 0.0, 0.0));
+    wind_model.shear_coefficient = 0.12;
     // turbine
     double initial_pitch = seahowl::PI / 8.0;
 
@@ -812,6 +816,7 @@ TEST(test_turbine, actuator_disk) {
     // wind
     auto wind_model = seahowl::env::ConstantWind();
     wind_model.set_wind_velocity(Vector3d(11.0, 0.0, 0.0));
+    wind_model.shear_coefficient = 0.12;
     // turbine
     double initial_pitch = 0.0 * seahowl::PI / 1000.0;
     // power target
@@ -901,8 +906,8 @@ TEST(test_aerodyn, rpm_initial_pitch) {
     // timestepping
     double dt = 0.1;
     // wind
-    auto wind_model = seahowl::env::ConstantWind();
-    wind_model.set_wind_velocity(Vector3d(8.0, 0.0, 0.0));
+    auto wind_model =
+        seahowl::env::InflowWindAdapter((DATADIR / "aerodyn/IEA-15-240-RWT_InflowWind.dat").generic_string());
     // turbine
     double initial_pitch = seahowl::PI / 8.0;
 
@@ -965,6 +970,7 @@ TEST(test_turbine, multiturbines) {
     // wind
     auto wind_model = std::make_shared<seahowl::env::ConstantWind>();
     wind_model->set_wind_velocity(Vector3d(8.0, 0.0, 0.0));
+    wind_model->shear_coefficient = 0.12;
     // turbine
     double initial_pitch = seahowl::PI / 8.0;
 


### PR DESCRIPTION
In this PR:
- Massless rigid body added for blade pitch axis
- Massless rigid body added for blade mounting point
- Remove pitch variable and replace by getter calculating pitch on the fly
- Pass root body info to AeroDyn's BladeRootMotion
- Update tests (+ add wind shear on all tests)
- Fix DISCON issue when using IPC mode