### PR TITLE
Add gradual ramp option on fluid models vel/acc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,7 @@ source_group(hydro FILES ${SEAHOWL_HYDRO_SOURCES} ${SEAHOWL_HYDRO_HEADERS})
 
 # env
 set(SEAHOWL_ENV_SOURCES
+    src/env/fluid_models.cpp
     src/env/wind_models.cpp
     src/env/wave_models.cpp
     src/env/soil_models.cpp

--- a/data/IEA15MW/environment.json
+++ b/data/IEA15MW/environment.json
@@ -1,5 +1,7 @@
 ﻿{
   "gravity": [0.0, 0.0, -9.81],
+  "ramp_start": 0.0,
+  "ramp_end": 0.0,
   "wind": {
     "type": "ramp",
     "air_density": 1.225,

--- a/data/IEA15MW/environment_hydrochrono.json
+++ b/data/IEA15MW/environment_hydrochrono.json
@@ -1,5 +1,7 @@
 ﻿{
   "gravity": [0.0, 0.0, -9.81],
+  "ramp_start": 0.0,
+  "ramp_end": 0.0,
   "wind": {
     "type": "ramp",
     "air_density": 1.225,

--- a/data/IEA15MW/environment_inflowwind.json
+++ b/data/IEA15MW/environment_inflowwind.json
@@ -1,5 +1,7 @@
 ﻿{
   "gravity": [0.0, 0.0, -9.81],
+  "ramp_start": 0.0,
+  "ramp_end": 0.0,
   "wind": {
     "type": "inflowwind",
     "options": {

--- a/include/seahowl/env/combined_models.h
+++ b/include/seahowl/env/combined_models.h
@@ -16,21 +16,17 @@ class WaveWindModel : public FluidModel {
     std::shared_ptr<WindModel> wind_model;
     std::shared_ptr<WaveModel> wave_model;
 
-    virtual Vector3d get_fluid_velocity(const Vector3d& position, double time) const override;
-
-    virtual Vector3d get_fluid_acceleration(const Vector3d& position, double time) const override;
-
     virtual double get_fluid_density(const Vector3d& position, double time) const override;
+
+  protected:
+    virtual Vector3d get_fluid_velocity_this(const Vector3d& position, double time) const override;
+    virtual Vector3d get_fluid_acceleration_this(const Vector3d& position, double time) const override;
 };
 
 class FluidSoilModel : public FluidModel, public SoilModel {
   public:
     std::shared_ptr<FluidModel> fluid_model;
     std::shared_ptr<SoilModel> soil_model;
-
-    virtual Vector3d get_fluid_velocity(const Vector3d& position, double time) const override;
-
-    virtual Vector3d get_fluid_acceleration(const Vector3d& position, double time) const override;
 
     virtual double get_fluid_density(const Vector3d& position, double time) const override;
 
@@ -39,6 +35,10 @@ class FluidSoilModel : public FluidModel, public SoilModel {
     virtual Vector3d get_penetration_load(const EntityDynamic& entity,
                                           double contact_area,
                                           double entity_mass) const override;
+
+  protected:
+    virtual Vector3d get_fluid_velocity_this(const Vector3d& position, double time) const override;
+    virtual Vector3d get_fluid_acceleration_this(const Vector3d& position, double time) const override;
 };
 
 }  // namespace env

--- a/include/seahowl/env/fluid_models.h
+++ b/include/seahowl/env/fluid_models.h
@@ -14,25 +14,6 @@ class FluidModel {
     double ramp_end = 0.0;
 
     /**
-     * @brief Returns fluid velocity at given coordinates.
-     *
-     * @param[in] position Position at which fluid velocity is extracted.
-     * @param[in] time Time of simulation.
-     */
-    Vector3d get_fluid_velocity(const Vector3d& position, double time) const {
-        Vector3d velocity = get_fluid_velocity_this(position, time);
-        if (time < ramp_end) {
-            if (time > ramp_start) {
-                double ramp_fraction = time / (ramp_end - ramp_start);
-                velocity *= ramp_fraction;
-            } else {
-                velocity *= 0.0;
-            }
-        }
-        return velocity;
-    };
-
-    /**
      * @brief Returns fluid density at given coordinates.
      *
      * @param[in] position Position at which fluid density is extracted.
@@ -40,23 +21,24 @@ class FluidModel {
      */
     virtual double get_fluid_density(const Vector3d& position, double time) const = 0;
 
-    virtual Vector3d get_fluid_acceleration(const Vector3d& position, double time) const {
-        Vector3d acceleration = get_fluid_acceleration_this(position, time);
-        if (time < ramp_end) {
-            if (time > ramp_start) {
-                double ramp_fraction = time / (ramp_end - ramp_start);
-                acceleration *= ramp_fraction;
-            } else {
-                acceleration *= 0.0;
-            }
-        }
-        return acceleration;
-    };
+    /**
+     * @brief Returns fluid velocity at given coordinates.
+     *
+     * @param[in] position Position at which fluid velocity is extracted.
+     * @param[in] time Time of simulation.
+     */
+    Vector3d get_fluid_velocity(const Vector3d& position, double time) const;
+
+    /**
+     * @brief Returns fluid acceleration at given coordinates.
+     *
+     * @param[in] position Position at which fluid acceleration is extracted.
+     * @param[in] time Time of simulation.
+     */
+    virtual Vector3d get_fluid_acceleration(const Vector3d& position, double time) const;
 
   protected:
-    virtual Vector3d get_fluid_acceleration_this(const Vector3d& position, double time) const {
-        return Vector3d(0.0, 0.0, 0.0);
-    };
+    virtual Vector3d get_fluid_acceleration_this(const Vector3d& position, double time) const = 0;
     virtual Vector3d get_fluid_velocity_this(const Vector3d& position, double time) const = 0;
 };
 

--- a/include/seahowl/env/fluid_models.h
+++ b/include/seahowl/env/fluid_models.h
@@ -10,13 +10,27 @@ namespace env {
  */
 class FluidModel {
   public:
+    double ramp_start = 0.0;
+    double ramp_end = 0.0;
+
     /**
      * @brief Returns fluid velocity at given coordinates.
      *
      * @param[in] position Position at which fluid velocity is extracted.
      * @param[in] time Time of simulation.
      */
-    virtual Vector3d get_fluid_velocity(const Vector3d& position, double time) const = 0;
+    Vector3d get_fluid_velocity(const Vector3d& position, double time) const {
+        Vector3d velocity = get_fluid_velocity_this(position, time);
+        if (time < ramp_end) {
+            if (time > ramp_start) {
+                double ramp_fraction = time / (ramp_end - ramp_start);
+                velocity *= ramp_fraction;
+            } else {
+                velocity *= 0.0;
+            }
+        }
+        return velocity;
+    };
 
     /**
      * @brief Returns fluid density at given coordinates.
@@ -27,8 +41,23 @@ class FluidModel {
     virtual double get_fluid_density(const Vector3d& position, double time) const = 0;
 
     virtual Vector3d get_fluid_acceleration(const Vector3d& position, double time) const {
+        Vector3d acceleration = get_fluid_acceleration_this(position, time);
+        if (time < ramp_end) {
+            if (time > ramp_start) {
+                double ramp_fraction = time / (ramp_end - ramp_start);
+                acceleration *= ramp_fraction;
+            } else {
+                acceleration *= 0.0;
+            }
+        }
+        return acceleration;
+    };
+
+  protected:
+    virtual Vector3d get_fluid_acceleration_this(const Vector3d& position, double time) const {
         return Vector3d(0.0, 0.0, 0.0);
     };
+    virtual Vector3d get_fluid_velocity_this(const Vector3d& position, double time) const = 0;
 };
 
 }  // namespace env

--- a/include/seahowl/env/inflowwind_adapter.h
+++ b/include/seahowl/env/inflowwind_adapter.h
@@ -98,6 +98,7 @@ class InflowWindAdapter : public WindModel {
 
   protected:
     virtual Vector3d get_fluid_velocity_this(const Vector3d& position, double time) const override;
+    virtual Vector3d get_fluid_acceleration_this(const Vector3d& position, double time) const override;
 };
 
 }  // namespace env

--- a/include/seahowl/env/inflowwind_adapter.h
+++ b/include/seahowl/env/inflowwind_adapter.h
@@ -95,7 +95,9 @@ class InflowWindAdapter : public WindModel {
     ~InflowWindAdapter();
 
     void end();
-    virtual Vector3d get_fluid_velocity(const Vector3d& position, double time) const override;
+
+  protected:
+    virtual Vector3d get_fluid_velocity_this(const Vector3d& position, double time) const override;
 };
 
 }  // namespace env

--- a/include/seahowl/env/wave_models.h
+++ b/include/seahowl/env/wave_models.h
@@ -44,13 +44,13 @@ class StillWater : public WaveModel {
      */
     StillWater();
 
-    virtual Vector3d get_fluid_velocity(const Vector3d& position, double time) const override;
-
-    virtual Vector3d get_fluid_acceleration(const Vector3d& position, double time) const override;
-
     virtual double get_fluid_density(const Vector3d& position, double time) const override;
 
     virtual double get_water_level(const Vector3d& position, double time) const override;
+
+  protected:
+    virtual Vector3d get_fluid_velocity_this(const Vector3d& position, double time) const override;
+    virtual Vector3d get_fluid_acceleration_this(const Vector3d& position, double time) const override;
 };
 
 /**
@@ -72,9 +72,9 @@ class CurrentConstant : public StillWater {
      */
     CurrentConstant();
 
-    virtual Vector3d get_fluid_velocity(const Vector3d& position, double time) const override;
-
-    virtual Vector3d get_fluid_acceleration(const Vector3d& position, double time) const override;
+  protected:
+    virtual Vector3d get_fluid_velocity_this(const Vector3d& position, double time) const override;
+    virtual Vector3d get_fluid_acceleration_this(const Vector3d& position, double time) const override;
 };
 
 }  // namespace env

--- a/include/seahowl/env/wind_models.h
+++ b/include/seahowl/env/wind_models.h
@@ -51,6 +51,7 @@ class ConstantWind : public ShearedWind {
 
   protected:
     virtual Vector3d get_fluid_velocity_this(const Vector3d& position, double time) const override;
+    virtual Vector3d get_fluid_acceleration_this(const Vector3d& position, double time) const override;
 };
 
 /**@brief Wind ramp model. */
@@ -85,6 +86,7 @@ class WindRamp : public ShearedWind {
 
   protected:
     virtual Vector3d get_fluid_velocity_this(const Vector3d& position, double time) const override;
+    virtual Vector3d get_fluid_acceleration_this(const Vector3d& position, double time) const override;
 };
 
 }  // namespace env

--- a/include/seahowl/env/wind_models.h
+++ b/include/seahowl/env/wind_models.h
@@ -49,13 +49,8 @@ class ConstantWind : public ShearedWind {
      */
     void set_wind_velocity(Vector3d velocity);
 
-    /**
-     * @brief Returns wind velocity at given coordinates.
-     *
-     * @param[in] position Position at which wind velocity is extracted.
-     * @param[in] time Time of simulation.
-     */
-    virtual Vector3d get_fluid_velocity(const Vector3d& position, double time) const override;
+  protected:
+    virtual Vector3d get_fluid_velocity_this(const Vector3d& position, double time) const override;
 };
 
 /**@brief Wind ramp model. */
@@ -88,13 +83,8 @@ class WindRamp : public ShearedWind {
                        const Vector3d& velocity_end,
                        double time_end);
 
-    /**
-     * @brief Returns wind velocity at given coordinates.
-     *
-     * @param[in] position Position at which wind velocity is extracted.
-     * @param[in] time Time of simulation.
-     */
-    virtual Vector3d get_fluid_velocity(const Vector3d& position, double time) const override;
+  protected:
+    virtual Vector3d get_fluid_velocity_this(const Vector3d& position, double time) const override;
 };
 
 }  // namespace env

--- a/include/seahowl/hydro/hydrochrono_adapter.h
+++ b/include/seahowl/hydro/hydrochrono_adapter.h
@@ -86,11 +86,12 @@ class WaveModelHydroChrono : public WaveModel {
      * @brief Constructor.
      */
     WaveModelHydroChrono();
-
-    virtual Vector3d get_fluid_velocity(const Vector3d& position, double time) const override;
-    virtual Vector3d get_fluid_acceleration(const Vector3d& position, double time) const override;
     virtual double get_fluid_density(const Vector3d& position, double time) const override;
     virtual double get_water_level(const Vector3d& position, double time) const override;
+
+  protected:
+    virtual Vector3d get_fluid_velocity_this(const Vector3d& position, double time) const override;
+    virtual Vector3d get_fluid_acceleration_this(const Vector3d& position, double time) const override;
 };
 
 }  // namespace env

--- a/src/bindings/python/pyseahowl_env.cpp
+++ b/src/bindings/python/pyseahowl_env.cpp
@@ -21,7 +21,10 @@ void initialize_pyseahowl_env(py::module& m) {
 
     // env/fluid_models.h
     py::class_<seahowl::env::FluidModel, std::shared_ptr<seahowl::env::FluidModel>>(m_env, "FluidModel")
+        .def_readwrite("ramp_start", &seahowl::env::FluidModel::ramp_start)
+        .def_readwrite("ramp_end", &seahowl::env::FluidModel::ramp_end)
         .def("get_fluid_velocity", &seahowl::env::FluidModel::get_fluid_velocity)
+        .def("get_fluid_acceleration", &seahowl::env::FluidModel::get_fluid_acceleration)
         .def("get_fluid_density", &seahowl::env::FluidModel::get_fluid_density);
 
     // env/wind_models.h

--- a/src/env/combined_models.cpp
+++ b/src/env/combined_models.cpp
@@ -11,7 +11,7 @@ double WaveWindModel::get_fluid_density(const Vector3d& position, double time) c
     }
 }
 
-Vector3d WaveWindModel::get_fluid_velocity(const Vector3d& position, double time) const {
+Vector3d WaveWindModel::get_fluid_velocity_this(const Vector3d& position, double time) const {
     if (wave_model->is_in_water(position, time)) {
         return wave_model->get_fluid_velocity(position, time);
     } else {
@@ -19,7 +19,7 @@ Vector3d WaveWindModel::get_fluid_velocity(const Vector3d& position, double time
     }
 }
 
-Vector3d WaveWindModel::get_fluid_acceleration(const Vector3d& position, double time) const {
+Vector3d WaveWindModel::get_fluid_acceleration_this(const Vector3d& position, double time) const {
     if (wave_model->is_in_water(position, time)) {
         return wave_model->get_fluid_acceleration(position, time);
     } else {
@@ -31,11 +31,11 @@ double FluidSoilModel::get_fluid_density(const Vector3d& position, double time) 
     return fluid_model->get_fluid_density(position, time);
 }
 
-Vector3d FluidSoilModel::get_fluid_velocity(const Vector3d& position, double time) const {
+Vector3d FluidSoilModel::get_fluid_velocity_this(const Vector3d& position, double time) const {
     return fluid_model->get_fluid_velocity(position, time);
 }
 
-Vector3d FluidSoilModel::get_fluid_acceleration(const Vector3d& position, double time) const {
+Vector3d FluidSoilModel::get_fluid_acceleration_this(const Vector3d& position, double time) const {
     return fluid_model->get_fluid_acceleration(position, time);
 }
 

--- a/src/env/fluid_models.cpp
+++ b/src/env/fluid_models.cpp
@@ -7,7 +7,7 @@ Vector3d FluidModel::get_fluid_velocity(const Vector3d& position, double time) c
     Vector3d velocity = get_fluid_velocity_this(position, time);
     if (time < ramp_end) {
         if (time > ramp_start) {
-            double ramp_fraction = time / (ramp_end - ramp_start);
+            double ramp_fraction = (time - ramp_start) / (ramp_end - ramp_start);
             velocity *= ramp_fraction;
         } else {
             velocity *= 0.0;
@@ -20,7 +20,7 @@ Vector3d FluidModel::get_fluid_acceleration(const Vector3d& position, double tim
     Vector3d acceleration = get_fluid_acceleration_this(position, time);
     if (time < ramp_end) {
         if (time > ramp_start) {
-            double ramp_fraction = time / (ramp_end - ramp_start);
+            double ramp_fraction = (time - ramp_start) / (ramp_end - ramp_start);
             acceleration *= ramp_fraction;
         } else {
             acceleration *= 0.0;

--- a/src/env/fluid_models.cpp
+++ b/src/env/fluid_models.cpp
@@ -1,0 +1,30 @@
+#include "seahowl/env/fluid_models.h"
+
+using namespace seahowl::env;
+using seahowl::Vector3d;
+
+Vector3d FluidModel::get_fluid_velocity(const Vector3d& position, double time) const {
+    Vector3d velocity = get_fluid_velocity_this(position, time);
+    if (time < ramp_end) {
+        if (time > ramp_start) {
+            double ramp_fraction = time / (ramp_end - ramp_start);
+            velocity *= ramp_fraction;
+        } else {
+            velocity *= 0.0;
+        }
+    }
+    return velocity;
+};
+
+Vector3d FluidModel::get_fluid_acceleration(const Vector3d& position, double time) const {
+    Vector3d acceleration = get_fluid_acceleration_this(position, time);
+    if (time < ramp_end) {
+        if (time > ramp_start) {
+            double ramp_fraction = time / (ramp_end - ramp_start);
+            acceleration *= ramp_fraction;
+        } else {
+            acceleration *= 0.0;
+        }
+    }
+    return acceleration;
+};

--- a/src/env/inflowwind_adapter.cpp
+++ b/src/env/inflowwind_adapter.cpp
@@ -55,6 +55,10 @@ seahowl::Vector3d InflowWindAdapter::get_fluid_velocity_this(const seahowl::Vect
     return velocity;
 }
 
+seahowl::Vector3d InflowWindAdapter::get_fluid_acceleration_this(const seahowl::Vector3d& position, double time) const {
+    return Vector3d(0.0, 0.0, 0.0);
+}
+
 void InflowWindLib::SetIFWINFILE(std::string name) {
     spdlog::info("Set InflowWind INFILE: {}.", name);
     IfWinputFileString = name;

--- a/src/env/inflowwind_adapter.cpp
+++ b/src/env/inflowwind_adapter.cpp
@@ -36,7 +36,7 @@ void InflowWindAdapter::end() {
     pImpl->End();
 }
 
-seahowl::Vector3d InflowWindAdapter::get_fluid_velocity(const seahowl::Vector3d& position, double time) const {
+seahowl::Vector3d InflowWindAdapter::get_fluid_velocity_this(const seahowl::Vector3d& position, double time) const {
     if (position.z() < zmin) {
         // zmin is set for cases such as TurbSim that cannot generate wind field close or below z=0
         return Vector3d(0.0, 0.0, 0.0);

--- a/src/env/wave_models.cpp
+++ b/src/env/wave_models.cpp
@@ -13,7 +13,7 @@ bool WaveModel::is_in_water(const Vector3d& position, double time) const {
 
 StillWater::StillWater() {}
 
-Vector3d StillWater::get_fluid_velocity(const Vector3d& position, double time) const {
+Vector3d StillWater::get_fluid_velocity_this(const Vector3d& position, double time) const {
     if (is_in_water(position, time)) {
         return Vector3d(0.0, 0.0, 0.0);
     } else {
@@ -21,7 +21,7 @@ Vector3d StillWater::get_fluid_velocity(const Vector3d& position, double time) c
     }
 }
 
-Vector3d StillWater::get_fluid_acceleration(const Vector3d& position, double time) const {
+Vector3d StillWater::get_fluid_acceleration_this(const Vector3d& position, double time) const {
     if (is_in_water(position, time)) {
         return Vector3d(0.0, 0.0, 0.0);
     } else {
@@ -43,7 +43,7 @@ double StillWater::get_water_level(const Vector3d& position, double time) const 
 
 CurrentConstant::CurrentConstant() {}
 
-Vector3d CurrentConstant::get_fluid_velocity(const Vector3d& position, double time) const {
+Vector3d CurrentConstant::get_fluid_velocity_this(const Vector3d& position, double time) const {
     if (is_in_water(position, time)) {
         auto position_depth = position.dot(surface_normal) - mean_water_level;
         auto horizontal_velocity =
@@ -55,7 +55,7 @@ Vector3d CurrentConstant::get_fluid_velocity(const Vector3d& position, double ti
     }
 }
 
-Vector3d CurrentConstant::get_fluid_acceleration(const Vector3d& position, double time) const {
+Vector3d CurrentConstant::get_fluid_acceleration_this(const Vector3d& position, double time) const {
     if (is_in_water(position, time)) {
         return Vector3d(0.0, 0.0, 0.0);
     } else {

--- a/src/env/wind_models.cpp
+++ b/src/env/wind_models.cpp
@@ -35,6 +35,10 @@ Vector3d ConstantWind::get_fluid_velocity_this(const Vector3d& position, double 
     return velocity;
 }
 
+Vector3d ConstantWind::get_fluid_acceleration_this(const Vector3d& position, double time) const {
+    return Vector3d(0.0, 0.0, 0.0);
+}
+
 WindRamp::WindRamp() {}
 
 void WindRamp::set_wind_ramp(const Vector3d& velocity_start,
@@ -62,4 +66,12 @@ Vector3d WindRamp::get_fluid_velocity_this(const Vector3d& position, double time
     }
     velocity = get_sheared_wind_velocity(velocity, position, direction_gravity, shear_coefficient, reference_height);
     return velocity;
+}
+
+Vector3d WindRamp::get_fluid_acceleration_this(const Vector3d& position, double time) const {
+    auto acceleration = Vector3d(0.0, 0.0, 0.0);
+    if (time >= time_start) {
+        acceleration = (wind_velocity_end - wind_velocity_start) / (time_end - time_start);
+    }
+    return acceleration;
 }

--- a/src/env/wind_models.cpp
+++ b/src/env/wind_models.cpp
@@ -29,7 +29,7 @@ void ConstantWind::set_wind_velocity(Vector3d velocity) {
     wind_velocity = velocity;
 }
 
-Vector3d ConstantWind::get_fluid_velocity(const Vector3d& position, double time) const {
+Vector3d ConstantWind::get_fluid_velocity_this(const Vector3d& position, double time) const {
     auto velocity =
         get_sheared_wind_velocity(wind_velocity, position, direction_gravity, shear_coefficient, reference_height);
     return velocity;
@@ -47,7 +47,7 @@ void WindRamp::set_wind_ramp(const Vector3d& velocity_start,
     this->time_end = time_end;
 }
 
-Vector3d WindRamp::get_fluid_velocity(const Vector3d& position, double time) const {
+Vector3d WindRamp::get_fluid_velocity_this(const Vector3d& position, double time) const {
     auto velocity = wind_velocity_start;
     if (time >= time_start) {
         if (time_end != time_start) {

--- a/src/hydro/hydrochrono_adapter.cpp
+++ b/src/hydro/hydrochrono_adapter.cpp
@@ -52,7 +52,7 @@ WaveModelHydroChrono::WaveModelHydroChrono() {
     waves = std::make_shared<NoWave>();
 }
 
-seahowl::Vector3d WaveModelHydroChrono::get_fluid_velocity(const Vector3d& position, double time) const {
+seahowl::Vector3d WaveModelHydroChrono::get_fluid_velocity_this(const Vector3d& position, double time) const {
     if (is_in_water(position, time)) {
         return waves->GetVelocity(position, time);
     } else {
@@ -60,7 +60,7 @@ seahowl::Vector3d WaveModelHydroChrono::get_fluid_velocity(const Vector3d& posit
     }
 }
 
-seahowl::Vector3d WaveModelHydroChrono::get_fluid_acceleration(const Vector3d& position, double time) const {
+seahowl::Vector3d WaveModelHydroChrono::get_fluid_acceleration_this(const Vector3d& position, double time) const {
     if (is_in_water(position, time)) {
         return waves->GetAcceleration(position, time);
     } else {

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -983,6 +983,18 @@ std::shared_ptr<seahowl::env::FluidSoilModel> get_environmental_model_from_json(
         env_model->fluid_model = std::move(wind_model_ptr);
     }
 
+    // apply ramp options
+    double ramp_start = 0.0;
+    double ramp_end = 0.0;
+    if (environment_json.contains("ramp_start")) {
+        environment_json.at("ramp_start").get_to(ramp_start);
+    }
+    if (environment_json.contains("ramp_end")) {
+        environment_json.at("ramp_end").get_to(ramp_end);
+    }
+    env_model->fluid_model->ramp_start = ramp_start;
+    env_model->fluid_model->ramp_end = ramp_end;
+
     // soil
     if (environment_json.contains("soil")) {
         auto soil_json = environment_json.at("soil");


### PR DESCRIPTION
This PR implements an option to apply ramp on fluid models for gradually applying their target velocity and acceleration.
- Added `ramp_start` and `ramp_end` to all fluid models to define start and end times of the ramp, with vel/acc of fluid applied with a factor varying linearly from 0.0 to 1.0
- This option can also be set in environment.json or Python