### PR TITLE
Gradually relax damping on FEA blades at presetup

### DIFF
--- a/include/seahowl/elasto/blade_elasto.h
+++ b/include/seahowl/elasto/blade_elasto.h
@@ -102,6 +102,7 @@ class BladeElastoFEA : public BladeElasto, public ComponentElastoFEA {
      */
     BladeElastoFEA();
 
+    virtual void presetup(double fraction) override;
     virtual void build() override;
     virtual void rotate(double angle, const Vector3d& axis) const override;
     virtual void translate(const Vector3d& translation_vector) const override;

--- a/include/seahowl/elasto/chrono_adapters.h
+++ b/include/seahowl/elasto/chrono_adapters.h
@@ -173,6 +173,7 @@ class ElementElastoChrono : public virtual ElementElasto {
     virtual void evaluate_position_rotation(double eta, Vector3d& position, Quaternion& rotation) override;
     virtual void evaluate_force_torque(double eta, Vector3d& force, Vector3d& torque) override;
     virtual double get_mass() override;
+    virtual void update_properties();
 };
 
 /**
@@ -186,6 +187,7 @@ class ElementBladeElastoChrono : public ElementElastoChrono, public ElementBlade
     ElementBladeElastoChrono();
     virtual void set_nodes(std::shared_ptr<NodeElasto> node1, std::shared_ptr<NodeElasto> node2) override;
     virtual void set_prebend(const Quaternion& prebend) override;
+    virtual void update_properties() override;
 };
 
 /**
@@ -199,6 +201,7 @@ class ElementBladeElastoChronoFPM : public ElementElastoChrono, public ElementBl
     ElementBladeElastoChronoFPM();
     virtual void set_nodes(std::shared_ptr<NodeElasto> node1, std::shared_ptr<NodeElasto> node2) override;
     virtual void set_prebend(const Quaternion& prebend) override;
+    virtual void update_properties() override;
 };
 
 /**

--- a/include/seahowl/elasto/rotor_elasto.h
+++ b/include/seahowl/elasto/rotor_elasto.h
@@ -82,7 +82,7 @@ class RotorElasto : public ComponentElasto {
      * @brief Builds the rotor.
      */
     void build() override;
-
+    virtual void presetup(double fraction) override;
     virtual void rotate(double angle, const Vector3d& axis) const override;
     virtual void translate(const Vector3d& translation_vector) const override;
     virtual double get_mass() const override;
@@ -166,6 +166,7 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
      */
     void build() override;
 
+    virtual void presetup(double fraction) override;
     void rotate(double angle, const Vector3d& axis) const override;     ///< @see ElastoComponent::rotate
     void translate(const Vector3d& translation_vector) const override;  ///< @see ElastoComponent::translate
     double get_mass() const override;                                   ///< @see ElastoComponent::get_mass

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -132,6 +132,21 @@ void BladeElastoFEA::update_root_constraint() {
     link_root_mount->initialize(*body_root, *body_mount);
 }
 
+void BladeElastoFEA::presetup(double fraction) {
+    for (int ii = 0; ii < nodes.size(); ii++) {
+        BladeReferencePointElasto ref = discretized_points[ii];
+        for (int jj = 0; jj < ref.damping_coefficients.size(); jj++) {
+            ref.damping_coefficients[jj] = (1.0 - fraction) + ref.damping_coefficients[jj] * fraction;
+        }
+        auto node = std::dynamic_pointer_cast<NodeElastoChrono>(nodes[ii]);
+        node->set_properties(ref);
+    }
+    for (auto& element : elements) {
+        std::dynamic_pointer_cast<ElementElastoChrono>(element)->update_properties();
+    }
+    spdlog::debug("Presetup for blade at fraction {} (relaxing damping to target value gradually).", fraction);
+}
+
 void BladeElastoFEA::build() {
     reset_bodies();
 

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -570,6 +570,8 @@ ElementBladeElastoChrono::ElementBladeElastoChrono() {
     chobj->SetTaperedSection(blade_section);
 }
 
+void ElementElastoChrono::update_properties() {}
+
 void ElementBladeElastoChrono::set_nodes(std::shared_ptr<NodeElasto> node1, std::shared_ptr<NodeElasto> node2) {
     nodes.clear();
     nodes.push_back(node1);
@@ -587,6 +589,10 @@ void ElementBladeElastoChrono::set_prebend(const Quaternion& prebend) {
     // switch from IEC standard (Z along blade) to chrono element coordinate system (X along element)
     auto prebend_ch = chrono::ChQuaternion<double>(prebend.w(), prebend.z(), prebend.y(), prebend.x());
     chobj->SetNodeBreferenceRot(prebend_ch);
+}
+
+void ElementBladeElastoChrono::update_properties() {
+    chobj->GetTaperedSection()->ComputeAverageSectionParameters();
 }
 
 ElementBladeElastoChronoFPM::ElementBladeElastoChronoFPM() {
@@ -618,6 +624,10 @@ void ElementBladeElastoChronoFPM::set_prebend(const Quaternion& prebend) {
     // switch from IEC standard (Z along blade) to chrono element coordinate system (X along element)
     auto prebend_ch = chrono::ChQuaternion<double>(prebend.w(), prebend.z(), prebend.y(), prebend.x());
     chobj->SetNodeBreferenceRot(prebend_ch);
+}
+
+void ElementBladeElastoChronoFPM::update_properties() {
+    chobj->GetTaperedSection()->ComputeAverageSectionParameters();
 }
 
 ElementMooringElastoChrono::ElementMooringElastoChrono() {

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -17,6 +17,12 @@ void RotorElasto::assemble_this(SystemElasto& system) {
     system.add(*(body_hub.get()));
 }
 
+void RotorElasto::presetup(double fraction) {
+    for (auto& blade : blades) {
+        blade->presetup(fraction);
+    }
+}
+
 void RotorElasto::build() {
     // build blades
     for (auto& blade : blades) {
@@ -120,6 +126,10 @@ RotorNacelleAssemblyElasto::RotorNacelleAssemblyElasto() {
     // link between yaw bearing body and shaft body
     link_shaft_yaw_bearing = std::make_unique<LinkChrono>();
     link_shaft_yaw_bearing->set_constraints(true, true, true, true, true, true);
+}
+
+void RotorNacelleAssemblyElasto::presetup(double fraction) {
+    rotor->presetup(fraction);
 }
 
 void RotorNacelleAssemblyElasto::assemble_this(SystemElasto& system) {


### PR DESCRIPTION
Small PR to apply high damping and gradually relax it to target damping during presetup phase of simulation.
This can allow for easier startup in case statics prestep was not or could not be used.