### PR TITLE
elasto::ElementElasto::nodes exposed in pybinds

### DIFF
--- a/include/seahowl/elasto/entities_elasto.h
+++ b/include/seahowl/elasto/entities_elasto.h
@@ -169,6 +169,30 @@ class ElementElasto {
     virtual void evaluate_force_torque(double eta, Vector3d& force, Vector3d& torque) = 0;
 
     /**
+     * @brief Returns position of point within element.
+     *
+     * param[in] eta Normalized abscissa along element within range [-1, +1].
+     */
+    Vector3d get_position(double eta) {
+        auto position = Vector3d(0.0, 0.0, 0.0);
+        auto rotation = Quaternion(0.0, 0.0, 0.0, 0.0);
+        evaluate_position_rotation(eta, position, rotation);
+        return position;
+    };
+
+    /**
+     * @brief Returns rotation of point within element.
+     *
+     * param[in] eta Normalized abscissa along element within range [-1, +1].
+     */
+    Quaternion get_rotation(double eta) {
+        auto position = Vector3d(0.0, 0.0, 0.0);
+        auto rotation = Quaternion(0.0, 0.0, 0.0, 0.0);
+        evaluate_position_rotation(eta, position, rotation);
+        return rotation;
+    };
+
+    /**
      * @brief Returns force of point within element.
      *
      * param[in] eta Normalized abscissa along element within range [-1, +1].

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -50,6 +50,8 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("evaluate_force_torque", &seahowl::elasto::ElementElasto::evaluate_force_torque)
         .def("get_force", &seahowl::elasto::ElementElasto::get_force)
         .def("get_torque", &seahowl::elasto::ElementElasto::get_torque)
+        .def("get_position", &seahowl::elasto::ElementElasto::get_position)
+        .def("get_rotation", &seahowl::elasto::ElementElasto::get_rotation)
         .def("get_mass", &seahowl::elasto::ElementElasto::get_mass);
     py::class_<seahowl::elasto::ElementBladeElasto, std::shared_ptr<seahowl::elasto::ElementBladeElasto>,
                seahowl::elasto::ElementElasto>(m_elasto, "ElementBladeElasto")

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -42,8 +42,9 @@ void initialize_pyseahowl_elasto(py::module& m) {
     py::class_<seahowl::elasto::NodeElasto, std::shared_ptr<seahowl::elasto::NodeElasto>,
                seahowl::elasto::EntityLoadable>(m_elasto, "NodeElasto", pybind11::multiple_inheritance())
         .def("set_fixed", &seahowl::elasto::NodeElasto::set_fixed);
-    py::class_<seahowl::elasto::ElementElasto, std::shared_ptr<seahowl::elasto::ElementElasto>>(m_elasto,
-                                                                                                "ElementElasto")
+    py::class_<seahowl::elasto::ElementElasto, std::shared_ptr<seahowl::elasto::ElementElasto>>(
+        m_elasto, "ElementElasto", pybind11::multiple_inheritance())
+        .def_readonly("nodes", &seahowl::elasto::ElementElasto::nodes)
         .def("set_nodes", &seahowl::elasto::ElementElasto::set_nodes)
         .def("evaluate_position_rotation", &seahowl::elasto::ElementElasto::evaluate_position_rotation)
         .def("evaluate_force_torque", &seahowl::elasto::ElementElasto::evaluate_force_torque)


### PR DESCRIPTION
To access nodes of a ElementElasto instanced object, the nodes property is exposed in python bindings.
Moreover, the class entities_elasto has been completed with get_position and get_rotation made as get_force and get_torque