### PR TITLE
Add pitch and yaw actuator dynamics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,7 @@ source_group(core FILES ${SEAHOWL_CORE_SOURCES} ${SEAHOWL_CORE_HEADERS})
 
 # elasto
 set(SEAHOWL_ELASTO_SOURCES
+    src/elasto/entities_elasto.cpp
     src/elasto/component_elasto.cpp
     src/elasto/blade_elasto.cpp
     src/elasto/reference_point_elasto.cpp

--- a/data/IEA15MW/base/controller/DISCON.IN
+++ b/data/IEA15MW/base/controller/DISCON.IN
@@ -13,7 +13,7 @@
 2                   ! VS_ControlMode	- Generator torque control mode in above rated conditions (0- no torque control, 1- k*omega^2 with PI transitions, 2- WSE TSR Tracking, 3- Power-based TSR Tracking)}
 0                   ! VS_ConstPower  	- Do constant power torque control, where above rated torque varies, 0 for constant torque}
 1                   ! PC_ControlMode  - Blade pitch control mode {0: No pitch, fix to fine pitch, 1: active PI blade pitch control}
-0                   ! Y_ControlMode   - Yaw control mode {0: no yaw control, 1: yaw rate control, 2: yaw-by-IPC}
+1                   ! Y_ControlMode   - Yaw control mode {0: no yaw control, 1: yaw rate control, 2: yaw-by-IPC}
 1                   ! SS_Mode         - Setpoint Smoother mode {0: no setpoint smoothing, 1: introduce setpoint smoothing}
 0                   ! PRC_Mode        - Power reference tracking mode{0: use standard rotor speed set points, 1: use PRC rotor speed setpoints}
 2                   ! WE_Mode         - Wind speed estimator mode {0: One-second low pass filtered hub height wind speed, 1: Immersion and Invariance Estimator, 2: Extended Kalman Filter}

--- a/data/IEA15MW/base/controller/DISCON_yaw.IN
+++ b/data/IEA15MW/base/controller/DISCON_yaw.IN
@@ -13,7 +13,7 @@
 2                   ! VS_ControlMode	- Generator torque control mode in above rated conditions (0- no torque control, 1- k*omega^2 with PI transitions, 2- WSE TSR Tracking, 3- Power-based TSR Tracking)}
 0                   ! VS_ConstPower  	- Do constant power torque control, where above rated torque varies, 0 for constant torque}
 1                   ! PC_ControlMode  - Blade pitch control mode {0: No pitch, fix to fine pitch, 1: active PI blade pitch control}
-0                   ! Y_ControlMode   - Yaw control mode {0: no yaw control, 1: yaw rate control, 2: yaw-by-IPC}
+1                   ! Y_ControlMode   - Yaw control mode {0: no yaw control, 1: yaw rate control, 2: yaw-by-IPC}
 1                   ! SS_Mode         - Setpoint Smoother mode {0: no setpoint smoothing, 1: introduce setpoint smoothing}
 0                   ! PRC_Mode        - Power reference tracking mode{0: use standard rotor speed set points, 1: use PRC rotor speed setpoints}
 2                   ! WE_Mode         - Wind speed estimator mode {0: One-second low pass filtered hub height wind speed, 1: Immersion and Invariance Estimator, 2: Extended Kalman Filter}

--- a/data/IEA15MW/floating/turbine.json
+++ b/data/IEA15MW/floating/turbine.json
@@ -36,8 +36,9 @@
     ]
   },
   "rna": {
+    "file": "../base/rna.json",
     "initial_yaw": 0.0,
-    "file": "../base/rna.json"
+    "yaw_actuator_dynamics": true
   },
   "tower": {
     "discretization": {

--- a/data/IEA15MW/floating/turbine.json
+++ b/data/IEA15MW/floating/turbine.json
@@ -16,6 +16,7 @@
       "elasto": [49],
       "aero": [49]
     },
+    "pitch_actuator_dynamics": true,
     "blades": [
       {
         "file": "../base/blade.json",

--- a/data/IEA15MW/monopile/turbine.json
+++ b/data/IEA15MW/monopile/turbine.json
@@ -16,6 +16,7 @@
       "elasto": [49],
       "aero": [49]
     },
+    "pitch_actuator_dynamics": true,
     "blades": [
       {
         "file": "../base/blade.json",

--- a/data/IEA15MW/monopile/turbine.json
+++ b/data/IEA15MW/monopile/turbine.json
@@ -36,8 +36,9 @@
     ]
   },
   "rna": {
+    "file": "../base/rna.json",
     "initial_yaw": 0.0,
-    "file": "../base/rna.json"
+    "yaw_actuator_dynamics": false
   },
   "tower": {
     "discretization": {

--- a/data/IEA15MW/onshore/turbine.json
+++ b/data/IEA15MW/onshore/turbine.json
@@ -36,8 +36,9 @@
     ]
   },
   "rna": {
+    "file": "../base/rna.json",
     "initial_yaw": 0.0,
-    "file": "../base/rna.json"
+    "yaw_actuator_dynamics": true
   },
   "tower": {
     "discretization": {

--- a/data/IEA15MW/onshore/turbine.json
+++ b/data/IEA15MW/onshore/turbine.json
@@ -16,6 +16,7 @@
       "elasto": [49],
       "aero": [49]
     },
+    "pitch_actuator_dynamics": true,
     "blades": [
       {
         "file": "../base/blade.json",

--- a/data/IEA15MW/onshore/turbine.json
+++ b/data/IEA15MW/onshore/turbine.json
@@ -20,17 +20,17 @@
     "blades": [
       {
         "file": "../base/blade.json",
-        "initial_pitch": 0,
+        "initial_pitch": 0.0,
         "precone": -4.0
       },
       {
         "file": "../base/blade.json",
-        "initial_pitch": 0,
+        "initial_pitch": 0.0,
         "precone": -4.0
       },
       {
         "file": "../base/blade.json",
-        "initial_pitch": 0,
+        "initial_pitch": 0.0,
         "precone": -4.0
       }
     ]

--- a/data/IEA15MW/onshore/turbine_aerodyn.json
+++ b/data/IEA15MW/onshore/turbine_aerodyn.json
@@ -35,8 +35,9 @@
     ]
   },
   "rna": {
+    "file": "../base/rna.json",
     "initial_yaw": 0.0,
-    "file": "../base/rna.json"
+    "yaw_actuator_dynamics": true
   },
   "tower": {
     "discretization": {

--- a/data/IEA15MW/onshore/turbine_aerodyn.json
+++ b/data/IEA15MW/onshore/turbine_aerodyn.json
@@ -19,17 +19,17 @@
     "blades": [
       {
         "file": "../base/blade.json",
-        "initial_pitch": 0,
+        "initial_pitch": 0.0,
         "precone": -4.0
       },
       {
         "file": "../base/blade.json",
-        "initial_pitch": 0,
+        "initial_pitch": 0.0,
         "precone": -4.0
       },
       {
         "file": "../base/blade.json",
-        "initial_pitch": 0,
+        "initial_pitch": 0.0,
         "precone": -4.0
       }
     ]

--- a/data/IEA15MW/onshore/turbine_aerodyn.json
+++ b/data/IEA15MW/onshore/turbine_aerodyn.json
@@ -15,6 +15,7 @@
       "elasto": [49],
       "aero": [49]
     },
+    "pitch_actuator_dynamics": true,
     "blades": [
       {
         "file": "../base/blade.json",

--- a/data/IEA15MW/onshore/turbine_disk.json
+++ b/data/IEA15MW/onshore/turbine_disk.json
@@ -14,8 +14,9 @@
     }
   },
   "rna": {
+    "file": "../base/rna.json",
     "initial_yaw": 0.0,
-    "file": "../base/rna.json"
+    "yaw_actuator_dynamics": true
   },
   "tower": {
     "discretization": {

--- a/data/IEA15MW/onshore/turbine_rigid.json
+++ b/data/IEA15MW/onshore/turbine_rigid.json
@@ -33,8 +33,9 @@
     ]
   },
   "rna": {
+    "file": "../base/rna.json",
     "initial_yaw": 0.0,
-    "file": "../base/rna.json"
+    "yaw_actuator_dynamics": true
   },
   "tower": {
     "discretization": {

--- a/data/IEA15MW/onshore/turbine_rigid.json
+++ b/data/IEA15MW/onshore/turbine_rigid.json
@@ -13,6 +13,7 @@
       "elasto": [49],
       "aero": [49]
     },
+    "pitch_actuator_dynamics": true,
     "blades": [
       {
         "file": "../base/blade.json",

--- a/data/IEA15MW/onshore/turbine_rigid.json
+++ b/data/IEA15MW/onshore/turbine_rigid.json
@@ -17,17 +17,17 @@
     "blades": [
       {
         "file": "../base/blade.json",
-        "initial_pitch": 0,
+        "initial_pitch": 0.0,
         "precone": -4.0
       },
       {
         "file": "../base/blade.json",
-        "initial_pitch": 0,
+        "initial_pitch": 0.0,
         "precone": -4.0
       },
       {
         "file": "../base/blade.json",
-        "initial_pitch": 0,
+        "initial_pitch": 0.0,
         "precone": -4.0
       }
     ]

--- a/include/seahowl/elasto/blade_elasto.h
+++ b/include/seahowl/elasto/blade_elasto.h
@@ -23,7 +23,7 @@ class BladeElasto : public virtual ComponentElasto {
     /** @brief Actuator for pitch dynamics. */
     std::unique_ptr<ActuatorRotation> actuator_pitch;
     /** @brief Whether actuator dynamics (motor) is used for pitching. */
-    bool has_actuator_dynamics = true;
+    bool has_pitch_actuator_dynamics = true;
     /** @brief Link between blade and body (usually hub). */
     std::unique_ptr<Link> link_blade;
     /** @brief Initial pitch of the blade (in radians). */

--- a/include/seahowl/elasto/blade_elasto.h
+++ b/include/seahowl/elasto/blade_elasto.h
@@ -12,18 +12,10 @@ namespace elasto {
  */
 class BladeElasto : public virtual ComponentElasto {
   public:
-    /** @brief Body at the root of the blade. */
-    std::unique_ptr<BodyElastoChrono> body_root;
-    /** @brief Body for mounting point of blade (to link to other structures, e.g. hub). */
-    std::unique_ptr<BodyElastoChrono> body_mount;
     /** @brief Link between blade and pitch axis body. */
     std::unique_ptr<Link> link_root;
-    /** @brief Link between blade root and mounting point. */
-    std::unique_ptr<Link> link_root_mount;
     /** @brief Actuator for pitch dynamics. */
     std::unique_ptr<ActuatorRotation> actuator_pitch;
-    /** @brief Whether actuator dynamics (motor) is used for pitching. */
-    bool has_pitch_actuator_dynamics = true;
     /** @brief Link between blade and body (usually hub). */
     std::unique_ptr<Link> link_blade;
     /** @brief Initial pitch of the blade (in radians). */

--- a/include/seahowl/elasto/blade_elasto.h
+++ b/include/seahowl/elasto/blade_elasto.h
@@ -20,6 +20,10 @@ class BladeElasto : public virtual ComponentElasto {
     std::unique_ptr<Link> link_root;
     /** @brief Link between blade root and mounting point. */
     std::unique_ptr<Link> link_root_mount;
+    /** @brief Actuator for pitch dynamics. */
+    std::unique_ptr<ActuatorRotation> actuator_pitch;
+    /** @brief Whether actuator dynamics (motor) is used for pitching. */
+    bool has_actuator_dynamics = true;
     /** @brief Link between blade and body (usually hub). */
     std::unique_ptr<Link> link_blade;
     /** @brief Initial pitch of the blade (in radians). */
@@ -77,7 +81,7 @@ class BladeElasto : public virtual ComponentElasto {
 
     virtual void assemble_this(SystemElasto& system) override;
 
-    virtual void update_root_constraint() = 0;
+    void update_root_constraint();
 
     void reset_bodies();
 };
@@ -127,8 +131,6 @@ class BladeElastoFEA : public BladeElasto, public ComponentElastoFEA {
      * @brief Builds the blade with FPM Timoshenko elements (6x6 mass and stiffness matrices).
      */
     void build_elements_tapered_timoshenko_fpm();
-
-    virtual void update_root_constraint() override;
 };
 
 /**
@@ -163,8 +165,6 @@ class BladeElastoRigid : public BladeElasto {
     std::unique_ptr<BodyElastoChrono> body_cog;
 
     virtual void assemble_this(SystemElasto& system) override;
-
-    virtual void update_root_constraint() override;
 };
 
 }  // namespace elasto

--- a/include/seahowl/elasto/chrono_adapters.h
+++ b/include/seahowl/elasto/chrono_adapters.h
@@ -326,8 +326,9 @@ class ActuatorRotationChrono : public ActuatorRotation, public LinkChronoBase {
     std::shared_ptr<chrono::ChLinkMotorRotationAngle> chobj;
 
     ActuatorRotationChrono();
-    void set_timeseries(const std::vector<double>& time_array, const std::vector<double>& values_array) override;
-    double get_wanted_value(double time) const override;
+    void set_control_timeseries(const std::vector<double>& time_array,
+                                const std::vector<double>& values_array) override;
+    double get_control_value(double time) const override;
     void impose_value_constant(double value) override;
     void increment_value_constant(double value) override;
     double get_angle() const override;
@@ -338,7 +339,7 @@ class ActuatorRotationChrono : public ActuatorRotation, public LinkChronoBase {
     /** @brief Function piloting the actuator. */
     std::shared_ptr<chrono::ChFunction> chfunc;
 
-    void initialize_links();
+    void initialize_links() override;
 };
 
 /**

--- a/include/seahowl/elasto/chrono_adapters.h
+++ b/include/seahowl/elasto/chrono_adapters.h
@@ -197,8 +197,8 @@ class ElementElastoChrono : public virtual ElementElasto {
   public:
     std::shared_ptr<chrono::fea::ChElementBeam> chobj;
     virtual void set_nodes(std::shared_ptr<NodeElasto> node1, std::shared_ptr<NodeElasto> node2) override;
-    virtual void evaluate_position_rotation(double eta, Vector3d& position, Quaternion& rotation) override;
-    virtual void evaluate_force_torque(double eta, Vector3d& force, Vector3d& torque) override;
+    virtual void evaluate_position_rotation(double eta, Vector3d& position, Quaternion& rotation) const override;
+    virtual void evaluate_force_torque(double eta, Vector3d& force, Vector3d& torque) const override;
     virtual double get_mass() override;
     virtual void update_properties();
 };
@@ -320,19 +320,25 @@ class LinkMatrixStiffnessDampingChrono : public LinkMatrixStiffnessDamping {
     void set_damping_matrix(const Eigen::Matrix<double, 6, 6>& damping_matrix) override;
 };
 
-class ActuatorRotationChrono : public virtual ActuatorRotation {
+class ActuatorRotationChrono : public ActuatorRotation, public LinkChronoBase {
   public:
     /** @brief Pointer to underlying Chrono object. */
     std::shared_ptr<chrono::ChLinkMotorRotationAngle> chobj;
 
     ActuatorRotationChrono();
-    void initialize(const Entity& entity1, const Entity& entity2, const Vector3d& rotation_axis) override;
     void set_timeseries(const std::vector<double>& time_array, const std::vector<double>& values_array) override;
-    double get_value(double time) override;
+    double get_wanted_value(double time) const override;
+    void impose_value_constant(double value) override;
+    void increment_value_constant(double value) override;
+    double get_angle() const override;
+    void set_fixed_actuator(bool is_fixed) override;
+    bool is_fixed_actuator() const override;
 
   private:
     /** @brief Function piloting the actuator. */
     std::shared_ptr<chrono::ChFunction> chfunc;
+
+    void initialize_links();
 };
 
 /**

--- a/include/seahowl/elasto/chrono_adapters.h
+++ b/include/seahowl/elasto/chrono_adapters.h
@@ -328,6 +328,7 @@ class ActuatorRotationChrono : public virtual ActuatorRotation {
     ActuatorRotationChrono();
     void initialize(const Entity& entity1, const Entity& entity2, const Vector3d& rotation_axis) override;
     void set_timeseries(const std::vector<double>& time_array, const std::vector<double>& values_array) override;
+    double get_value(double time) override;
 
   private:
     /** @brief Function piloting the actuator. */

--- a/include/seahowl/elasto/chrono_adapters.h
+++ b/include/seahowl/elasto/chrono_adapters.h
@@ -31,11 +31,13 @@ class ChLinkBase;
 class ChLinkPointPoint;
 class ChLinkPointFrame;
 class ChLinkMateGeneric;
+class ChLinkMotorRotationAngle;
 class ChLinkTSDA;
 class ChLoadBodyBodyBushingGeneric;
 class ChSystem;
 class ChLoadLocal66;
 class ChLoadContainer;
+class ChFunction;
 namespace fea {
 class ChNodeFEAbase;
 class ChNodeFEAxyzrot;
@@ -274,7 +276,7 @@ class SpringLinearChrono : public SpringLinear {
 /**
  * @brief Chrono link class.
  */
-class LinkChrono : public Link, public LinkChronoBase {
+class LinkChrono : public virtual Link, public LinkChronoBase {
   public:
     /** @brief Pointer to underlying Chrono object. */
     std::shared_ptr<chrono::ChLinkMateGeneric> chobj;
@@ -318,6 +320,20 @@ class LinkMatrixStiffnessDampingChrono : public LinkMatrixStiffnessDamping {
     void set_damping_matrix(const Eigen::Matrix<double, 6, 6>& damping_matrix) override;
 };
 
+class ActuatorRotationChrono : public virtual ActuatorRotation {
+  public:
+    /** @brief Pointer to underlying Chrono object. */
+    std::shared_ptr<chrono::ChLinkMotorRotationAngle> chobj;
+
+    ActuatorRotationChrono();
+    void initialize(const Entity& entity1, const Entity& entity2, const Vector3d& rotation_axis) override;
+    void set_timeseries(const std::vector<double>& time_array, const std::vector<double>& values_array) override;
+
+  private:
+    /** @brief Function piloting the actuator. */
+    std::shared_ptr<chrono::ChFunction> chfunc;
+};
+
 /**
  * @brief Chrono elasto mesh class.
  */
@@ -355,6 +371,7 @@ class SystemElastoChrono : public SystemElasto {
     virtual void add(Link& link) override;
     virtual void add(LinkMatrixStiffnessDamping& link) override;
     virtual void add(SpringLinear& spring) override;
+    virtual void add(ActuatorRotation& actuator) override;
 };
 
 }  // namespace elasto

--- a/include/seahowl/elasto/entities_elasto.h
+++ b/include/seahowl/elasto/entities_elasto.h
@@ -453,6 +453,13 @@ class ActuatorRotation {
      * @param[in] values_array Values array (angles).
      */
     virtual void set_timeseries(const std::vector<double>& time_array, const std::vector<double>& values_array) = 0;
+
+    /**
+     * @brief Returns value for actuator at given time.
+     *
+     * @param[in] time Time value.
+     */
+    virtual double get_value(double time) = 0;
 };
 
 /**

--- a/include/seahowl/elasto/entities_elasto.h
+++ b/include/seahowl/elasto/entities_elasto.h
@@ -436,14 +436,15 @@ class ActuatorRotation : public virtual Entity {
      * @param[in] time_array Time array.
      * @param[in] values_array Values array (angles).
      */
-    virtual void set_timeseries(const std::vector<double>& time_array, const std::vector<double>& values_array) = 0;
+    virtual void set_control_timeseries(const std::vector<double>& time_array,
+                                        const std::vector<double>& values_array) = 0;
 
     /**
      * @brief Returns wanted value for actuator at given time.
      *
      * @param[in] time Time value.
      */
-    virtual double get_wanted_value(double time) const = 0;
+    virtual double get_control_value(double time) const = 0;
 
     /**
      * @brief Imposes a constant value.
@@ -480,6 +481,8 @@ class ActuatorRotation : public virtual Entity {
      * @brief Returns whether the actuator is fixed or not.
      */
     virtual bool is_fixed_actuator() const = 0;
+
+    virtual void initialize_links() = 0;
 
     void set_position(const Vector3d& position) override;
     Vector3d get_position() const override;

--- a/include/seahowl/elasto/entities_elasto.h
+++ b/include/seahowl/elasto/entities_elasto.h
@@ -207,7 +207,7 @@ class ElementElasto {
      * param[out] position Position to evaluate.
      * param[out] rotation Rotation to evaluate.
      */
-    virtual void evaluate_position_rotation(double eta, Vector3d& position, Quaternion& rotation) = 0;
+    virtual void evaluate_position_rotation(double eta, Vector3d& position, Quaternion& rotation) const = 0;
 
     /**
      * @brief Evaluates force and torque of point within element.
@@ -216,55 +216,35 @@ class ElementElasto {
      * param[out] force Force to evaluate.
      * param[out] torque Torque to evaluate.
      */
-    virtual void evaluate_force_torque(double eta, Vector3d& force, Vector3d& torque) = 0;
+    virtual void evaluate_force_torque(double eta, Vector3d& force, Vector3d& torque) const = 0;
 
     /**
      * @brief Returns position of point within element.
      *
      * param[in] eta Normalized abscissa along element within range [-1, +1].
      */
-    Vector3d get_position(double eta) {
-        auto position = Vector3d(0.0, 0.0, 0.0);
-        auto rotation = Quaternion(0.0, 0.0, 0.0, 0.0);
-        evaluate_position_rotation(eta, position, rotation);
-        return position;
-    };
+    Vector3d get_position(double eta) const;
 
     /**
      * @brief Returns rotation of point within element.
      *
      * param[in] eta Normalized abscissa along element within range [-1, +1].
      */
-    Quaternion get_rotation(double eta) {
-        auto position = Vector3d(0.0, 0.0, 0.0);
-        auto rotation = Quaternion(0.0, 0.0, 0.0, 0.0);
-        evaluate_position_rotation(eta, position, rotation);
-        return rotation;
-    };
+    Quaternion get_rotation(double eta) const;
 
     /**
      * @brief Returns force of point within element.
      *
      * param[in] eta Normalized abscissa along element within range [-1, +1].
      */
-    Vector3d get_force(double eta) {
-        auto force = Vector3d(0.0, 0.0, 0.0);
-        auto torque = Vector3d(0.0, 0.0, 0.0);
-        evaluate_force_torque(eta, force, torque);
-        return force;
-    };
+    Vector3d get_force(double eta) const;
 
     /**
      * @brief Returns force of point within element.
      *
      * param[in] eta Normalized abscissa along element within range [-1, +1].
      */
-    Vector3d get_torque(double eta) {
-        auto force = Vector3d(0.0, 0.0, 0.0);
-        auto torque = Vector3d(0.0, 0.0, 0.0);
-        evaluate_force_torque(eta, force, torque);
-        return torque;
-    };
+    Vector3d get_torque(double eta) const;
 
     /**
      * @brief Returns mass of elasto element.
@@ -434,17 +414,21 @@ class LinkMatrixStiffnessDamping {
 
 /**
  * @brief Actuator class for imposing rotation between two bodies.
+ *
+ * Rotation happens around the Z-axis of the controller body (body_controller).
+ * The axis can be changed by providing reference_rotation to the actuator.
+ * Reference rotation is expressed in the local coordinate system of controller body.
  */
-class ActuatorRotation {
+class ActuatorRotation : public virtual Entity {
   public:
-    /**
-     * @brief Initialization of actuator.
-     *
-     * @param[in] entity1 First entity (body) to link with actuator.
-     * @param[in] entity2 Second entity (body) to link with actuator.
-     * @param[in] rotation_axis Rotation axis of actuator, relative to body2 coordinate system.
-     */
-    virtual void initialize(const Entity& entity1, const Entity& entity2, const Vector3d& rotation_axis) = 0;
+    /** @brief Body of the controller (manages motor). */
+    std::unique_ptr<BodyElasto> body_controller;
+    /** @brief Body of the worker (rotating around controller body). */
+    std::unique_ptr<BodyElasto> body_worker;
+    /** @brief Reference rotation to change axis from local the Z-axis of controller body. */
+    Quaternion reference_rotation;
+    /** @brief Link for fixing the actuator in space. */
+    std::unique_ptr<Link> link;
 
     /**
      * @brief Sets timeseries for actuator.
@@ -455,11 +439,53 @@ class ActuatorRotation {
     virtual void set_timeseries(const std::vector<double>& time_array, const std::vector<double>& values_array) = 0;
 
     /**
-     * @brief Returns value for actuator at given time.
+     * @brief Returns wanted value for actuator at given time.
      *
      * @param[in] time Time value.
      */
-    virtual double get_value(double time) = 0;
+    virtual double get_wanted_value(double time) const = 0;
+
+    /**
+     * @brief Imposes a constant value.
+     *
+     * @param[in] value Value to impose.
+     */
+    virtual void impose_value_constant(double value) = 0;
+
+    /**
+     * @brief Increments value to current angle and make it constant.
+     *
+     * @param[in] value Value to impose.
+     */
+    virtual void increment_value_constant(double value) = 0;
+
+    /**
+     * @brief Returns current angle between the 2 actuator bodies.
+     */
+    virtual double get_angle() const = 0;
+
+    /**
+     * @brief Returns the rotation axis of the actuator.
+     */
+    Vector3d get_rotation_axis() const;
+
+    /**
+     * @brief Sets whether the actuator if fixed or not (keep it false for actuator dynamics).
+     *
+     * @param[in] is_fixed Whether the actuator is fixed or not.
+     */
+    virtual void set_fixed_actuator(bool is_fixed) = 0;
+
+    /**
+     * @brief Returns whether the actuator is fixed or not.
+     */
+    virtual bool is_fixed_actuator() const = 0;
+
+    void set_position(const Vector3d& position) override;
+    Vector3d get_position() const override;
+    void set_rotation(const Quaternion& rotation);
+    Quaternion get_rotation() const override;
+    Vector3d get_rpy_angles() const override;
 };
 
 /**

--- a/include/seahowl/elasto/entities_elasto.h
+++ b/include/seahowl/elasto/entities_elasto.h
@@ -433,6 +433,29 @@ class LinkMatrixStiffnessDamping {
 };
 
 /**
+ * @brief Actuator class for imposing rotation between two bodies.
+ */
+class ActuatorRotation {
+  public:
+    /**
+     * @brief Initialization of actuator.
+     *
+     * @param[in] entity1 First entity (body) to link with actuator.
+     * @param[in] entity2 Second entity (body) to link with actuator.
+     * @param[in] rotation_axis Rotation axis of actuator, relative to body2 coordinate system.
+     */
+    virtual void initialize(const Entity& entity1, const Entity& entity2, const Vector3d& rotation_axis) = 0;
+
+    /**
+     * @brief Sets timeseries for actuator.
+     *
+     * @param[in] time_array Time array.
+     * @param[in] values_array Values array (angles).
+     */
+    virtual void set_timeseries(const std::vector<double>& time_array, const std::vector<double>& values_array) = 0;
+};
+
+/**
  * @brief Elasto mesh base class.
  */
 class MeshElasto {

--- a/include/seahowl/elasto/rotor_elasto.h
+++ b/include/seahowl/elasto/rotor_elasto.h
@@ -137,10 +137,8 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
     std::unique_ptr<seahowl::elasto::BodyElasto> body_shaft;
     /** @brief Nacelle rigid body. */
     std::unique_ptr<seahowl::elasto::BodyElasto> body_nacelle;
-    /** @brief Yaw bearing rigid body. */
-    std::unique_ptr<seahowl::elasto::BodyElasto> body_yaw_bearing;
-    /** @brief Body for mounting point of RNA (to link to other structures, e.g. tower). */
-    std::unique_ptr<seahowl::elasto::BodyElasto> body_mount;
+    /** @brief Actuator for yaw dynamics. */
+    std::unique_ptr<ActuatorRotation> actuator_yaw;
 
     // links
     //
@@ -150,10 +148,8 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
     std::unique_ptr<Link> link_shaft_nacelle;
     /** @brief Link between shaft and yaw bearing (fixed). */
     std::unique_ptr<Link> link_shaft_yaw_bearing;
-    /** @brief Link between yaw bearing and mounting point (fixed). */
-    std::unique_ptr<Link> link_yaw_bearing_mount;
-    /** @brief Link between towertop (if any) and mounting point (fixed). */
-    std::unique_ptr<Link> link_towertop_mount;
+    /** @brief Link between RNA and mounting point (fixed). */
+    std::unique_ptr<Link> link_rna;
     ///@}
 
     // reference properties
@@ -226,13 +222,6 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
      * @brief Returns current of the RNA.
      */
     double get_yaw() const;
-
-    /**
-     * @brief Sets whether the RNA is considered fixed or free to yaw (without control).
-     *
-     * @param is_fixed Whether RNA is fixed in yaw or not.
-     */
-    void set_fixed_yaw(bool is_fixed);
 
     /**
      * @brief Attaches RNA to body on mounting point.

--- a/include/seahowl/elasto/system_elasto.h
+++ b/include/seahowl/elasto/system_elasto.h
@@ -113,6 +113,13 @@ class SystemElasto {
     virtual void add(SpringLinear& spring) = 0;
 
     /**
+     * @brief Adds actuator to system.
+     *
+     * @param[in] actuator Actuator to add to system.
+     */
+    virtual void add(ActuatorRotation& actuator) = 0;
+
+    /**
      * @brief Adds component to system.
      *
      * @param[in] component Component to add to system.

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -84,6 +84,10 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("initialize", &seahowl::elasto::LinkMatrixStiffnessDamping::initialize)
         .def("set_stiffness_matrix", &seahowl::elasto::LinkMatrixStiffnessDamping::set_stiffness_matrix)
         .def("set_damping_matrix", &seahowl::elasto::LinkMatrixStiffnessDamping::set_damping_matrix);
+    py::class_<seahowl::elasto::ActuatorRotation, std::shared_ptr<seahowl::elasto::ActuatorRotation>>(
+        m_elasto, "ActuatorRotation")
+        .def("initialize", &seahowl::elasto::ActuatorRotation::initialize)
+        .def("set_timeseries", &seahowl::elasto::ActuatorRotation::set_timeseries);
     py::class_<seahowl::elasto::MeshElasto, std::shared_ptr<seahowl::elasto::MeshElasto>>(m_elasto, "MeshElasto");
     py::class_<seahowl::elasto::SystemElasto, std::shared_ptr<seahowl::elasto::SystemElasto>>(m_elasto, "SystemElasto")
         .def("step", &seahowl::elasto::SystemElasto::step)
@@ -102,6 +106,8 @@ void initialize_pyseahowl_elasto(py::module& m) {
              static_cast<void (seahowl::elasto::SystemElasto::*)(seahowl::elasto::LinkMatrixStiffnessDamping & link)>(
                  &seahowl::elasto::SystemElasto::add))
         .def("add", static_cast<void (seahowl::elasto::SystemElasto::*)(seahowl::elasto::SpringLinear & spring)>(
+                        &seahowl::elasto::SystemElasto::add))
+        .def("add", static_cast<void (seahowl::elasto::SystemElasto::*)(seahowl::elasto::ActuatorRotation & spring)>(
                         &seahowl::elasto::SystemElasto::add))
         .def("add", static_cast<void (seahowl::elasto::SystemElasto::*)(
                         std::shared_ptr<seahowl::elasto::TurbineElasto> turbine)>(&seahowl::elasto::SystemElasto::add))
@@ -138,9 +144,11 @@ void initialize_pyseahowl_elasto(py::module& m) {
     py::class_<seahowl::elasto::LinkChrono, std::shared_ptr<seahowl::elasto::LinkChrono>, seahowl::elasto::Link>(
         m_elasto, "LinkChrono")
         .def(py::init<>());
-
     py::class_<seahowl::elasto::SpringLinearChrono, std::shared_ptr<seahowl::elasto::SpringLinearChrono>,
                seahowl::elasto::SpringLinear>(m_elasto, "SpringLinearChrono")
+        .def(py::init<>());
+    py::class_<seahowl::elasto::ActuatorRotationChrono, std::shared_ptr<seahowl::elasto::ActuatorRotationChrono>,
+               seahowl::elasto::ActuatorRotation>(m_elasto, "ActuatorRotationChrono")
         .def(py::init<>());
     py::class_<seahowl::elasto::LinkMatrixStiffnessDampingChrono,
                std::shared_ptr<seahowl::elasto::LinkMatrixStiffnessDampingChrono>,

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -86,9 +86,12 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("set_damping_matrix", &seahowl::elasto::LinkMatrixStiffnessDamping::set_damping_matrix);
     py::class_<seahowl::elasto::ActuatorRotation, std::shared_ptr<seahowl::elasto::ActuatorRotation>>(
         m_elasto, "ActuatorRotation")
-        .def("initialize", &seahowl::elasto::ActuatorRotation::initialize)
         .def("set_timeseries", &seahowl::elasto::ActuatorRotation::set_timeseries)
-        .def("get_value", &seahowl::elasto::ActuatorRotation::get_value);
+        .def("get_wanted_value", &seahowl::elasto::ActuatorRotation::get_wanted_value)
+        .def("impose_value_constant", &seahowl::elasto::ActuatorRotation::impose_value_constant)
+        .def("increment_value_constant", &seahowl::elasto::ActuatorRotation::increment_value_constant)
+        .def("set_fixed_actuator", &seahowl::elasto::ActuatorRotation::set_fixed_actuator)
+        .def("is_fixed_actuator", &seahowl::elasto::ActuatorRotation::is_fixed_actuator);
     py::class_<seahowl::elasto::MeshElasto, std::shared_ptr<seahowl::elasto::MeshElasto>>(m_elasto, "MeshElasto");
     py::class_<seahowl::elasto::SystemElasto, std::shared_ptr<seahowl::elasto::SystemElasto>>(m_elasto, "SystemElasto")
         .def("step", &seahowl::elasto::SystemElasto::step)
@@ -223,6 +226,8 @@ void initialize_pyseahowl_elasto(py::module& m) {
                seahowl::elasto::ComponentElasto>(m_elasto, "BladeElasto")
         .def_readonly("azimuth0", &seahowl::elasto::BladeElasto::azimuth0)
         .def_readonly("precone", &seahowl::elasto::BladeElasto::precone)
+        .def_property_readonly("actuator_pitch",
+                               [](seahowl::elasto::BladeElasto& blade) { return blade.actuator_pitch.get(); })
         .def_readwrite("reference_points", &seahowl::elasto::BladeElasto::reference_points)
         .def_readwrite("discretization_fractions", &seahowl::elasto::BladeElasto::discretization_fractions)
         .def("apply_pitch_increment", &seahowl::elasto::BladeElasto::apply_pitch_increment)

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -86,8 +86,13 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("set_damping_matrix", &seahowl::elasto::LinkMatrixStiffnessDamping::set_damping_matrix);
     py::class_<seahowl::elasto::ActuatorRotation, std::shared_ptr<seahowl::elasto::ActuatorRotation>>(
         m_elasto, "ActuatorRotation")
-        .def("set_timeseries", &seahowl::elasto::ActuatorRotation::set_timeseries)
-        .def("get_wanted_value", &seahowl::elasto::ActuatorRotation::get_wanted_value)
+        .def_property_readonly(
+            "body_controller",
+            [](seahowl::elasto::ActuatorRotation& actuator) { return actuator.body_controller.get(); })
+        .def_property_readonly("body_worker",
+                               [](seahowl::elasto::ActuatorRotation& actuator) { return actuator.body_worker.get(); })
+        .def("set_control_timeseries", &seahowl::elasto::ActuatorRotation::set_control_timeseries)
+        .def("get_control_value", &seahowl::elasto::ActuatorRotation::get_control_value)
         .def("impose_value_constant", &seahowl::elasto::ActuatorRotation::impose_value_constant)
         .def("increment_value_constant", &seahowl::elasto::ActuatorRotation::increment_value_constant)
         .def("set_fixed_actuator", &seahowl::elasto::ActuatorRotation::set_fixed_actuator)
@@ -264,7 +269,6 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("get_azimuth", &seahowl::elasto::RotorNacelleAssemblyElasto::get_azimuth)
         .def("apply_yaw_increment", &seahowl::elasto::RotorNacelleAssemblyElasto::apply_yaw_increment)
         .def("get_yaw", &seahowl::elasto::RotorNacelleAssemblyElasto::get_yaw)
-        .def("set_fixed_yaw", &seahowl::elasto::RotorNacelleAssemblyElasto::set_fixed_yaw)
         .def("attach_rna_to_body", &seahowl::elasto::RotorNacelleAssemblyElasto::attach_rna_to_body)
         .def("attach_rna_to_node", &seahowl::elasto::RotorNacelleAssemblyElasto::attach_rna_to_node)
         .def_property_readonly(
@@ -277,11 +281,7 @@ void initialize_pyseahowl_elasto(py::module& m) {
             "body_nacelle", [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.body_nacelle.get(); },
             py::return_value_policy::reference_internal)
         .def_property_readonly(
-            "body_yaw_bearing",
-            [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.body_yaw_bearing.get(); },
-            py::return_value_policy::reference_internal)
-        .def_property_readonly(
-            "body_mount", [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.body_mount.get(); },
+            "actuator_yaw", [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.actuator_yaw.get(); },
             py::return_value_policy::reference_internal)
         .def_property_readonly(
             "link_shaft_hub", [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_shaft_hub.get(); },
@@ -295,12 +295,7 @@ void initialize_pyseahowl_elasto(py::module& m) {
             [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_shaft_yaw_bearing.get(); },
             py::return_value_policy::reference_internal)
         .def_property_readonly(
-            "link_towertop_mount",
-            [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_towertop_mount.get(); },
-            py::return_value_policy::reference_internal)
-        .def_property_readonly(
-            "link_yaw_bearing_mount",
-            [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_yaw_bearing_mount.get(); },
+            "link_rna", [](seahowl::elasto::RotorNacelleAssemblyElasto& rna) { return rna.link_rna.get(); },
             py::return_value_policy::reference_internal);
 
     // elasto/tower_elasto.h

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -87,7 +87,8 @@ void initialize_pyseahowl_elasto(py::module& m) {
     py::class_<seahowl::elasto::ActuatorRotation, std::shared_ptr<seahowl::elasto::ActuatorRotation>>(
         m_elasto, "ActuatorRotation")
         .def("initialize", &seahowl::elasto::ActuatorRotation::initialize)
-        .def("set_timeseries", &seahowl::elasto::ActuatorRotation::set_timeseries);
+        .def("set_timeseries", &seahowl::elasto::ActuatorRotation::set_timeseries)
+        .def("get_value", &seahowl::elasto::ActuatorRotation::get_value);
     py::class_<seahowl::elasto::MeshElasto, std::shared_ptr<seahowl::elasto::MeshElasto>>(m_elasto, "MeshElasto");
     py::class_<seahowl::elasto::SystemElasto, std::shared_ptr<seahowl::elasto::SystemElasto>>(m_elasto, "SystemElasto")
         .def("step", &seahowl::elasto::SystemElasto::step)

--- a/src/core/blade.cpp
+++ b/src/core/blade.cpp
@@ -100,12 +100,13 @@ void Blade::update_positions_aero() {
     aero.pitch = elasto.get_pitch();
 
     // update blade body root required by AeroDyn coupling
-    aero.body_root->set_rotation(elasto.body_root->get_rotation());
-    aero.body_root->set_position(elasto.body_root->get_position());
-    aero.body_root->set_velocity(elasto.body_root->get_velocity());
-    aero.body_root->set_rotational_velocity(elasto.body_root->get_rotational_velocity());
-    aero.body_root->set_acceleration(elasto.body_root->get_acceleration());
-    aero.body_root->set_rotational_acceleration(elasto.body_root->get_rotational_acceleration());
+    auto& elasto_root = *elasto.actuator_pitch->body_worker;
+    aero.body_root->set_rotation(elasto_root.get_rotation());
+    aero.body_root->set_position(elasto_root.get_position());
+    aero.body_root->set_velocity(elasto_root.get_velocity());
+    aero.body_root->set_rotational_velocity(elasto_root.get_rotational_velocity());
+    aero.body_root->set_acceleration(elasto_root.get_acceleration());
+    aero.body_root->set_rotational_acceleration(elasto_root.get_rotational_acceleration());
 }
 
 void Blade::update_loads_elasto() {

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -49,13 +49,28 @@ void Turbine::apply_control(double time, double dt) {
             // individual pitch only works with rotors from 1 to 3 blades
             for (int idx_blade = 0; idx_blade < rna.blades.size(); idx_blade++) {
                 auto& blade = *rna.blades[idx_blade];
-                auto blade_pitch_increment = controller->get_pitch_blade(idx_blade) - blade.elasto.get_pitch();
-                blade.apply_pitch_increment(blade_pitch_increment);
+                if (blade.elasto.has_actuator_dynamics) {
+                    std::vector<double> time_array{time, time + dt};
+                    std::vector<double> angle_array{blade.elasto.get_pitch(), controller->get_pitch_blade(idx_blade)};
+                    blade.elasto.actuator_pitch->set_timeseries(time_array, angle_array);
+                } else {
+                    auto blade_pitch_increment = controller->get_pitch_blade(idx_blade) - blade.elasto.get_pitch();
+                    blade.apply_pitch_increment(blade_pitch_increment);
+                }
             }
         } else {
             // collective pitch for more than 3 blades or 0 blade (e.g. actuator disk)
-            auto collective_pitch_increment = controller->get_collective_pitch() - rna.elasto.rotor->pitch_collective;
-            rna.elasto.rotor->apply_collective_pitch_increment(collective_pitch_increment);
+            for (auto& blade : rna.blades) {
+                if (blade->elasto.has_actuator_dynamics) {
+                    std::vector<double> time_array{time, time + dt};
+                    std::vector<double> angle_array{blade->elasto.get_pitch(), controller->get_collective_pitch()};
+                    blade->elasto.actuator_pitch->set_timeseries(time_array, angle_array);
+                } else {
+                    auto collective_pitch_increment =
+                        controller->get_collective_pitch() - rna.elasto.rotor->pitch_collective;
+                    rna.elasto.rotor->apply_collective_pitch_increment(collective_pitch_increment);
+                }
+            }
         }
         // store collective pitch value from controller for information purposes
         // (even if pitch was applied individually to blades)

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -55,7 +55,7 @@ void Turbine::apply_control(double time, double dt) {
                 } else {
                     std::vector<double> time_array{time, time + dt};
                     std::vector<double> angle_array{blade.elasto.get_pitch(), controller->get_pitch_blade(idx_blade)};
-                    blade.elasto.actuator_pitch->set_timeseries(time_array, angle_array);
+                    blade.elasto.actuator_pitch->set_control_timeseries(time_array, angle_array);
                 }
             }
         } else {
@@ -68,7 +68,7 @@ void Turbine::apply_control(double time, double dt) {
                 } else {
                     std::vector<double> time_array{time, time + dt};
                     std::vector<double> angle_array{blade->elasto.get_pitch(), controller->get_collective_pitch()};
-                    blade->elasto.actuator_pitch->set_timeseries(time_array, angle_array);
+                    blade->elasto.actuator_pitch->set_control_timeseries(time_array, angle_array);
                 }
             }
         }
@@ -81,8 +81,14 @@ void Turbine::apply_control(double time, double dt) {
     if (controller->has_yaw_control) {
         auto yaw_rate = controller->get_yaw_rate();
         auto yaw_increment = yaw_rate * dt;
-        rna.elasto.apply_yaw_increment(yaw_increment);
-        rna.update_positions_aero();
+        if (rna.elasto.actuator_yaw->is_fixed_actuator()) {
+            rna.elasto.apply_yaw_increment(yaw_increment);
+            rna.update_positions_aero();
+        } else {
+            std::vector<double> time_array{time, time + dt};
+            std::vector<double> angle_array{rna.elasto.get_yaw() + yaw_increment, rna.elasto.get_yaw() + yaw_increment};
+            rna.elasto.actuator_yaw->set_control_timeseries(time_array, angle_array);
+        }
     }
 }
 

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -49,7 +49,7 @@ void Turbine::apply_control(double time, double dt) {
             // individual pitch only works with rotors from 1 to 3 blades
             for (int idx_blade = 0; idx_blade < rna.blades.size(); idx_blade++) {
                 auto& blade = *rna.blades[idx_blade];
-                if (blade.elasto.has_actuator_dynamics) {
+                if (blade.elasto.has_pitch_actuator_dynamics) {
                     std::vector<double> time_array{time, time + dt};
                     std::vector<double> angle_array{blade.elasto.get_pitch(), controller->get_pitch_blade(idx_blade)};
                     blade.elasto.actuator_pitch->set_timeseries(time_array, angle_array);
@@ -61,7 +61,7 @@ void Turbine::apply_control(double time, double dt) {
         } else {
             // collective pitch for more than 3 blades or 0 blade (e.g. actuator disk)
             for (auto& blade : rna.blades) {
-                if (blade->elasto.has_actuator_dynamics) {
+                if (blade->elasto.has_pitch_actuator_dynamics) {
                     std::vector<double> time_array{time, time + dt};
                     std::vector<double> angle_array{blade->elasto.get_pitch(), controller->get_collective_pitch()};
                     blade->elasto.actuator_pitch->set_timeseries(time_array, angle_array);

--- a/src/core/turbine.cpp
+++ b/src/core/turbine.cpp
@@ -49,26 +49,26 @@ void Turbine::apply_control(double time, double dt) {
             // individual pitch only works with rotors from 1 to 3 blades
             for (int idx_blade = 0; idx_blade < rna.blades.size(); idx_blade++) {
                 auto& blade = *rna.blades[idx_blade];
-                if (blade.elasto.has_pitch_actuator_dynamics) {
+                if (blade.elasto.actuator_pitch->is_fixed_actuator()) {
+                    auto blade_pitch_increment = controller->get_pitch_blade(idx_blade) - blade.elasto.get_pitch();
+                    blade.apply_pitch_increment(blade_pitch_increment);
+                } else {
                     std::vector<double> time_array{time, time + dt};
                     std::vector<double> angle_array{blade.elasto.get_pitch(), controller->get_pitch_blade(idx_blade)};
                     blade.elasto.actuator_pitch->set_timeseries(time_array, angle_array);
-                } else {
-                    auto blade_pitch_increment = controller->get_pitch_blade(idx_blade) - blade.elasto.get_pitch();
-                    blade.apply_pitch_increment(blade_pitch_increment);
                 }
             }
         } else {
             // collective pitch for more than 3 blades or 0 blade (e.g. actuator disk)
             for (auto& blade : rna.blades) {
-                if (blade->elasto.has_pitch_actuator_dynamics) {
-                    std::vector<double> time_array{time, time + dt};
-                    std::vector<double> angle_array{blade->elasto.get_pitch(), controller->get_collective_pitch()};
-                    blade->elasto.actuator_pitch->set_timeseries(time_array, angle_array);
-                } else {
+                if (blade->elasto.actuator_pitch->is_fixed_actuator()) {
                     auto collective_pitch_increment =
                         controller->get_collective_pitch() - rna.elasto.rotor->pitch_collective;
                     rna.elasto.rotor->apply_collective_pitch_increment(collective_pitch_increment);
+                } else {
+                    std::vector<double> time_array{time, time + dt};
+                    std::vector<double> angle_array{blade->elasto.get_pitch(), controller->get_collective_pitch()};
+                    blade->elasto.actuator_pitch->set_timeseries(time_array, angle_array);
                 }
             }
         }

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -10,16 +10,11 @@
 using namespace seahowl::elasto;
 
 BladeElasto::BladeElasto() {
-    // body mount
-    body_mount = std::make_unique<BodyElastoChrono>();
-    // body root
-    body_root = std::make_unique<BodyElastoChrono>();
     // links
     link_root = std::make_unique<LinkChrono>();
     link_root->set_constraints(true, true, true, true, true, true);
-    link_root_mount = std::make_unique<LinkChrono>();
-    link_root_mount->set_constraints(true, true, true, true, true, true);
     actuator_pitch = std::make_unique<ActuatorRotationChrono>();
+    actuator_pitch->reference_rotation = Quaternion(AngleAxisd(PI, Vector3d(1.0, 0.0, 0.0)));
     link_blade = std::make_unique<LinkChrono>();
     link_blade->set_constraints(true, true, true, true, true, true);
     //
@@ -29,100 +24,59 @@ BladeElasto::BladeElasto() {
 
 void BladeElasto::apply_pitch_increment(double pitch_increment) {
     // apply pitch from root node direction and position
-    auto root_dir = body_root->get_rotation() * Vector3d(0.0, 0.0, 1.0);
-    auto root_pos = body_root->get_position();
+    auto root_dir = actuator_pitch->body_worker->get_rotation() * Vector3d(0.0, 0.0, 1.0);
+    auto root_pos = actuator_pitch->body_worker->get_position();
     translate(-root_pos);
     rotate(-pitch_increment, root_dir);
-    body_mount->rotate(pitch_increment, root_dir);  // rotate mounting point back
-    link_root_mount->initialize(*body_root, *body_mount);
+    actuator_pitch->rotate(pitch_increment, root_dir);  // rotate actuator back
     translate(root_pos);
 
-    // update actuator pitch timeseries in case it is used
-    if (has_pitch_actuator_dynamics) {
-        if (is_assembled) {
-            spdlog::warn(
-                "Blade pitch has been incremented instantaneously by {} degrees, resetting dynamic pitch actuator to "
-                "current pitch value ({} degrees) as a constant over time.",
-                pitch_increment * 180 / seahowl::PI, get_pitch() * 180 / seahowl::PI);
-        }
-        actuator_pitch->set_timeseries(std::vector<double>{0.0, 0.0}, std::vector<double>{get_pitch(), get_pitch()});
-    }
+    actuator_pitch->increment_value_constant(pitch_increment);
 }
 
 double BladeElasto::get_pitch() const {
-    // get angle between quaternions
-    auto qq = (body_root->get_rotation().conjugate() * body_mount->get_rotation()).normalized();
-    double angle0 = 2 * std::atan2(qq.vec().z(), qq.w());
-    // get angle between 0 and 2pi
-    double angle1 = fmod(angle0, 2 * PI);
-    return angle1;
+    return actuator_pitch->get_angle();
 }
 
 void BladeElasto::attach_blade_to_body(const BodyElasto& body) {
     is_mounted = true;
-    link_blade->initialize(*body_mount, body);
+    link_blade->initialize(*actuator_pitch->body_controller, body);
 }
 
 void BladeElasto::assemble_this(SystemElasto& system) {
-    system.add(*(body_root.get()));
-    system.add(*(link_root.get()));
-    system.add(*(body_mount.get()));
-    if (has_pitch_actuator_dynamics) {
-        system.add(*(actuator_pitch.get()));
-    } else {
-        system.add(*(link_root_mount));
-    }
+    system.add(*link_root);
+    system.add(*actuator_pitch);
     if (is_mounted) {
-        system.add(*(link_blade.get()));
+        system.add(*link_blade);
     }
 }
 
 void BladeElasto::rotate(double angle, const Vector3d& axis) const {
     // blade root
-    body_root->rotate(angle, axis);
-    body_mount->rotate(angle, axis);
+    actuator_pitch->rotate(angle, axis);
 }
 
 void BladeElasto::translate(const Vector3d& translation_vector) const {
     // blade root
-    body_root->translate(translation_vector);
-    body_mount->translate(translation_vector);
+    actuator_pitch->translate(translation_vector);
 }
 
 double BladeElasto::get_mass() const {
-    // adding body_root for consistency even if mass is supposed to be zero.
-    return body_root->get_mass() + body_mount->get_mass();
+    // adding actuator mass for consistency even if mass is supposed to be zero.
+    return actuator_pitch->body_worker->get_mass() + actuator_pitch->body_worker->get_mass();
 }
 
-void BladeElasto::reset_bodies() {
-    // body mount
-    body_mount->set_position(Vector3d(0.0, 0.0, 0.0));
-    body_mount->set_rotation(Quaternion(1.0, 0.0, 0.0, 0.0));
-    body_mount->set_mass(0.0);
-    body_mount->set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
-    // body root
-    body_root->set_position(Vector3d(0.0, 0.0, 0.0));
-    body_root->set_rotation(Quaternion(1.0, 0.0, 0.0, 0.0));
-    body_root->set_mass(0.0);
-    body_root->set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
-}
+void BladeElasto::reset_bodies() {}
 
 seahowl::Vector3d BladeElasto::get_blade_root_moment() const {
-    return link_root->get_reaction_torque() + body_root->get_torque(true);
+    return link_root->get_reaction_torque() + actuator_pitch->body_worker->get_torque(true);
 }
 
 seahowl::Vector3d BladeElasto::get_blade_root_force() const {
-    return link_root->get_reaction_force() + body_root->get_force(true);
+    return link_root->get_reaction_force() + actuator_pitch->body_worker->get_force(true);
 }
 
-void BladeElasto::update_root_constraint() {
-    // attach COG body to root body
-    link_root_mount->initialize(*body_root, *body_mount);
-    // attach root body to mounting point
-    actuator_pitch->initialize(*body_root, *body_mount, Vector3d(-1.0, 0.0, 0.0));
-    // set initial pitch
-    actuator_pitch->set_timeseries(std::vector<double>{0.0, 0.0}, std::vector<double>{get_pitch(), get_pitch()});
-}
+void BladeElasto::update_root_constraint() {}
 
 BladeElastoFEA::BladeElastoFEA() {}
 
@@ -221,7 +175,7 @@ void BladeElastoFEA::build() {
     }
 
     // attach node to root body
-    link_root->initialize(*nodes[0], *body_root);
+    link_root->initialize(*nodes[0], *actuator_pitch->body_worker);
 
     // apply initial pitch
     apply_pitch_increment(pitch0);
@@ -321,10 +275,10 @@ void BladeElastoRigid::build() {
     body_cog->set_position(Vector3d(0., 0., z_pos));
     body_cog->set_mass(mass_total);
     body_cog->set_inertia_diagonal(Vector3d(0., 0., 0.));
-    body_root->set_inertia_diagonal(Vector3d(inertia_total, inertia_total, 0.0));
+    actuator_pitch->body_worker->set_inertia_diagonal(Vector3d(inertia_total, inertia_total, 0.0));
 
     // attach COG body to root body
-    link_root->initialize(*body_cog, *body_root);
+    link_root->initialize(*body_cog, *actuator_pitch->body_worker);
 
     // apply initial pitch
     apply_pitch_increment(pitch0);
@@ -333,7 +287,7 @@ void BladeElastoRigid::build() {
 
 void BladeElastoRigid::assemble_this(SystemElasto& system) {
     BladeElasto::assemble_this(system);
-    system.add(*(body_cog.get()));
+    system.add(*body_cog);
 }
 
 void BladeElastoRigid::rotate(double angle, const Vector3d& axis) const {
@@ -360,8 +314,10 @@ seahowl::EntityDynamicEigen BladeElastoRigid::get_entity_along_blade(double eta,
     // relative position along z axis of blade
     auto z_position = (0.5 * fabs(eta + 1.0)) * length;
 
+    auto& body_root = *actuator_pitch->body_worker;
+
     // position
-    Vector3d position = body_root->get_position() + body_root->get_rotation() * Vector3d(0.0, 0.0, z_position);
+    Vector3d position = body_root.get_position() + body_root.get_rotation() * Vector3d(0.0, 0.0, z_position);
     entity.set_position(position);
 
     // get structural twist
@@ -369,30 +325,31 @@ seahowl::EntityDynamicEigen BladeElastoRigid::get_entity_along_blade(double eta,
     auto twist = seahowl::get_discretized_points(eta_vector, reference_points)[0].structural_twist;
 
     // rotation
-    auto twist_matrix = AngleAxisd(-twist, body_root->get_rotation() * Vector3d(0.0, 0.0, 1.0));
-    auto rotation_matrix = twist_matrix * body_root->get_rotation().toRotationMatrix();
+    auto twist_matrix = AngleAxisd(-twist, body_root.get_rotation() * Vector3d(0.0, 0.0, 1.0));
+    auto rotation_matrix = twist_matrix * body_root.get_rotation().toRotationMatrix();
     entity.set_rotation(Quaternion(rotation_matrix));
 
     // below has to be explicitly declared as Vector3d or there is an issue;
     Vector3d pos1 = entity.get_position();
-    Vector3d radius_vector = (pos1 - body_root->get_position());
+    Vector3d radius_vector = (pos1 - body_root.get_position());
 
     // velocity
-    Vector3d velocity = body_root->get_velocity() + (body_root->get_rotational_velocity(false)).cross(radius_vector);
+    Vector3d velocity = body_root.get_velocity() + (body_root.get_rotational_velocity(false)).cross(radius_vector);
     entity.set_velocity(velocity);
-    entity.set_rotational_velocity(body_root->get_rotational_velocity());
+    entity.set_rotational_velocity(body_root.get_rotational_velocity());
 
     // acceleration
     Vector3d acceleration =
-        body_root->get_acceleration() + (body_root->get_rotational_acceleration(false)).cross(radius_vector);
+        body_root.get_acceleration() + (body_root.get_rotational_acceleration(false)).cross(radius_vector);
     entity.set_acceleration(acceleration);
-    entity.set_rotational_acceleration(body_root->get_rotational_acceleration());
+    entity.set_rotational_acceleration(body_root.get_rotational_acceleration());
 
     return entity;
 }
 
 void BladeElastoRigid::reset_loads() {
-    body_root->reset_loads();
+    auto& body_root = *actuator_pitch->body_worker;
+    body_root.reset_loads();
     body_cog->reset_loads();
 }
 
@@ -402,10 +359,11 @@ void BladeElastoRigid::accumulate_load_along_blade(const seahowl::Vector3d& load
                                                    double eta,
                                                    const seahowl::Vector3d& offset) {
     // apply force on root
-    body_root->accumulate_force(load, false);
+    auto& body_root = *actuator_pitch->body_worker;
+    body_root.accumulate_force(load, false);
 
     // apply moment on root
     auto entity = get_entity_along_blade(eta, element_index);
-    auto distance = (entity.get_position() + offset - body_root->get_position());
-    body_root->accumulate_torque(moment + distance.cross(load), false);
+    auto distance = (entity.get_position() + offset - body_root.get_position());
+    body_root.accumulate_torque(moment + distance.cross(load), false);
 }

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -36,6 +36,17 @@ void BladeElasto::apply_pitch_increment(double pitch_increment) {
     body_mount->rotate(pitch_increment, root_dir);  // rotate mounting point back
     link_root_mount->initialize(*body_root, *body_mount);
     translate(root_pos);
+
+    // update actuator pitch timeseries in case it is used
+    if (has_pitch_actuator_dynamics) {
+        if (is_assembled) {
+            spdlog::warn(
+                "Blade pitch has been incremented instantaneously by {} degrees, resetting dynamic pitch actuator to "
+                "current pitch value ({} degrees) as a constant over time.",
+                pitch_increment * 180 / seahowl::PI, get_pitch() * 180 / seahowl::PI);
+        }
+        actuator_pitch->set_timeseries(std::vector<double>{0.0, 0.0}, std::vector<double>{get_pitch(), get_pitch()});
+    }
 }
 
 double BladeElasto::get_pitch() const {
@@ -56,7 +67,7 @@ void BladeElasto::assemble_this(SystemElasto& system) {
     system.add(*(body_root.get()));
     system.add(*(link_root.get()));
     system.add(*(body_mount.get()));
-    if (has_actuator_dynamics) {
+    if (has_pitch_actuator_dynamics) {
         system.add(*(actuator_pitch.get()));
     } else {
         system.add(*(link_root_mount));

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -23,15 +23,17 @@ BladeElasto::BladeElasto() {
 }
 
 void BladeElasto::apply_pitch_increment(double pitch_increment) {
-    // apply pitch from root node direction and position
-    auto root_dir = actuator_pitch->body_worker->get_rotation() * Vector3d(0.0, 0.0, 1.0);
-    auto root_pos = actuator_pitch->body_worker->get_position();
-    translate(-root_pos);
-    rotate(-pitch_increment, root_dir);
-    actuator_pitch->rotate(pitch_increment, root_dir);  // rotate actuator back
-    translate(root_pos);
-
-    actuator_pitch->increment_value_constant(pitch_increment);
+    if (pitch_increment != 0.0) {
+        // apply pitch from root node direction and position
+        auto root_dir = actuator_pitch->get_rotation_axis();
+        auto root_pos = actuator_pitch->body_controller->get_position();
+        translate(-root_pos);
+        rotate(pitch_increment, root_dir);
+        actuator_pitch->rotate(-pitch_increment, root_dir);  // rotate actuator back
+        translate(root_pos);
+        // increment actuator
+        actuator_pitch->increment_value_constant(pitch_increment);
+    }
 }
 
 double BladeElasto::get_pitch() const {
@@ -180,6 +182,9 @@ void BladeElastoFEA::build() {
     // apply initial pitch
     apply_pitch_increment(pitch0);
     update_root_constraint();
+
+    // initialize actuator links
+    actuator_pitch->initialize_links();
 };
 
 void BladeElastoFEA::build_elements_tapered_timoshenko() {
@@ -283,6 +288,9 @@ void BladeElastoRigid::build() {
     // apply initial pitch
     apply_pitch_increment(pitch0);
     update_root_constraint();
+
+    // initialize actuator links
+    actuator_pitch->initialize_links();
 }
 
 void BladeElastoRigid::assemble_this(SystemElasto& system) {

--- a/src/elasto/blade_elasto.cpp
+++ b/src/elasto/blade_elasto.cpp
@@ -19,6 +19,7 @@ BladeElasto::BladeElasto() {
     link_root->set_constraints(true, true, true, true, true, true);
     link_root_mount = std::make_unique<LinkChrono>();
     link_root_mount->set_constraints(true, true, true, true, true, true);
+    actuator_pitch = std::make_unique<ActuatorRotationChrono>();
     link_blade = std::make_unique<LinkChrono>();
     link_blade->set_constraints(true, true, true, true, true, true);
     //
@@ -55,7 +56,11 @@ void BladeElasto::assemble_this(SystemElasto& system) {
     system.add(*(body_root.get()));
     system.add(*(link_root.get()));
     system.add(*(body_mount.get()));
-    system.add(*(link_root_mount.get()));
+    if (has_actuator_dynamics) {
+        system.add(*(actuator_pitch.get()));
+    } else {
+        system.add(*(link_root_mount));
+    }
     if (is_mounted) {
         system.add(*(link_blade.get()));
     }
@@ -99,6 +104,15 @@ seahowl::Vector3d BladeElasto::get_blade_root_force() const {
     return link_root->get_reaction_force() + body_root->get_force(true);
 }
 
+void BladeElasto::update_root_constraint() {
+    // attach COG body to root body
+    link_root_mount->initialize(*body_root, *body_mount);
+    // attach root body to mounting point
+    actuator_pitch->initialize(*body_root, *body_mount, Vector3d(-1.0, 0.0, 0.0));
+    // set initial pitch
+    actuator_pitch->set_timeseries(std::vector<double>{0.0, 0.0}, std::vector<double>{get_pitch(), get_pitch()});
+}
+
 BladeElastoFEA::BladeElastoFEA() {}
 
 void BladeElastoFEA::assemble_this(SystemElasto& system) {
@@ -123,13 +137,6 @@ void BladeElastoFEA::translate(const Vector3d& translation_vector) const {
 double BladeElastoFEA::get_mass() const {
     // adding body_root for consistency even if mass is supposed to be zero.
     return ComponentElastoFEA::get_mass() + BladeElasto::get_mass();
-}
-
-void BladeElastoFEA::update_root_constraint() {
-    // attach node to root body
-    link_root->initialize(*nodes[0], *body_root);
-    // attach root body to mounting point
-    link_root_mount->initialize(*body_root, *body_mount);
 }
 
 void BladeElastoFEA::presetup(double fraction) {
@@ -202,9 +209,11 @@ void BladeElastoFEA::build() {
         build_elements_tapered_timoshenko();
     }
 
+    // attach node to root body
+    link_root->initialize(*nodes[0], *body_root);
+
     // apply initial pitch
     apply_pitch_increment(pitch0);
-
     update_root_constraint();
 };
 
@@ -303,10 +312,11 @@ void BladeElastoRigid::build() {
     body_cog->set_inertia_diagonal(Vector3d(0., 0., 0.));
     body_root->set_inertia_diagonal(Vector3d(inertia_total, inertia_total, 0.0));
 
+    // attach COG body to root body
+    link_root->initialize(*body_cog, *body_root);
+
     // apply initial pitch
     apply_pitch_increment(pitch0);
-
-    // link root and cog
     update_root_constraint();
 }
 
@@ -331,13 +341,6 @@ void BladeElastoRigid::translate(const Vector3d& translation_vector) const {
 
 double BladeElastoRigid::get_mass() const {
     return BladeElasto::get_mass() + body_cog->get_mass();
-}
-
-void BladeElastoRigid::update_root_constraint() {
-    // attach COG body to root body
-    link_root->initialize(*body_cog, *body_root);
-    // attach root body to mounting point
-    link_root_mount->initialize(*body_root, *body_mount);
 }
 
 seahowl::EntityDynamicEigen BladeElastoRigid::get_entity_along_blade(double eta, int element_index) const {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -1099,10 +1099,14 @@ ActuatorRotationChrono::ActuatorRotationChrono() {
     // make actuator bodies (massless)
     body_worker = std::make_unique<BodyElastoChrono>();
     auto body1ref = dynamic_cast<BodyElastoChrono&>(*body_worker);
+    body1ref.set_position(Vector3d(0.0, 0.0, 0.0));
+    body1ref.set_rotation(Quaternion(1.0, 0.0, 0.0, 0.0));
     body1ref.set_mass(0.0);
     body1ref.set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
     body_controller = std::make_unique<BodyElastoChrono>();
     auto body2ref = dynamic_cast<BodyElastoChrono&>(*body_controller);
+    body2ref.set_position(Vector3d(0.0, 0.0, 0.0));
+    body2ref.set_rotation(Quaternion(1.0, 0.0, 0.0, 0.0));
     body2ref.set_mass(0.0);
     body2ref.set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
 
@@ -1116,17 +1120,20 @@ ActuatorRotationChrono::ActuatorRotationChrono() {
     link = std::make_unique<LinkChrono>();
     set_fixed_actuator(false);
 
+    // initialize with angle zero
+    set_control_timeseries(std::vector<double>{0.0, 0.0}, std::vector<double>{0.0, 0.0});
+
     // initialize links
     initialize_links();
 }
 
-void ActuatorRotationChrono::set_timeseries(const std::vector<double>& time_array,
-                                            const std::vector<double>& values_array) {
+void ActuatorRotationChrono::set_control_timeseries(const std::vector<double>& time_array,
+                                                    const std::vector<double>& values_array) {
     std::dynamic_pointer_cast<ChFunctionArray>(chfunc)->time_array = time_array;
     std::dynamic_pointer_cast<ChFunctionArray>(chfunc)->values_array = values_array;
 }
 
-double ActuatorRotationChrono::get_wanted_value(double time) const {
+double ActuatorRotationChrono::get_control_value(double time) const {
     return std::dynamic_pointer_cast<ChFunctionArray>(chfunc)->Get_y(time);
 }
 
@@ -1151,7 +1158,7 @@ void ActuatorRotationChrono::impose_value_constant(double value) {
 void ActuatorRotationChrono::increment_value_constant(double value) {
     auto new_angle = get_angle() + value;
     body_worker->set_rotation(AngleAxisd(value, get_rotation_axis()) * body_worker->get_rotation());
-    set_timeseries(std::vector<double>{0.0, 0.0}, std::vector<double>{new_angle, new_angle});
+    set_control_timeseries(std::vector<double>{0.0, 0.0}, std::vector<double>{new_angle, new_angle});
     initialize_links();
 }
 

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -1138,16 +1138,7 @@ double ActuatorRotationChrono::get_control_value(double time) const {
 }
 
 double ActuatorRotationChrono::get_angle() const {
-    if (!is_fixed_actuator()) {
-        return chobj->GetMotorRot();
-    } else {
-        // get angle between quaternions
-        auto qq = (body_worker->get_rotation().conjugate() * body_controller->get_rotation()).normalized();
-        double angle0 = 2 * std::atan2(qq.vec().z(), qq.w());
-        // get angle between 0 and 2pi
-        double angle1 = fmod(angle0, 2 * PI);
-        return angle1;
-    }
+    return chobj->GetMotorRot();
 }
 
 void ActuatorRotationChrono::impose_value_constant(double value) {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -17,6 +17,7 @@
 #include <chrono/fea/ChMesh.h>
 #include <chrono/physics/ChSystemSMC.h>
 #include <chrono/solver/ChDirectSolverLS.h>
+#include <chrono/physics/ChLinkMotorRotationAngle.h>
 
 #include <vector>
 #include <memory>
@@ -1066,6 +1067,61 @@ Vector3d LinkChronoCable::get_reaction_torque() const {
     return ch2vec(chobj->Get_react_torque());
 }
 
+class ChFunctionArray : public chrono::ChFunction {
+  public:
+    std::vector<double> time_array{0.0, 0.0};
+    std::vector<double> values_array{0.0, 0.0};
+
+    virtual ChFunctionArray* Clone() const override { return new ChFunctionArray(*this); }
+
+    virtual double Get_y(double x) const override {
+        if (x >= time_array.back()) {
+            return values_array.back();
+        } else if (x <= time_array.front()) {
+            return values_array.front();
+        } else {
+            for (int ii = 0; ii < time_array.size() - 1; ii++) {
+                if (time_array[ii] <= x && time_array[ii + 1] >= x) {
+                    auto t1 = time_array[ii];
+                    auto v1 = values_array[ii];
+                    auto t2 = time_array[ii + 1];
+                    auto v2 = values_array[ii + 1];
+                    return (v1 + (v2 - v1) * (x - t1) / (t2 - t1));
+                }
+            }
+            // throw error if value not found
+            throw std::runtime_error("Cannot find value from time array in ChFunctionArray.");
+        }
+    }
+};
+
+ActuatorRotationChrono::ActuatorRotationChrono() {
+    chobj = std::make_shared<chrono::ChLinkMotorRotationAngle>();
+    chfunc = std::make_shared<ChFunctionArray>();
+    chobj->SetMotorFunction(chfunc);
+}
+
+void ActuatorRotationChrono::initialize(const Entity& entity1, const Entity& entity2, const Vector3d& rotation_axis) {
+    auto body1 = dynamic_cast<const BodyElastoChrono&>(entity1);
+    auto body2 = dynamic_cast<const BodyElastoChrono&>(entity2);
+
+    // create a frame that has its Z axis aligned to rotation_axis
+    auto chaxis = chrono::Vector(rotation_axis[0], rotation_axis[1], rotation_axis[2]).GetNormalized();
+    auto chzero = chrono::Vector(0.0, 0.0, 0.0);
+    // chaxis relative to body1
+    auto rotation_axis_rel1 = body2.get_rotation().inverse() * body1.get_rotation() * rotation_axis;
+    auto chaxis_rel1 =
+        chrono::Vector(rotation_axis_rel1[0], rotation_axis_rel1[1], rotation_axis_rel1[2]).GetNormalized();
+
+    chobj->Initialize(body1.chobj, body2.chobj, true, chzero, chzero, chaxis, chaxis);
+}
+
+void ActuatorRotationChrono::set_timeseries(const std::vector<double>& time_array,
+                                            const std::vector<double>& values_array) {
+    std::dynamic_pointer_cast<ChFunctionArray>(chfunc)->time_array = time_array;
+    std::dynamic_pointer_cast<ChFunctionArray>(chfunc)->values_array = values_array;
+}
+
 LinkMatrixStiffnessDampingChrono::LinkMatrixStiffnessDampingChrono() {
     // empty stiffness and damping matrices
     stiffness_matrix = Eigen::Matrix<double, 6, 6>::Zero();
@@ -1267,4 +1323,8 @@ void SystemElastoChrono::add(LinkMatrixStiffnessDamping& link) {
 
 void SystemElastoChrono::add(SpringLinear& spring) {
     chobj->Add(dynamic_cast<SpringLinearChrono&>(spring).chobj);
+}
+
+void SystemElastoChrono::add(ActuatorRotation& actuator) {
+    chobj->Add(dynamic_cast<ActuatorRotationChrono&>(actuator).chobj);
 }

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -1122,6 +1122,10 @@ void ActuatorRotationChrono::set_timeseries(const std::vector<double>& time_arra
     std::dynamic_pointer_cast<ChFunctionArray>(chfunc)->values_array = values_array;
 }
 
+double ActuatorRotationChrono::get_value(double time) {
+    return std::dynamic_pointer_cast<ChFunctionArray>(chfunc)->Get_y(time);
+}
+
 LinkMatrixStiffnessDampingChrono::LinkMatrixStiffnessDampingChrono() {
     // empty stiffness and damping matrices
     stiffness_matrix = Eigen::Matrix<double, 6, 6>::Zero();

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -825,7 +825,7 @@ void ElementElastoChrono::set_nodes(std::shared_ptr<NodeElasto> node1, std::shar
     nodes.push_back(node2);
 }
 
-void ElementElastoChrono::evaluate_position_rotation(double eta, Vector3d& position, Quaternion& rotation) {
+void ElementElastoChrono::evaluate_position_rotation(double eta, Vector3d& position, Quaternion& rotation) const {
     auto chvec = vec2ch(position);
     auto chquat = quat2ch(rotation);
     chobj->EvaluateSectionFrame(eta, chvec, chquat);
@@ -835,7 +835,7 @@ void ElementElastoChrono::evaluate_position_rotation(double eta, Vector3d& posit
     rotation = node_ch2iec(chquat);
 }
 
-void ElementElastoChrono::evaluate_force_torque(double eta, Vector3d& force, Vector3d& torque) {
+void ElementElastoChrono::evaluate_force_torque(double eta, Vector3d& force, Vector3d& torque) const {
     auto chforce = vec2ch(force);
     auto chtorque = vec2ch(torque);
     chobj->EvaluateSectionForceTorque(eta, chforce, chtorque);
@@ -1096,24 +1096,28 @@ class ChFunctionArray : public chrono::ChFunction {
 };
 
 ActuatorRotationChrono::ActuatorRotationChrono() {
+    // make actuator bodies (massless)
+    body_worker = std::make_unique<BodyElastoChrono>();
+    auto body1ref = dynamic_cast<BodyElastoChrono&>(*body_worker);
+    body1ref.set_mass(0.0);
+    body1ref.set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
+    body_controller = std::make_unique<BodyElastoChrono>();
+    auto body2ref = dynamic_cast<BodyElastoChrono&>(*body_controller);
+    body2ref.set_mass(0.0);
+    body2ref.set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
+
+    // make actuator abject
     chobj = std::make_shared<chrono::ChLinkMotorRotationAngle>();
+    LinkChronoBase::chobj = chobj;
     chfunc = std::make_shared<ChFunctionArray>();
     chobj->SetMotorFunction(chfunc);
-}
 
-void ActuatorRotationChrono::initialize(const Entity& entity1, const Entity& entity2, const Vector3d& rotation_axis) {
-    auto body1 = dynamic_cast<const BodyElastoChrono&>(entity1);
-    auto body2 = dynamic_cast<const BodyElastoChrono&>(entity2);
+    // make link
+    link = std::make_unique<LinkChrono>();
+    set_fixed_actuator(false);
 
-    // create a frame that has its Z axis aligned to rotation_axis
-    auto chaxis = chrono::Vector(rotation_axis[0], rotation_axis[1], rotation_axis[2]).GetNormalized();
-    auto chzero = chrono::Vector(0.0, 0.0, 0.0);
-    // chaxis relative to body1
-    auto rotation_axis_rel1 = body2.get_rotation().inverse() * body1.get_rotation() * rotation_axis;
-    auto chaxis_rel1 =
-        chrono::Vector(rotation_axis_rel1[0], rotation_axis_rel1[1], rotation_axis_rel1[2]).GetNormalized();
-
-    chobj->Initialize(body1.chobj, body2.chobj, true, chzero, chzero, chaxis, chaxis);
+    // initialize links
+    initialize_links();
 }
 
 void ActuatorRotationChrono::set_timeseries(const std::vector<double>& time_array,
@@ -1122,8 +1126,53 @@ void ActuatorRotationChrono::set_timeseries(const std::vector<double>& time_arra
     std::dynamic_pointer_cast<ChFunctionArray>(chfunc)->values_array = values_array;
 }
 
-double ActuatorRotationChrono::get_value(double time) {
+double ActuatorRotationChrono::get_wanted_value(double time) const {
     return std::dynamic_pointer_cast<ChFunctionArray>(chfunc)->Get_y(time);
+}
+
+double ActuatorRotationChrono::get_angle() const {
+    if (!is_fixed_actuator()) {
+        return chobj->GetMotorRot();
+    } else {
+        // get angle between quaternions
+        auto qq = (body_worker->get_rotation().conjugate() * body_controller->get_rotation()).normalized();
+        double angle0 = 2 * std::atan2(qq.vec().z(), qq.w());
+        // get angle between 0 and 2pi
+        double angle1 = fmod(angle0, 2 * PI);
+        return angle1;
+    }
+}
+
+void ActuatorRotationChrono::impose_value_constant(double value) {
+    auto current_angle = get_angle();
+    increment_value_constant(value - current_angle);
+}
+
+void ActuatorRotationChrono::increment_value_constant(double value) {
+    auto new_angle = get_angle() + value;
+    body_worker->set_rotation(AngleAxisd(value, get_rotation_axis()) * body_worker->get_rotation());
+    set_timeseries(std::vector<double>{0.0, 0.0}, std::vector<double>{new_angle, new_angle});
+    initialize_links();
+}
+
+void ActuatorRotationChrono::set_fixed_actuator(bool is_fixed) {
+    dynamic_cast<LinkChrono&>(*link).chobj->SetDisabled(!is_fixed);
+    chobj->SetDisabled(is_fixed);
+}
+
+bool ActuatorRotationChrono::is_fixed_actuator() const {
+    return chobj->IsDisabled();
+}
+
+void ActuatorRotationChrono::initialize_links() {
+    // link
+    link->initialize(*body_worker, *body_controller);
+
+    // actuator link
+    auto body1ref = dynamic_cast<BodyElastoChrono&>(*body_worker);
+    auto body2ref = dynamic_cast<BodyElastoChrono&>(*body_controller);
+    auto chframe0 = chrono::ChFrame<double>(chrono::Vector(0.0, 0.0, 0.0), quat2ch(reference_rotation));
+    chobj->Initialize(body1ref.chobj, body2ref.chobj, true, chframe0, chframe0);
 }
 
 LinkMatrixStiffnessDampingChrono::LinkMatrixStiffnessDampingChrono() {
@@ -1331,4 +1380,7 @@ void SystemElastoChrono::add(SpringLinear& spring) {
 
 void SystemElastoChrono::add(ActuatorRotation& actuator) {
     chobj->Add(dynamic_cast<ActuatorRotationChrono&>(actuator).chobj);
+    add(*actuator.body_worker);
+    add(*actuator.body_controller);
+    add(*actuator.link);
 }

--- a/src/elasto/entities_elasto.cpp
+++ b/src/elasto/entities_elasto.cpp
@@ -1,0 +1,59 @@
+#include "seahowl/elasto/entities_elasto.h"
+
+using namespace seahowl;
+using namespace seahowl::elasto;
+
+Vector3d ElementElasto::get_position(double eta) const {
+    auto position = Vector3d(0.0, 0.0, 0.0);
+    auto rotation = Quaternion(0.0, 0.0, 0.0, 0.0);
+    evaluate_position_rotation(eta, position, rotation);
+    return position;
+}
+
+Quaternion ElementElasto::get_rotation(double eta) const {
+    auto position = Vector3d(0.0, 0.0, 0.0);
+    auto rotation = Quaternion(0.0, 0.0, 0.0, 0.0);
+    evaluate_position_rotation(eta, position, rotation);
+    return rotation;
+}
+
+Vector3d ElementElasto::get_force(double eta) const {
+    auto force = Vector3d(0.0, 0.0, 0.0);
+    auto torque = Vector3d(0.0, 0.0, 0.0);
+    evaluate_force_torque(eta, force, torque);
+    return force;
+}
+
+Vector3d ElementElasto::get_torque(double eta) const {
+    auto force = Vector3d(0.0, 0.0, 0.0);
+    auto torque = Vector3d(0.0, 0.0, 0.0);
+    evaluate_force_torque(eta, force, torque);
+    return torque;
+}
+
+Vector3d ActuatorRotation::get_rotation_axis() const {
+    return body_controller->get_rotation() * (reference_rotation * Vector3d(0.0, 0.0, 1.0));
+}
+
+void ActuatorRotation::set_position(const Vector3d& position) {
+    body_worker->set_position(position);
+    body_controller->set_position(position);
+}
+
+Vector3d ActuatorRotation::get_position() const {
+    return body_controller->get_position();
+}
+
+void ActuatorRotation::set_rotation(const Quaternion& rotation) {
+    auto rotation_relative = body_controller->get_rotation().inverse() * body_worker->get_rotation();
+    body_controller->set_rotation(rotation);
+    body_worker->set_rotation(rotation * rotation_relative);
+}
+
+Quaternion ActuatorRotation::get_rotation() const {
+    return body_controller->get_rotation();
+}
+
+Vector3d ActuatorRotation::get_rpy_angles() const {
+    return body_controller->get_rpy_angles();
+}

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -62,10 +62,12 @@ void RotorElasto::build() {
 }
 
 void RotorElasto::apply_collective_pitch_increment(double pitch_increment) {
-    for (auto& blade : blades) {
-        blade->apply_pitch_increment(pitch_increment);
+    if (pitch_increment != 0.0) {
+        for (auto& blade : blades) {
+            blade->apply_pitch_increment(pitch_increment);
+        }
+        pitch_collective += pitch_increment;
     }
-    pitch_collective += pitch_increment;
 }
 
 void RotorElasto::rotate(double angle, const Vector3d& axis) const {
@@ -121,21 +123,18 @@ RotorNacelleAssemblyElasto::RotorNacelleAssemblyElasto() {
     link_shaft_nacelle = std::make_unique<LinkChrono>();
     link_shaft_nacelle->set_constraints(true, true, true, true, true, true);
 
-    // yaw bearing
-    body_yaw_bearing = std::make_unique<BodyElastoChrono>();
     // link between yaw bearing body and shaft body
     link_shaft_yaw_bearing = std::make_unique<LinkChrono>();
     link_shaft_yaw_bearing->set_constraints(true, true, true, true, true, true);
 
-    // mounting point
-    body_mount = std::make_unique<BodyElastoChrono>();
-    // link between yaw bearing body and shaft body
-    link_yaw_bearing_mount = std::make_unique<LinkChrono>();
-    link_yaw_bearing_mount->set_constraints(true, true, true, true, true, true);
+    // yaw actuator
+    actuator_yaw = std::make_unique<ActuatorRotationChrono>();
+    actuator_yaw->reference_rotation = Quaternion(1.0, 0.0, 0.0, 0.0);
+    // actuator_yaw->reference_rotation = Quaternion(AngleAxisd(PI, Vector3d(1.0, 0.0, 0.0)));
 
     // RNA link
-    link_towertop_mount = std::make_unique<LinkChrono>();
-    link_towertop_mount->set_constraints(true, true, true, true, true, true);
+    link_rna = std::make_unique<LinkChrono>();
+    link_rna->set_constraints(true, true, true, true, true, true);
 }
 
 void RotorNacelleAssemblyElasto::presetup(double fraction) {
@@ -148,12 +147,10 @@ void RotorNacelleAssemblyElasto::assemble_this(SystemElasto& system) {
     system.add(*link_shaft_hub);
     system.add(*body_nacelle);
     system.add(*link_shaft_nacelle);
-    system.add(*body_yaw_bearing);
     system.add(*link_shaft_yaw_bearing);
-    system.add(*body_mount);
-    system.add(*link_yaw_bearing_mount);
+    system.add(*actuator_yaw);
     if (is_mounted) {
-        system.add(*link_towertop_mount);
+        system.add(*link_rna);
     }
 }
 
@@ -187,26 +184,21 @@ void RotorNacelleAssemblyElasto::build() {
     // link nacelle body to shaft body
     link_shaft_nacelle->initialize(*body_nacelle, *body_shaft);
 
+    // actuator yaw
+    actuator_yaw->set_position(Vector3d(0.0, 0.0, 0.0));
+    actuator_yaw->set_rotation(rotation0);
     // yaw bearing
-    body_yaw_bearing->set_position(Vector3d(0.0, 0.0, 0.0));
-    body_yaw_bearing->set_rotation(rotation0);
-    body_yaw_bearing->set_mass(nacelle.yaw_bearing_mass);
-    body_yaw_bearing->set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
+    auto& body_yaw_bearing = *actuator_yaw->body_worker;
+    body_yaw_bearing.set_mass(nacelle.yaw_bearing_mass);
+    body_yaw_bearing.set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
     // link yaw bearing body to shaft body
-    link_shaft_yaw_bearing->initialize(*body_shaft, *body_yaw_bearing);
-
-    // mounting point
-    body_mount->set_position(Vector3d(0.0, 0.0, 0.0));
-    body_mount->set_rotation(rotation0);
-    body_mount->set_mass(0.0);
-    body_mount->set_inertia_diagonal(Vector3d(0.0, 0.0, 0.0));
-    // link mount to yaw bearing
-    link_yaw_bearing_mount->initialize(*body_yaw_bearing, *body_mount);
+    link_shaft_yaw_bearing->initialize(*body_shaft, body_yaw_bearing);
 
     // apply initial yaw increment
-    if (yaw0 != 0.0) {
-        apply_yaw_increment(yaw0);
-    }
+    apply_yaw_increment(yaw0);
+
+    // initialize actuator links
+    actuator_yaw->initialize_links();
 }
 
 void RotorNacelleAssemblyElasto::rotate(double angle, const Vector3d& axis) const {
@@ -217,10 +209,8 @@ void RotorNacelleAssemblyElasto::rotate(double angle, const Vector3d& axis) cons
     body_shaft->rotate(angle, axis);
     // nacelle
     body_nacelle->rotate(angle, axis);
-    // yaw bearing
-    body_yaw_bearing->rotate(angle, axis);
-    // mounting point
-    body_mount->rotate(angle, axis);
+    // yaw actuator
+    actuator_yaw->rotate(angle, axis);
 }
 
 void RotorNacelleAssemblyElasto::translate(const Vector3d& translation_vector) const {
@@ -230,10 +220,8 @@ void RotorNacelleAssemblyElasto::translate(const Vector3d& translation_vector) c
     body_shaft->translate(translation_vector);
     // nacelle
     body_nacelle->translate(translation_vector);
-    // yaw bearing
-    body_yaw_bearing->translate(translation_vector);
-    // mounting point
-    body_mount->translate(translation_vector);
+    // yaw actuator
+    actuator_yaw->translate(translation_vector);
 }
 
 double RotorNacelleAssemblyElasto::get_mass() const {
@@ -244,10 +232,9 @@ double RotorNacelleAssemblyElasto::get_mass() const {
     total_mass += body_shaft->get_mass();
     // nacelle
     total_mass += body_nacelle->get_mass();
-    // yaw bearing
-    total_mass += body_yaw_bearing->get_mass();
-    // mounting point
-    total_mass += body_mount->get_mass();
+    // yaw actuator
+    total_mass += actuator_yaw->body_worker->get_mass();
+    total_mass += actuator_yaw->body_controller->get_mass();
     return total_mass;
 }
 
@@ -303,36 +290,29 @@ double RotorNacelleAssemblyElasto::get_electrical_torque() const {
 }
 
 void RotorNacelleAssemblyElasto::apply_yaw_increment(double yaw_increment) {
-    // apply pitch from root node direction and position
-    auto root_dir = body_mount->get_rotation() * Vector3d(0.0, 0.0, 1.0);
-    auto root_pos = body_mount->get_position();
-    translate(-root_pos);
-    rotate(yaw_increment, root_dir);
-    body_mount->rotate(-yaw_increment, root_dir);  // rotate mounting point back
-    link_yaw_bearing_mount->initialize(*body_yaw_bearing, *body_mount);
-    translate(root_pos);
+    if (yaw_increment != 0.0) {
+        // apply yaw increment from actuator position
+        auto root_dir = actuator_yaw->get_rotation_axis();
+        auto root_pos = actuator_yaw->body_controller->get_position();
+        translate(-root_pos);
+        rotate(yaw_increment, root_dir);
+        actuator_yaw->rotate(-yaw_increment, root_dir);  // rotate mounting point back
+        translate(root_pos);
+
+        actuator_yaw->increment_value_constant(yaw_increment);
+    }
 }
 
 double RotorNacelleAssemblyElasto::get_yaw() const {
-    // get angle between quaternions
-    auto qq = (body_yaw_bearing->get_rotation().conjugate() * body_mount->get_rotation()).normalized();
-    double angle0 = 2 * std::atan2(qq.vec().z(), qq.w());
-    // get angle between 0 and 2pi
-    double angle1 = fmod(angle0, 2 * PI);
-    return -angle1;
-}
-
-void RotorNacelleAssemblyElasto::set_fixed_yaw(bool is_fixed) {
-    link_yaw_bearing_mount->set_constraints(true, true, true, true, true, is_fixed);
-    link_yaw_bearing_mount->initialize(*body_yaw_bearing, *body_mount);
+    return actuator_yaw->get_angle();
 }
 
 void RotorNacelleAssemblyElasto::attach_rna_to_body(const BodyElasto& body) {
     is_mounted = true;
-    link_towertop_mount->initialize(*body_mount, body);
+    link_rna->initialize(*actuator_yaw->body_controller, body);
 }
 
 void RotorNacelleAssemblyElasto::attach_rna_to_node(const NodeElasto& node) {
     is_mounted = true;
-    link_towertop_mount->initialize(*body_mount, node);
+    link_rna->initialize(*actuator_yaw->body_controller, node);
 }

--- a/src/elasto/turbine_elasto.cpp
+++ b/src/elasto/turbine_elasto.cpp
@@ -31,8 +31,8 @@ void TurbineElasto::build() {
 
     // link tower to rotor
     auto& towertop_node = *tower.nodes.back();
-    // translate RNA center of origin to towertop
-    rna.translate(towertop_node.get_position() - rna.body_mount->get_position());
+    // translate RNA center of origin (yaw bearing body) to towertop
+    rna.translate(towertop_node.get_position() - rna.actuator_yaw->body_controller->get_position());
     rna.attach_rna_to_node(towertop_node);
 
     // build foundation

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -708,6 +708,10 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
             if (rotor_json.at("type").get<std::string>() == "rigid") {
                 blade_elasto->precone = 0.0;
             }
+
+            // pitch actuator dynamics
+            rotor_json.at("pitch_actuator_dynamics").get_to(blade_elasto->has_pitch_actuator_dynamics);
+
             blades_elasto.push_back(blade_elasto);
             blades_aero.push_back(blade_aero);
             blades.push_back(blade);

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -682,6 +682,9 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
     // blades
     // only make blades if rotor type is not disk
     if (rotor_json.at("type").get<std::string>() != "disk") {
+        // pitch actuator dynamics
+        bool has_pitch_actuator_dynamics = rotor_json.at("pitch_actuator_dynamics").get<bool>();
+
         std::vector<std::shared_ptr<seahowl::core::Blade>> blades;
         std::vector<std::shared_ptr<seahowl::elasto::BladeElasto>> blades_elasto;
         std::vector<std::shared_ptr<seahowl::aero::BladeAero>> blades_aero;
@@ -709,8 +712,7 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
                 blade_elasto->precone = 0.0;
             }
 
-            // pitch actuator dynamics
-            rotor_json.at("pitch_actuator_dynamics").get_to(blade_elasto->has_pitch_actuator_dynamics);
+            blade_elasto->actuator_pitch->set_fixed_actuator(!has_pitch_actuator_dynamics);
 
             blades_elasto.push_back(blade_elasto);
             blades_aero.push_back(blade_aero);
@@ -831,12 +833,8 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
             // populate monopile
             auto filepath_monopile = (DATADIR / foundation_json.at("file").get<std::string>()).generic_string();
             populate_tower_from_json(filepath_monopile, *monopile_core);
-            foundation_json.at("discretization")
-                    .at("elasto")
-                    .get_to(monopile_elasto->discretization_fractions);
-            foundation_json.at("discretization")
-                    .at("hydro")
-                    .get_to(monopile_hydro->discretization_fractions);
+            foundation_json.at("discretization").at("elasto").get_to(monopile_elasto->discretization_fractions);
+            foundation_json.at("discretization").at("hydro").get_to(monopile_hydro->discretization_fractions);
             if (foundation_json.contains("options")) {
                 if (foundation_json.at("options").contains("use_MacCamyFuchs_correction"))
                     foundation_json.at("options")

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -728,6 +728,8 @@ void populate_turbine_from_json(const std::string& filepath, seahowl::core::Turb
     populate_rna_from_json(filepath_rna, turbine.rna);
     auto yaw_rna = rna_json.at("initial_yaw").get<double>() * PI / 180.0;
     turbine.rna.elasto.yaw0 = yaw_rna;
+    bool has_yaw_actuator_dynamics = rna_json.at("yaw_actuator_dynamics").get<bool>();
+    turbine.rna.elasto.actuator_yaw->set_fixed_actuator(!has_yaw_actuator_dynamics);
 
     // update info if rotor is disk
     if (rotor_json.at("type").get<std::string>() == "disk") {

--- a/tests/unit_tests/data/test_controller/ref/test_collective_pitch_control.csv
+++ b/tests/unit_tests/data/test_controller/ref/test_collective_pitch_control.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12ea4d831e9d655d4f3f095a82a0c973a23e511af8cacafd71c16bcd9b77eb72
+size 66070

--- a/tests/unit_tests/data/test_controller/ref/test_collective_pitch_control_snap.csv
+++ b/tests/unit_tests/data/test_controller/ref/test_collective_pitch_control_snap.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd8e1aad89a5f54feed5b8455295ff6c9506ef31f146f3c5b672e30931d42097
+size 66069

--- a/tests/unit_tests/data/test_controller/ref/test_controller.csv
+++ b/tests/unit_tests/data/test_controller/ref/test_controller.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1fc2b78121944f20d602f6d7c0d42610f8984a7ec54da327d331c73e7657bbe
-size 426808
+oid sha256:9089be2840e29be380035eb3ed3dc933addbc0ccd9714e4684e76e314eb403bc
+size 426504

--- a/tests/unit_tests/data/test_controller/ref/test_controller_actuator_disk.csv
+++ b/tests/unit_tests/data/test_controller/ref/test_controller_actuator_disk.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6de8c01f84c4d5920fa1d536348c031a4e9cb9aa28221f05906960ac28bf175d
-size 24260
+oid sha256:5a950562e33c6cf7117b17eb702bad1ccd6ff28551239a1a30e0cb8b432efb88
+size 24259

--- a/tests/unit_tests/data/test_controller/ref/test_yaw_control.csv
+++ b/tests/unit_tests/data/test_controller/ref/test_yaw_control.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ce3e90b1be0578d9b00880a9e32da4f23b2b8bcd8a210fc2813fb8948929dd3
+size 68471

--- a/tests/unit_tests/data/test_controller/ref/test_yaw_control_snap.csv
+++ b/tests/unit_tests/data/test_controller/ref/test_yaw_control_snap.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d94ce5f8dfaafc871d52da7edad9ec097baebf8adb2ba804c817be834b4c501f
+size 66609

--- a/tests/unit_tests/test_controller.cpp
+++ b/tests/unit_tests/test_controller.cpp
@@ -5,7 +5,9 @@
 #include <seahowl/core/simulation.h>
 #include <seahowl/env/wind_models.h>
 #include <seahowl/core/turbine.h>
+#include <seahowl/core/blade.h>
 #include <seahowl/core/system.h>
+#include <seahowl/servo/controller_discon.h>
 #include <seahowl/elasto/blade_elasto.h>
 #include <seahowl/io/read_json.h>
 
@@ -22,6 +24,242 @@ class TestController : public FixtureComponents {
         ref_dir /= "test_controller/ref";
         test_dir /= "test_controller/test";
     }
+};
+
+TEST_F(TestController, collective_pitch_control) {
+    // make simulation object
+    auto simulation = seahowl::core::Simulation();
+    simulation.dt = 0.05;
+    simulation.duration = 50.0;
+    simulation.outputs->dt_output = 9999.9;  // no output, using custom CSV
+    simulation.outputs->has_csv = false;
+    simulation.outputs->has_gui = false;
+    simulation.outputs->has_vtk = false;
+
+    auto& system_core = *simulation.system_core;
+    auto& system_elasto = system_core.elasto;
+
+    // add turbine to system
+    seahowl::io::add_turbine_to_system_from_json((DATADIR / "IEA15MW/onshore/turbine.json").generic_string(),
+                                                 system_core);
+    auto& turbine = *system_core.turbines[0];
+    for (auto& blade : turbine.rna.blades) {
+        blade->elasto.actuator_pitch->set_fixed_actuator(false);
+        blade->elasto.apply_pitch_increment(0.7);
+    }
+    // statics
+    system_elasto.do_statics(true, 10);
+
+    // add wind model
+    auto wind_model = std::make_shared<seahowl::env::ConstantWind>();
+    system_core.fluid_model = wind_model;
+    wind_model->shear_coefficient = 0.12;
+    wind_model->reference_height = turbine.elasto.rna.rotor->body_hub->get_position().z();
+    wind_model->set_wind_velocity(seahowl::Vector3d(12.0, 0.0, 0.0));
+
+    // initialize simulation
+    simulation.initialize();
+
+    // instantiate test dataset class (custom CSV)
+    TestFrameworkDataset test_dataset({false, (ref_dir / "test_collective_pitch_control.csv").generic_string(),
+                                       (test_dir / "test_collective_pitch_control.test.csv").generic_string()});
+    test_dataset.test_csv.add_function("time (s)", [&system_elasto]() { return system_elasto.get_time(); });
+    test_dataset.test_csv.add_function("blade pitch (rad)",
+                                       [&turbine]() { return turbine.rna.blades[0]->elasto.get_pitch(); });
+    test_dataset.test_csv.add_function("blade root moment (N)",
+                                       [&turbine]() { return turbine.rna.blades[0]->elasto.get_blade_root_moment(); });
+
+    // output values at time = 0
+    test_dataset.test_csv.write_row();
+
+    // simulation loop
+    while (system_core.get_time() < simulation.duration) {
+        // simulation step
+        simulation.step();
+        test_dataset.test_csv.write_row();
+    }
+
+    // compare ref and test CSVs
+    EvaluateTest(test_dataset);
+};
+
+TEST_F(TestController, collective_pitch_control_snap) {
+    // make simulation object
+    auto simulation = seahowl::core::Simulation();
+    simulation.dt = 0.05;
+    simulation.duration = 50.0;
+    simulation.outputs->dt_output = 9999.9;  // no output, using custom CSV
+    simulation.outputs->has_csv = false;
+    simulation.outputs->has_gui = false;
+    simulation.outputs->has_vtk = false;
+
+    auto& system_core = *simulation.system_core;
+    auto& system_elasto = system_core.elasto;
+
+    // add turbine to system
+    seahowl::io::add_turbine_to_system_from_json((DATADIR / "IEA15MW/onshore/turbine.json").generic_string(),
+                                                 system_core);
+    auto& turbine = *system_core.turbines[0];
+    for (auto& blade : turbine.rna.blades) {
+        blade->elasto.actuator_pitch->set_fixed_actuator(true);
+        blade->elasto.apply_pitch_increment(0.7);
+    }
+    // statics
+    system_elasto.do_statics(true, 10);
+
+    // add wind model
+    auto wind_model = std::make_shared<seahowl::env::ConstantWind>();
+    system_core.fluid_model = wind_model;
+    wind_model->shear_coefficient = 0.12;
+    wind_model->reference_height = turbine.elasto.rna.rotor->body_hub->get_position().z();
+    wind_model->set_wind_velocity(seahowl::Vector3d(12.0, 0.0, 0.0));
+
+    // initialize simulation
+    simulation.initialize();
+
+    // instantiate test dataset class (custom CSV)
+    TestFrameworkDataset test_dataset({false, (ref_dir / "test_collective_pitch_control_snap.csv").generic_string(),
+                                       (test_dir / "test_collective_pitch_control_snap.test.csv").generic_string()});
+    test_dataset.test_csv.add_function("time (s)", [&system_elasto]() { return system_elasto.get_time(); });
+    test_dataset.test_csv.add_function("blade pitch (rad)",
+                                       [&turbine]() { return turbine.rna.blades[0]->elasto.get_pitch(); });
+    test_dataset.test_csv.add_function("blade root moment (N)",
+                                       [&turbine]() { return turbine.rna.blades[0]->elasto.get_blade_root_moment(); });
+
+    // output values at time = 0
+    test_dataset.test_csv.write_row();
+
+    // simulation loop
+    while (system_core.get_time() < simulation.duration) {
+        // simulation step
+        simulation.step();
+        test_dataset.test_csv.write_row();
+    }
+
+    // compare ref and test CSVs
+    EvaluateTest(test_dataset);
+};
+
+TEST_F(TestController, yaw_control) {
+    // make simulation object
+    auto simulation = seahowl::core::Simulation();
+    simulation.dt = 0.05;
+    simulation.duration = 50.0;
+    simulation.outputs->dt_output = 9999.9;  // no output, using custom CSV
+    simulation.outputs->has_csv = false;
+    simulation.outputs->has_gui = false;
+    simulation.outputs->has_vtk = false;
+
+    auto& system_core = *simulation.system_core;
+    auto& system_elasto = system_core.elasto;
+
+    // add turbine to system
+    seahowl::io::add_turbine_to_system_from_json((DATADIR / "IEA15MW/onshore/turbine_rigid.json").generic_string(),
+                                                 system_core);
+    auto& turbine = *system_core.turbines[0];
+
+    // update controller to have yaw control
+    auto controller = std::make_shared<seahowl::servo::ControllerDISCON>(
+        (DATADIR / "IEA15MW/base/controller/DISCON_yaw.IN").generic_string(),
+        (DATADIR / "IEA15MW/base/controller/libdiscon.so").generic_string());
+    turbine.controller = controller;
+
+    turbine.rna.elasto.actuator_yaw->set_fixed_actuator(false);
+    turbine.rna.elasto.apply_yaw_increment(-0.1);
+    // statics
+    system_elasto.do_statics(true, 10);
+
+    // add wind model
+    auto wind_model = std::make_shared<seahowl::env::ConstantWind>();
+    system_core.fluid_model = wind_model;
+    wind_model->shear_coefficient = 0.12;
+    wind_model->reference_height = turbine.elasto.rna.rotor->body_hub->get_position().z();
+    wind_model->set_wind_velocity(seahowl::Vector3d(12.0, 1.0, 0.0));
+
+    // initialize simulation
+    simulation.initialize();
+
+    // instantiate test dataset class (custom CSV)
+    TestFrameworkDataset test_dataset({false, (ref_dir / "test_yaw_control.csv").generic_string(),
+                                       (test_dir / "test_yaw_control.test.csv").generic_string()});
+    test_dataset.test_csv.add_function("time (s)", [&system_elasto]() { return system_elasto.get_time(); });
+    test_dataset.test_csv.add_function("yaw (rad)", [&turbine]() { return turbine.rna.elasto.get_yaw(); });
+    test_dataset.test_csv.add_function("towerbase moment (N)",
+                                       [&turbine]() { return turbine.tower.elasto.get_tower_base_moment(); });
+
+    // output values at time = 0
+    test_dataset.test_csv.write_row();
+
+    // simulation loop
+    while (system_core.get_time() < simulation.duration) {
+        // simulation step
+        simulation.step();
+        test_dataset.test_csv.write_row();
+    }
+
+    // compare ref and test CSVs
+    EvaluateTest(test_dataset);
+};
+
+TEST_F(TestController, yaw_control_snap) {
+    // make simulation object
+    auto simulation = seahowl::core::Simulation();
+    simulation.dt = 0.05;
+    simulation.duration = 50.0;
+    simulation.outputs->dt_output = 9999.9;  // no output, using custom CSV
+    simulation.outputs->has_csv = false;
+    simulation.outputs->has_gui = false;
+    simulation.outputs->has_vtk = false;
+
+    auto& system_core = *simulation.system_core;
+    auto& system_elasto = system_core.elasto;
+
+    // add turbine to system
+    seahowl::io::add_turbine_to_system_from_json((DATADIR / "IEA15MW/onshore/turbine_rigid.json").generic_string(),
+                                                 system_core);
+    auto& turbine = *system_core.turbines[0];
+
+    // update controller to have yaw control
+    auto controller = std::make_shared<seahowl::servo::ControllerDISCON>(
+        (DATADIR / "IEA15MW/base/controller/DISCON_yaw.IN").generic_string(),
+        (DATADIR / "IEA15MW/base/controller/libdiscon.so").generic_string());
+    turbine.controller = controller;
+
+    turbine.rna.elasto.actuator_yaw->set_fixed_actuator(true);
+    turbine.rna.elasto.apply_yaw_increment(-0.1);
+    // statics
+    system_elasto.do_statics(true, 10);
+
+    // add wind model
+    auto wind_model = std::make_shared<seahowl::env::ConstantWind>();
+    system_core.fluid_model = wind_model;
+    wind_model->shear_coefficient = 0.12;
+    wind_model->reference_height = turbine.elasto.rna.rotor->body_hub->get_position().z();
+    wind_model->set_wind_velocity(seahowl::Vector3d(12.0, 1.0, 0.0));
+
+    // initialize simulation
+    simulation.initialize();
+
+    // instantiate test dataset class (custom CSV)
+    TestFrameworkDataset test_dataset({false, (ref_dir / "test_yaw_control_snap.csv").generic_string(),
+                                       (test_dir / "test_yaw_control_snap.test.csv").generic_string()});
+    test_dataset.test_csv.add_function("time (s)", [&system_elasto]() { return system_elasto.get_time(); });
+    test_dataset.test_csv.add_function("yaw (rad)", [&turbine]() { return turbine.rna.elasto.get_yaw(); });
+    test_dataset.test_csv.add_function("towerbase moment (N)",
+                                       [&turbine]() { return turbine.tower.elasto.get_tower_base_moment(); });
+
+    // output values at time = 0
+    test_dataset.test_csv.write_row();
+
+    // simulation loop
+    while (system_core.get_time() < simulation.duration) {
+        // simulation step
+        simulation.step();
+        test_dataset.test_csv.write_row();
+    }
+
+    // compare ref and test CSVs
+    EvaluateTest(test_dataset);
 };
 
 TEST_F(TestController, IEA15) {
@@ -92,12 +330,8 @@ TEST_F(TestController, IEA15) {
 
         // simulation step
         simulation.step();
+        test_dataset.test_csv.write_row();
         istep += 1;
-
-        // check if time to store results
-        if ((int)round(1.0 / simulation.dt)) {
-            test_dataset.test_csv.write_row();
-        }
     }
 
     // compare ref and test CSVs

--- a/tests/unit_tests/test_rotor.cpp
+++ b/tests/unit_tests/test_rotor.cpp
@@ -43,7 +43,7 @@ TEST_F(TestRotor, mass) {
     rna.rotor->blades = blades;
     rna.build();
     rna.assemble(system_elasto);
-    rna.body_yaw_bearing->set_fixed(true);
+    rna.actuator_yaw->body_controller->set_fixed(true);
 
     system_elasto.do_statics(true, 0);
 


### PR DESCRIPTION
This PR adds pitch and yaw actuator dynamics using motors imposing values for the pitch and yaw angles according to controller demand. A timeseries of angle values can also be manually provided to the actuators.
The IEA15 controller test was updated (using pitch actuator dynamics), and additional tests for pitch and yaw  control were added (with and without actuator dynamics).