### PR TITLE
Stabilize added mass effect + add damping loads

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-* text=auto
+* text=auto eol=lf
 tests/unit_tests/data/**/*.csv filter=lfs diff=lfs merge=lfs -text

--- a/include/seahowl/aero/tower_aero.h
+++ b/include/seahowl/aero/tower_aero.h
@@ -37,6 +37,8 @@ class TowerAero : public ComponentFluid {
     std::vector<hydro::MorisonElement> elements;
     /** @brief Loads at center of tower elements. */
     std::vector<Vector3d> loads;
+    /** @brief Loads without component from structural acceleration at center of tower elements. */
+    std::vector<Vector3d> loads_noacc;
     /** @brief Added mass matrices at center of tower elements. */
     std::vector<Eigen::Matrix<double, 6, 6>> added_mass_matrices;
     /** @brief MacCamy and Fuchs Correction for large cylinders, Flag. */

--- a/include/seahowl/aero/tower_aero.h
+++ b/include/seahowl/aero/tower_aero.h
@@ -37,6 +37,8 @@ class TowerAero : public ComponentFluid {
     std::vector<hydro::MorisonElement> elements;
     /** @brief Loads at center of tower elements. */
     std::vector<Vector3d> loads;
+    /** @brief Added mass matrices at center of tower elements. */
+    std::vector<Eigen::Matrix<double, 6, 6>> added_mass_matrices;
     /** @brief MacCamy and Fuchs Correction for large cylinders, Flag. */
     bool use_MacCamyFuchs_correction = false;
     /** @brief Cd Correction for large cylinders, Flag. */

--- a/include/seahowl/elasto/chrono_adapters.h
+++ b/include/seahowl/elasto/chrono_adapters.h
@@ -98,6 +98,8 @@ class BodyElastoChrono : public BodyElasto, public EntityDynamicChrono {
     virtual double get_mass() override;
     virtual void set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) override;
     virtual Eigen::Matrix<double, 6, 6> get_added_mass_matrix() const override;
+    virtual void set_damping_matrix(const Eigen::Matrix<double, 6, 6>& matrix) override;
+    virtual Eigen::Matrix<double, 6, 6> get_damping_matrix() const override;
 };
 
 class NodeElastoChronoBase {
@@ -133,6 +135,8 @@ class NodeElastoChrono : public NodeElasto, public EntityDynamicChrono, public N
     virtual double get_mass() override;
     virtual void set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) override;
     virtual Eigen::Matrix<double, 6, 6> get_added_mass_matrix() const override;
+    virtual void set_damping_matrix(const Eigen::Matrix<double, 6, 6>& matrix) override;
+    virtual Eigen::Matrix<double, 6, 6> get_damping_matrix() const override;
     void set_properties(const BladeReferencePointElasto& ref, bool fpm = false);
     void set_properties(const TowerReferencePointElasto& ref);
 };
@@ -159,6 +163,8 @@ class NodeElastoChronoD : public NodeElasto, public NodeElastoChronoBase {
     virtual double get_mass() override;
     virtual void set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) override;
     virtual Eigen::Matrix<double, 6, 6> get_added_mass_matrix() const override;
+    virtual void set_damping_matrix(const Eigen::Matrix<double, 6, 6>& matrix) override;
+    virtual Eigen::Matrix<double, 6, 6> get_damping_matrix() const override;
 
     virtual void set_position(const Vector3d& position) override;
     virtual Vector3d get_position() const override;

--- a/include/seahowl/elasto/chrono_adapters.h
+++ b/include/seahowl/elasto/chrono_adapters.h
@@ -34,6 +34,8 @@ class ChLinkMateGeneric;
 class ChLinkTSDA;
 class ChLoadBodyBodyBushingGeneric;
 class ChSystem;
+class ChLoadAddedMass66;
+class ChLoadContainer;
 namespace fea {
 class ChNodeFEAbase;
 class ChNodeFEAxyzrot;
@@ -50,11 +52,6 @@ class ChMesh;
 
 namespace seahowl {
 namespace elasto {
-
-chrono::ChVector<double> vec2ch(const Vector3d& vector_in);
-Vector3d ch2vec(const chrono::ChVector<double>& vector_in);
-chrono::ChQuaternion<double> quat2ch(const Quaternion& quaternion_in);
-Quaternion ch2quat(const chrono::ChQuaternion<double>& quaternion_in);
 
 //
 class EntityDynamicChrono : public virtual EntityDynamic {
@@ -82,6 +79,7 @@ class BodyElastoChrono : public BodyElasto, public EntityDynamicChrono {
   public:
     /** @brief Pointer to underlying Chrono object. */
     std::shared_ptr<chrono::ChBody> chobj;
+    std::shared_ptr<chrono::ChLoadAddedMass66> chload66;
 
     BodyElastoChrono();
     virtual void set_mass(double mass) override;
@@ -98,12 +96,15 @@ class BodyElastoChrono : public BodyElasto, public EntityDynamicChrono {
     virtual void set_fixed(bool is_fixed) override;
     virtual bool is_fixed() const override;
     virtual double get_mass() override;
+    virtual void set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) override;
+    virtual Eigen::Matrix<double, 6, 6> get_added_mass_matrix() const override;
 };
 
 class NodeElastoChronoBase {
   public:
     /** @brief Pointer to underlying Chrono object. */
     std::shared_ptr<chrono::fea::ChNodeFEAbase> chobj;
+    std::shared_ptr<chrono::ChLoadAddedMass66> chload66;
 };
 
 /**
@@ -128,6 +129,10 @@ class NodeElastoChrono : public NodeElasto, public EntityDynamicChrono, public N
     virtual void accumulate_torque(const Vector3d& torque, bool is_local = true) override;
     virtual void set_fixed(bool is_fixed) override;
     virtual bool is_fixed() const override;
+    virtual void set_mass(double mass) override;
+    virtual double get_mass() override;
+    virtual void set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) override;
+    virtual Eigen::Matrix<double, 6, 6> get_added_mass_matrix() const override;
     void set_properties(const BladeReferencePointElasto& ref, bool fpm = false);
     void set_properties(const TowerReferencePointElasto& ref);
 };
@@ -150,6 +155,10 @@ class NodeElastoChronoD : public NodeElasto, public NodeElastoChronoBase {
     virtual void accumulate_torque(const Vector3d& torque, bool is_local = true) override;
     virtual void set_fixed(bool is_fixed) override;
     virtual bool is_fixed() const override;
+    virtual void set_mass(double mass) override;
+    virtual double get_mass() override;
+    virtual void set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) override;
+    virtual Eigen::Matrix<double, 6, 6> get_added_mass_matrix() const override;
 
     virtual void set_position(const Vector3d& position) override;
     virtual Vector3d get_position() const override;
@@ -300,6 +309,7 @@ class MeshElastoChrono : public MeshElasto {
   public:
     /** @brief Pointer to underlying Chrono object. */
     std::shared_ptr<chrono::fea::ChMesh> chobj;
+    std::shared_ptr<chrono::ChLoadContainer> chloadcontainer;
 
     MeshElastoChrono();
     virtual void add(NodeElasto& node) override;
@@ -313,6 +323,7 @@ class SystemElastoChrono : public SystemElasto {
   public:
     /** @brief Pointer to underlying Chrono object. */
     std::shared_ptr<chrono::ChSystem> chobj;
+    std::shared_ptr<chrono::ChLoadContainer> chloadcontainer;
 
     SystemElastoChrono();
     virtual void assemble() override;

--- a/include/seahowl/elasto/chrono_adapters.h
+++ b/include/seahowl/elasto/chrono_adapters.h
@@ -80,6 +80,7 @@ class BodyElastoChrono : public BodyElasto, public EntityDynamicChrono {
     /** @brief Pointer to underlying Chrono object. */
     std::shared_ptr<chrono::ChBody> chobj;
     std::shared_ptr<chrono::ChLoadLocal66> chload66;
+    std::shared_ptr<chrono::ChLoadContainer> chloadcontainer;
 
     BodyElastoChrono();
     virtual void set_mass(double mass) override;
@@ -107,6 +108,9 @@ class NodeElastoChronoBase {
     /** @brief Pointer to underlying Chrono object. */
     std::shared_ptr<chrono::fea::ChNodeFEAbase> chobj;
     std::shared_ptr<chrono::ChLoadLocal66> chload66;
+    std::shared_ptr<chrono::ChLoadContainer> chloadcontainer;
+
+    NodeElastoChronoBase();
 };
 
 /**
@@ -315,7 +319,7 @@ class MeshElastoChrono : public MeshElasto {
   public:
     /** @brief Pointer to underlying Chrono object. */
     std::shared_ptr<chrono::fea::ChMesh> chobj;
-    std::shared_ptr<chrono::ChLoadContainer> chloadcontainer;
+    std::vector<std::shared_ptr<chrono::ChLoadContainer>> chloadcontainers;
 
     MeshElastoChrono();
     virtual void add(NodeElasto& node) override;

--- a/include/seahowl/elasto/chrono_adapters.h
+++ b/include/seahowl/elasto/chrono_adapters.h
@@ -34,7 +34,7 @@ class ChLinkMateGeneric;
 class ChLinkTSDA;
 class ChLoadBodyBodyBushingGeneric;
 class ChSystem;
-class ChLoadAddedMass66;
+class ChLoadLocal66;
 class ChLoadContainer;
 namespace fea {
 class ChNodeFEAbase;
@@ -79,7 +79,7 @@ class BodyElastoChrono : public BodyElasto, public EntityDynamicChrono {
   public:
     /** @brief Pointer to underlying Chrono object. */
     std::shared_ptr<chrono::ChBody> chobj;
-    std::shared_ptr<chrono::ChLoadAddedMass66> chload66;
+    std::shared_ptr<chrono::ChLoadLocal66> chload66;
 
     BodyElastoChrono();
     virtual void set_mass(double mass) override;
@@ -104,7 +104,7 @@ class NodeElastoChronoBase {
   public:
     /** @brief Pointer to underlying Chrono object. */
     std::shared_ptr<chrono::fea::ChNodeFEAbase> chobj;
-    std::shared_ptr<chrono::ChLoadAddedMass66> chload66;
+    std::shared_ptr<chrono::ChLoadLocal66> chload66;
 };
 
 /**

--- a/include/seahowl/elasto/component_elasto.h
+++ b/include/seahowl/elasto/component_elasto.h
@@ -149,6 +149,16 @@ class ComponentElastoFEA : public virtual ComponentElasto {
                                  const Vector3d& offset);
 
     /**
+     * @brief Accumulates added mass matrix on a given FEA element.
+     *
+     * @param[in] matrix Added mass matrix to accumulate.
+     * @param[in] element_index Index of the element on which the load is accumulated.
+     * @param[in] eta Abscissa of the element within the range [-1, +1], with -1 at node1 and +1 at node2.
+     * @param[in] offset Offset from given abscissa along longitudinal axis of element.
+     */
+    void accumulate_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix, int element_index, double eta);
+
+    /**
      * @brief Returns all nodes positions (global frame of reference).
      */
     std::vector<Vector3d> get_nodes_positions() const;

--- a/include/seahowl/elasto/entities_elasto.h
+++ b/include/seahowl/elasto/entities_elasto.h
@@ -65,6 +65,18 @@ class EntityLoadable : public virtual EntityDynamic {
      * @param[in] is_local Whether the torque is applied from local or global reference frame.
      */
     virtual void accumulate_torque(const Vector3d& torque, bool is_local = true) = 0;
+
+    /**
+     * @brief Sets added mass matrix of body.
+     *
+     * @param[in] matrix Added mass matrix.
+     */
+    virtual void set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) = 0;
+
+    /**
+     * @brief Returns added mass matrix of body.
+     */
+    virtual Eigen::Matrix<double, 6, 6> get_added_mass_matrix() const = 0;
 };
 
 /**
@@ -121,6 +133,18 @@ class BodyElasto : public virtual EntityLoadable {
  */
 class NodeElasto : public virtual EntityLoadable {
   public:
+    /**
+     * @brief Sets mass of node.
+     *
+     * @param[in] mass Mass of node.
+     */
+    virtual void set_mass(double mass) = 0;
+
+    /**
+     * @brief Get mass of node.
+     */
+    virtual double get_mass() = 0;
+
     /**
      * @brief Fix node in space.
      *

--- a/include/seahowl/elasto/entities_elasto.h
+++ b/include/seahowl/elasto/entities_elasto.h
@@ -67,16 +67,28 @@ class EntityLoadable : public virtual EntityDynamic {
     virtual void accumulate_torque(const Vector3d& torque, bool is_local = true) = 0;
 
     /**
-     * @brief Sets added mass matrix of body.
+     * @brief Sets added mass matrix of entity.
      *
      * @param[in] matrix Added mass matrix.
      */
     virtual void set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) = 0;
 
     /**
-     * @brief Returns added mass matrix of body.
+     * @brief Returns added mass matrix of entity.
      */
     virtual Eigen::Matrix<double, 6, 6> get_added_mass_matrix() const = 0;
+
+    /**
+     * @brief Sets damping matrix of entity.
+     *
+     * @param[in] matrix Damping matrix.
+     */
+    virtual void set_damping_matrix(const Eigen::Matrix<double, 6, 6>& matrix) = 0;
+
+    /**
+     * @brief Returns damping matrix of entity.
+     */
+    virtual Eigen::Matrix<double, 6, 6> get_damping_matrix() const = 0;
 };
 
 /**

--- a/include/seahowl/elasto/floater_elasto.h
+++ b/include/seahowl/elasto/floater_elasto.h
@@ -29,8 +29,6 @@ class FloaterElasto : public FoundationElasto {
     std::unique_ptr<seahowl::elasto::Link> link_floater_entity;
     /** @brief Mooring system of the floater. */
     std::unique_ptr<seahowl::elasto::MooringSystemElasto> mooring_system;
-    /** @brief Damping matrix of floater.*/
-    Eigen::Matrix<double, 6, 6> damping_matrix;
     /** @brief Main body of floater.*/
     std::unique_ptr<seahowl::elasto::BodyElasto> body_main;
 

--- a/include/seahowl/elasto/tower_elasto.h
+++ b/include/seahowl/elasto/tower_elasto.h
@@ -53,6 +53,11 @@ class TowerElasto : public ComponentElastoFEA {
      */
     Vector3d get_tower_top_force() const;
 
+    /**
+     * @brief Resets accumulated loads at nodes of tower component.
+     */
+    virtual void reset_loads() override;
+
   private:
     /**
      * @brief Builds the blade with Timoshenko elements (lineic density, foreaft stiffness, sideside stiffness).

--- a/include/seahowl/hydro/morison.h
+++ b/include/seahowl/hydro/morison.h
@@ -65,8 +65,8 @@ class MorisonNode : public EntityDynamicEigen {
     HydroCoefficients coefficients;
     /** @brief Load calculated at node. */
     Vector3d load{0.0, 0.0, 0.0};
-    /** @brief Load from fluid acceleration. */
-    Vector3d load_fluid{0.0, 0.0, 0.0};
+    /** @brief Load from without component from structural acceleration. */
+    Vector3d load_noacc{0.0, 0.0, 0.0};
     /** @brief Added mass matrix (actually linear density). */
     Eigen::Matrix<double, 6, 6> added_mass_matrix = Eigen::Matrix<double, 6, 6>::Zero();
     /** @brief Diameter at node. */
@@ -100,7 +100,12 @@ class MorisonElement {
     Vector3d get_load() const;
 
     /**
-     * @brief Returns integrated load at center of element.
+     * @brief Returns integrated load (without component from structural acceleration) at center of element.
+     */
+    Vector3d get_load_noacc() const;
+
+    /**
+     * @brief Returns added mass matrix at center of element.
      */
     Eigen::Matrix<double, 6, 6> get_added_mass_matrix() const;
 

--- a/include/seahowl/hydro/morison.h
+++ b/include/seahowl/hydro/morison.h
@@ -61,10 +61,14 @@ extern MacCamyFuchsTable myMCFtable;
  */
 class MorisonNode : public EntityDynamicEigen {
   public:
-    /** @brief Load calculated at node. */
-    Vector3d load{0.0, 0.0, 0.0};
     /** @brief Hydrodynamic coefficients. */
     HydroCoefficients coefficients;
+    /** @brief Load calculated at node. */
+    Vector3d load{0.0, 0.0, 0.0};
+    /** @brief Load from fluid acceleration. */
+    Vector3d load_fluid{0.0, 0.0, 0.0};
+    /** @brief Added mass matrix (actually linear density). */
+    Eigen::Matrix<double, 6, 6> added_mass_matrix = Eigen::Matrix<double, 6, 6>::Zero();
     /** @brief Diameter at node. */
     double diameter = 0.0;
 
@@ -94,6 +98,11 @@ class MorisonElement {
      * @brief Returns integrated load at center of element.
      */
     Vector3d get_load() const;
+
+    /**
+     * @brief Returns integrated load at center of element.
+     */
+    Eigen::Matrix<double, 6, 6> get_added_mass_matrix() const;
 
     /**
      * @brief Get position of center of element.

--- a/src/aero/tower_aero.cpp
+++ b/src/aero/tower_aero.cpp
@@ -51,9 +51,12 @@ void TowerAero::build() {
     // elements
     elements.clear();
     loads.clear();
+    loads_noacc.clear();
+    added_mass_matrices.clear();
     for (int ii = 0; ii < discretized_points.size() - 1; ii++) {
         elements.push_back(MorisonElement(nodes[ii], nodes[ii + 1]));
         loads.push_back(Vector3d(0.0, 0.0, 0.0));
+        loads_noacc.push_back(Vector3d(0.0, 0.0, 0.0));
         added_mass_matrices.push_back(Eigen::Matrix<double, 6, 6>::Zero());
     }
 }
@@ -67,6 +70,7 @@ void TowerAero::compute_fluid_loads(const FluidModel& wind_model, double time) {
     // integrate loads over elements and store them
     for (int ii = 0; ii < elements.size(); ii++) {
         loads[ii] = elements[ii].get_load();
+        loads_noacc[ii] = elements[ii].get_load_noacc();
         added_mass_matrices[ii] = elements[ii].get_added_mass_matrix();
     }
 }

--- a/src/aero/tower_aero.cpp
+++ b/src/aero/tower_aero.cpp
@@ -54,6 +54,7 @@ void TowerAero::build() {
     for (int ii = 0; ii < discretized_points.size() - 1; ii++) {
         elements.push_back(MorisonElement(nodes[ii], nodes[ii + 1]));
         loads.push_back(Vector3d(0.0, 0.0, 0.0));
+        added_mass_matrices.push_back(Eigen::Matrix<double, 6, 6>::Zero());
     }
 }
 
@@ -66,5 +67,6 @@ void TowerAero::compute_fluid_loads(const FluidModel& wind_model, double time) {
     // integrate loads over elements and store them
     for (int ii = 0; ii < elements.size(); ii++) {
         loads[ii] = elements[ii].get_load();
+        added_mass_matrices[ii] = elements[ii].get_added_mass_matrix();
     }
 }

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -316,7 +316,6 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def_property_readonly(
             "body_main", [](seahowl::elasto::FloaterElasto& floater) { return floater.body_main.get(); },
             py::return_value_policy::reference_internal)
-        .def_readwrite("damping_matrix", &seahowl::elasto::FloaterElasto::damping_matrix)
         .def("add_body", &seahowl::elasto::FloaterElasto::add_body)
         .def("get_body", &seahowl::elasto::FloaterElasto::get_body, py::return_value_policy::reference_internal)
         .def("add_fairlead", &seahowl::elasto::FloaterElasto::add_fairlead)

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -38,6 +38,7 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("set_inertia_diagonal", &seahowl::elasto::BodyElasto::set_inertia_diagonal)
         .def("set_inertia_matrix", &seahowl::elasto::BodyElasto::set_inertia_matrix)
         .def("get_inertia_matrix", &seahowl::elasto::BodyElasto::get_inertia_matrix)
+        .def("set_added_mass_matrix", &seahowl::elasto::BodyElasto::set_added_mass_matrix)
         .def("set_fixed", &seahowl::elasto::BodyElasto::set_fixed);
     py::class_<seahowl::elasto::NodeElasto, std::shared_ptr<seahowl::elasto::NodeElasto>,
                seahowl::elasto::EntityLoadable>(m_elasto, "NodeElasto", pybind11::multiple_inheritance())

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -32,7 +32,9 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("accumulate_force", &seahowl::elasto::EntityLoadable::accumulate_force)
         .def("accumulate_torque", &seahowl::elasto::EntityLoadable::accumulate_torque)
         .def("set_added_mass_matrix", &seahowl::elasto::EntityLoadable::set_added_mass_matrix)
-        .def("get_added_mass_matrix", &seahowl::elasto::EntityLoadable::get_added_mass_matrix);
+        .def("get_added_mass_matrix", &seahowl::elasto::EntityLoadable::get_added_mass_matrix)
+        .def("set_damping_matrix", &seahowl::elasto::EntityLoadable::set_damping_matrix)
+        .def("get_damping_matrix", &seahowl::elasto::EntityLoadable::get_damping_matrix);
     py::class_<seahowl::elasto::BodyElasto, std::shared_ptr<seahowl::elasto::BodyElasto>,
                seahowl::elasto::EntityLoadable>(m_elasto, "BodyElasto", pybind11::multiple_inheritance())
         .def("set_mass", &seahowl::elasto::BodyElasto::set_mass)

--- a/src/bindings/python/pyseahowl_elasto.cpp
+++ b/src/bindings/python/pyseahowl_elasto.cpp
@@ -30,7 +30,9 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("set_torque", &seahowl::elasto::EntityLoadable::set_torque)
         .def("get_torque", &seahowl::elasto::EntityLoadable::get_torque)
         .def("accumulate_force", &seahowl::elasto::EntityLoadable::accumulate_force)
-        .def("accumulate_torque", &seahowl::elasto::EntityLoadable::accumulate_torque);
+        .def("accumulate_torque", &seahowl::elasto::EntityLoadable::accumulate_torque)
+        .def("set_added_mass_matrix", &seahowl::elasto::EntityLoadable::set_added_mass_matrix)
+        .def("get_added_mass_matrix", &seahowl::elasto::EntityLoadable::get_added_mass_matrix);
     py::class_<seahowl::elasto::BodyElasto, std::shared_ptr<seahowl::elasto::BodyElasto>,
                seahowl::elasto::EntityLoadable>(m_elasto, "BodyElasto", pybind11::multiple_inheritance())
         .def("set_mass", &seahowl::elasto::BodyElasto::set_mass)
@@ -38,7 +40,6 @@ void initialize_pyseahowl_elasto(py::module& m) {
         .def("set_inertia_diagonal", &seahowl::elasto::BodyElasto::set_inertia_diagonal)
         .def("set_inertia_matrix", &seahowl::elasto::BodyElasto::set_inertia_matrix)
         .def("get_inertia_matrix", &seahowl::elasto::BodyElasto::get_inertia_matrix)
-        .def("set_added_mass_matrix", &seahowl::elasto::BodyElasto::set_added_mass_matrix)
         .def("set_fixed", &seahowl::elasto::BodyElasto::set_fixed);
     py::class_<seahowl::elasto::NodeElasto, std::shared_ptr<seahowl::elasto::NodeElasto>,
                seahowl::elasto::EntityLoadable>(m_elasto, "NodeElasto", pybind11::multiple_inheritance())

--- a/src/bindings/python/pyseahowl_hydro.cpp
+++ b/src/bindings/python/pyseahowl_hydro.cpp
@@ -43,6 +43,7 @@ void initialize_pyseahowl_hydro(py::module& m) {
         .def(py::init<>())
         .def("compute_fluid_loads", &seahowl::hydro::MorisonNode::compute_fluid_loads)
         .def_readwrite("load", &seahowl::hydro::MorisonNode::load)
+        .def_readwrite("load_noacc", &seahowl::hydro::MorisonNode::load_noacc)
         .def_readwrite("diameter", &seahowl::hydro::MorisonNode::diameter)
         .def_readwrite("coefficients", &seahowl::hydro::MorisonNode::coefficients);
     py::class_<seahowl::hydro::MorisonElement, std::shared_ptr<seahowl::hydro::MorisonElement>>(m_hydro,

--- a/src/core/tower.cpp
+++ b/src/core/tower.cpp
@@ -100,7 +100,10 @@ void Tower::update_loads_elasto() {
     }
     auto offset = Vector3d(0.0, 0.0, 0.0);
     for (int ii = 0; ii < aero.loads.size(); ii++) {
-        elasto.accumulate_element_load(aero.loads[ii], Vector3d(0.0, 0.0, 0.0), mapping_aero2elasto_elements[ii].index,
-                                       mapping_aero2elasto_elements[ii].eta, offset);
+        elasto.accumulate_element_load(aero.loads_noacc[ii], Vector3d(0.0, 0.0, 0.0),
+                                       mapping_aero2elasto_elements[ii].index, mapping_aero2elasto_elements[ii].eta,
+                                       offset);
+        elasto.accumulate_mass_matrix(aero.added_mass_matrices[ii], mapping_aero2elasto_elements[ii].index,
+                                      mapping_aero2elasto_elements[ii].eta);
     }
 }

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -146,14 +146,9 @@ class ChLoadLocal66 : public ChLoadCustom {
     virtual ChLoadLocal66* Clone() const override { return new ChLoadLocal66(*this); }
 
     void SetAddedMassMatrix(const ChMatrixDynamic<double>& matrix) { added_mass_matrix = matrix; }
-
     void SetDampingMatrix(const ChMatrixDynamic<double>& matrix) { damping_matrix = matrix; }
-
-    void SetStiffnessMatrix(const ChMatrixDynamic<double>& matrix) { stiffness_matrix = matrix; }
-
     ChMatrixDynamic<double> GetAddedMassMatrix() const { return added_mass_matrix; }
     ChMatrixDynamic<double> GetDampingMatrix() const { return damping_matrix; }
-    ChMatrixDynamic<double> GetStiffnessMatrix() const { return stiffness_matrix; }
 
     // nothing happening here
     virtual void ComputeQ(ChState* state_x, ChStateDelta* state_w) override{};
@@ -190,8 +185,8 @@ class ChLoadLocal66 : public ChLoadCustom {
         // damping matrix terms (6x6)
         jacobians->R = rot66 * (damping_matrix * rot66.inverse());
 
-        // stiffness matrix terms (6x6)
-        jacobians->K = rot66 * (stiffness_matrix * rot66.inverse());
+        // stiffness matrix terms (6x6) - keeping it to zero here
+        jacobians->K = Eigen::Matrix<double, 6, 6>::Zero();
     };
 
     virtual void LoadIntLoadResidual_Mv(ChVectorDynamic<>& R, const ChVectorDynamic<>& w, const double c) override {
@@ -399,6 +394,21 @@ Eigen::Matrix<double, 6, 6> BodyElastoChrono::get_added_mass_matrix() const {
     return chload66->GetAddedMassMatrix();
 }
 
+void BodyElastoChrono::set_damping_matrix(const Eigen::Matrix<double, 6, 6>& matrix) {
+    if (!chload66) {
+        chload66 = std::make_shared<chrono::ChLoadLocal66>(chobj);
+    }
+    chload66->SetDampingMatrix(matrix);
+};
+
+Eigen::Matrix<double, 6, 6> BodyElastoChrono::get_damping_matrix() const {
+    if (!chload66) {
+        throw std::runtime_error("Cannot get damping matrix for " + std::string(typeid(*this).name()) +
+                                 ", it was not set.");
+    }
+    return chload66->GetDampingMatrix();
+}
+
 NodeElastoChrono::NodeElastoChrono(const Vector3d& position, const Quaternion& rotation) {
     chobj = chrono_types::make_shared<chrono::fea::ChNodeFEAxyzrot>(
         chrono::ChFrame<>(vec2ch(position), node_iec2ch(rotation)));
@@ -486,7 +496,23 @@ Eigen::Matrix<double, 6, 6> NodeElastoChrono::get_added_mass_matrix() const {
         throw std::runtime_error("Cannot get added mass matrix for " + std::string(typeid(*this).name()) +
                                  ", it was not set.");
     }
-    return rot66_iec2ch.transpose() * chload66->GetAddedMassMatrix() * rot66_iec2ch;
+    return rot66_iec2ch.inverse() * chload66->GetAddedMassMatrix() * rot66_iec2ch;
+}
+
+void NodeElastoChrono::set_damping_matrix(const Eigen::Matrix<double, 6, 6>& matrix) {
+    if (!chload66) {
+        chload66 = std::make_shared<chrono::ChLoadLocal66>(chobj);
+    }
+    auto mm = rot66_iec2ch * matrix * rot66_iec2ch.inverse();
+    chload66->SetDampingMatrix(mm);
+};
+
+Eigen::Matrix<double, 6, 6> NodeElastoChrono::get_damping_matrix() const {
+    if (!chload66) {
+        throw std::runtime_error("Cannot get damping matrix for " + std::string(typeid(*this).name()) +
+                                 ", it was not set.");
+    }
+    return rot66_iec2ch.inverse() * chload66->GetDampingMatrix() * rot66_iec2ch;
 }
 
 void NodeElastoChrono::set_fixed(bool is_fixed) {
@@ -661,6 +687,18 @@ void NodeElastoChronoD::set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>&
 Eigen::Matrix<double, 6, 6> NodeElastoChronoD::get_added_mass_matrix() const {
     if (!chload66) {
         throw std::runtime_error("Cannot get added mass matrix for " + std::string(typeid(*this).name()) +
+                                 ", it was not set.");
+    }
+}
+
+void NodeElastoChronoD::set_damping_matrix(const Eigen::Matrix<double, 6, 6>& matrix) {
+    throw std::runtime_error("Cannot set damping matrix for " + std::string(typeid(*this).name()) +
+                             ", not implemented for cable nodes.");
+};
+
+Eigen::Matrix<double, 6, 6> NodeElastoChronoD::get_damping_matrix() const {
+    if (!chload66) {
+        throw std::runtime_error("Cannot get damping matrix for " + std::string(typeid(*this).name()) +
                                  ", it was not set.");
     }
 }

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -128,11 +128,7 @@ Eigen::Matrix<double, 6, 6> rot66_iec2ch = get_iec2ch_rotation_matrix();
 namespace chrono {
 
 /**
- * @brief Derived Chrono load class for using local 6x6 added mass, damping, and stiffness matrices.
- *
- * (inspired by HydroChrono's ChLoadCustomMultiple implementation, see Chrono and HydroChrono sources for details).
- * Note: damping matrix here is not equivalent to applying a damping depending on current velocity of a body, this needs
- to be done explicitly outside of this class.
+ * @brief Derived Chrono load class for using local 6x6 added mass and damping matrices.
  */
 class ChLoadLocal66 : public ChLoadCustom {
   public:
@@ -150,8 +146,36 @@ class ChLoadLocal66 : public ChLoadCustom {
     ChMatrixDynamic<double> GetAddedMassMatrix() const { return added_mass_matrix; }
     ChMatrixDynamic<double> GetDampingMatrix() const { return damping_matrix; }
 
-    // nothing happening here
-    virtual void ComputeQ(ChState* state_x, ChStateDelta* state_w) override{};
+    // compute external forces manually
+    virtual void ComputeQ(ChState* state_x, ChStateDelta* state_w) override {
+        // sanity check
+        if (this->LoadGet_ndof_w() != 6) {
+            throw std::runtime_error("6x6 added mass matrix only works with entities with 6 DOFs.");
+        }
+
+        // matrices expressed in local system --> transformation needed
+        // Chrono sends:
+        // - translation components in global system
+        // - rotation components in global system
+        Eigen::Matrix<double, 6, 6> rot66 = Eigen::Matrix<double, 6, 6>::Zero();
+        ChMatrix33<> rot33(body_frame->GetRot());
+        Eigen::Matrix<double, 3, 3> rotI = Eigen::Matrix<double, 3, 3>::Identity();
+        rot66.block<3, 3>(0, 0) = rot33.block(0, 0, 3, 3);
+        rot66.block<3, 3>(3, 3) = rotI.block(0, 0, 3, 3);
+
+        // reset load_Q
+        load_Q = ChVectorDynamic<>(this->LoadGet_ndof_w()).setZero();
+
+        // damping force
+        auto vv = body_frame->GetPos_dt();
+        auto rv = body_frame->GetWvel_loc();
+        ChVectorDynamic<> vvv(this->LoadGet_ndof_w());
+        for (int ii = 0; ii < 3; ii++) {
+            vvv[ii] = vv[ii];
+            vvv[ii + 3] = rv[ii];
+        }
+        load_Q += -rot66 * (damping_matrix * (rot66.inverse() * vvv));
+    };
 
     // compute jacobians manually
     virtual void ComputeJacobian(ChState* state_x,
@@ -159,16 +183,6 @@ class ChLoadLocal66 : public ChLoadCustom {
                                  ChMatrixRef mK,
                                  ChMatrixRef mR,
                                  ChMatrixRef mM) override {
-        // sanity check
-        if (this->LoadGet_ndof_w() != 6) {
-            throw std::runtime_error("6x6 added mass matrix only works with entities with 6 DOFs.");
-        }
-        if (!body_frame) {
-            throw std::runtime_error("6x6 added mass matrix needs to have a body frame attached.");
-        }
-
-        jacobians->M = added_mass_matrix;
-
         // matrices expressed in local system --> transformation needed
         // Chrono sends:
         // - translation components in global system
@@ -227,7 +241,6 @@ class ChLoadLocal66 : public ChLoadCustom {
   private:
     ChMatrixDynamic<double> added_mass_matrix = Eigen::Matrix<double, 6, 6>::Zero();
     ChMatrixDynamic<double> damping_matrix = Eigen::Matrix<double, 6, 6>::Zero();
-    ChMatrixDynamic<double> stiffness_matrix = Eigen::Matrix<double, 6, 6>::Zero();
 
     std::shared_ptr<ChBodyFrame> body_frame;
 };

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -25,8 +25,8 @@
 // default mass value for checking if ChBody mass was set.
 const double MASS_NOTSET_VALUE = -1.2345e-12;
 
-namespace seahowl {
-namespace elasto {
+using namespace seahowl;
+using namespace seahowl::elasto;
 
 chrono::ChVector<double> vec2ch(const Vector3d& vector_in) {
     return chrono::ChVector<double>(vector_in[0], vector_in[1], vector_in[2]);
@@ -100,6 +100,116 @@ Vector3d vec_iec2ch(const Vector3d& vector_in) {
     // ==> need to rotate -90 degrees around IEC y-axis to transform to Chrono convention.
     return Vector3d(vector_in[2], vector_in[1], -vector_in[0]);
 }
+
+// convenience matrix for rotation from IEC to Chrono convention for nodes
+Eigen::Matrix<double, 6, 6> get_iec2ch_rotation_matrix() {
+    // IEC standard:
+    // x-axis: flapwise pointing towards nacelle,
+    // y-axis : edgewise pointing towards trailing edge,
+    // z-axis : longitudinal pointing towards blade tip.
+    // Chrono convention:
+    // x-axis: longitudinal pointing towards blade tip,
+    // y-axis : edgewise pointing towards trailing edge,
+    // z-axis : flapwise pointing away from nacelle.
+
+    Eigen::Matrix<double, 3, 3> rot33_iec2ch = AngleAxisd(PI / 2, Vector3d(0.0, 1.0, 0.0)).toRotationMatrix();
+    Eigen::Matrix<double, 6, 6> rot66_iec2ch = Eigen::Matrix<double, 6, 6>::Zero();
+    for (int ii = 0; ii < 3; ii++) {
+        for (int jj = 0; jj < 3; jj++) {
+            rot66_iec2ch(ii, jj) = rot33_iec2ch(ii, jj);
+            rot66_iec2ch(ii + 3, jj + 3) = rot33_iec2ch(ii, jj);
+        }
+    }
+    return rot66_iec2ch;
+}
+Eigen::Matrix<double, 6, 6> rot66_iec2ch = get_iec2ch_rotation_matrix();
+
+namespace chrono {
+/**
+ * @brief Derived Chrono load class for using 6x6 added mass, damping, and stiffness matrices.
+ *
+ * (inspired by HydroChrono's ChLoadCustomMultiple implementation, see Chrono and HydroChrono sources for details).
+ */
+class ChLoadAddedMass66 : public ChLoadCustom {
+  public:
+    ChLoadAddedMass66(std::shared_ptr<ChLoadable> mloadable) : ChLoadCustom(mloadable) {
+        added_mass_matrix.setZero(6, 6);
+        damping_matrix.setZero(6, 6);
+        stiffness_matrix.setZero(6, 6);
+    };
+
+    /**
+     * @brief "Virtual" copy constructor (covariant return type). Required from chrono inheritance.
+     */
+    virtual ChLoadAddedMass66* Clone() const override { return new ChLoadAddedMass66(*this); }
+
+    void SetAddedMassMatrix(const ChMatrixDynamic<double>& matrix) { added_mass_matrix = matrix; }
+
+    void SetDampingMatrix(const ChMatrixDynamic<double>& matrix) { damping_matrix = matrix; }
+
+    void SetStiffnessMatrix(const ChMatrixDynamic<double>& matrix) { stiffness_matrix = matrix; }
+
+    ChMatrixDynamic<double> GetAddedMassMatrix() const { return added_mass_matrix; }
+    ChMatrixDynamic<double> GetDampingMatrix() const { return damping_matrix; }
+    ChMatrixDynamic<double> GetStiffnessMatrix() const { return stiffness_matrix; }
+
+    // nothing happening here
+    virtual void ComputeQ(ChState* state_x, ChStateDelta* state_w) override{};
+
+    // compute jacobians manually
+    virtual void ComputeJacobian(ChState* state_x,
+                                 ChStateDelta* state_w,
+                                 ChMatrixRef mK,
+                                 ChMatrixRef mR,
+                                 ChMatrixRef mM) override {
+        // mass matrix (6x6)
+        jacobians->M = added_mass_matrix;
+        // damping matrix terms (6x6)
+        jacobians->R = damping_matrix;
+        // stiffness matrix terms (6x6)
+        jacobians->K = stiffness_matrix;
+    };
+
+    virtual void LoadIntLoadResidual_Mv(ChVectorDynamic<>& R, const ChVectorDynamic<>& w, const double c) override {
+        if (!this->jacobians)
+            return;
+        // fetch w as a contiguous vector
+        ChVectorDynamic<> grouped_w(this->LoadGet_ndof_w());
+        ChVectorDynamic<> grouped_cMv(this->LoadGet_ndof_w());
+        unsigned int rowQ = 0;
+        for (int i = 0; i < loadable->GetSubBlocks(); ++i) {
+            if (loadable->IsSubBlockActive(i)) {
+                unsigned int moffset = loadable->GetSubBlockOffset(i);
+
+                for (unsigned int row = 0; row < loadable->GetSubBlockSize(i); ++row) {
+                    grouped_w(rowQ) = w(row + moffset);
+                    ++rowQ;
+                }
+            }
+        }
+        // do computation R=c*M*v
+        grouped_cMv = c * this->jacobians->M * grouped_w;
+        rowQ = 0;
+        for (int i = 0; i < loadable->GetSubBlocks(); ++i) {
+            if (loadable->IsSubBlockActive(i)) {
+                unsigned int moffset = loadable->GetSubBlockOffset(i);
+                for (unsigned int row = 0; row < loadable->GetSubBlockSize(i); ++row) {
+                    R(row + moffset) += grouped_cMv(rowQ);
+                    ++rowQ;
+                }
+            }
+        }
+    }
+
+    virtual bool IsStiff() override { return true; }  // this to force the use of the inertial M, R and K matrices
+
+  private:
+    ChMatrixDynamic<double> added_mass_matrix;
+    ChMatrixDynamic<double> damping_matrix;
+    ChMatrixDynamic<double> stiffness_matrix;
+};
+
+}  // namespace chrono
 
 void EntityDynamicChrono::set_position(const Vector3d& position) {
     chobj->SetPos(vec2ch(position));
@@ -246,6 +356,17 @@ double BodyElastoChrono::get_mass() {
     return chobj->GetMass();
 }
 
+void BodyElastoChrono::set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) {
+    if (!chload66) {
+        chload66 = std::make_shared<chrono::ChLoadAddedMass66>(chobj);
+    }
+    chload66->SetAddedMassMatrix(matrix);
+};
+
+Eigen::Matrix<double, 6, 6> BodyElastoChrono::get_added_mass_matrix() const {
+    return chload66->GetAddedMassMatrix();
+}
+
 NodeElastoChrono::NodeElastoChrono(const Vector3d& position, const Quaternion& rotation) {
     chobj = chrono_types::make_shared<chrono::fea::ChNodeFEAxyzrot>(
         chrono::ChFrame<>(vec2ch(position), node_iec2ch(rotation)));
@@ -311,6 +432,27 @@ void NodeElastoChrono::accumulate_torque(const Vector3d& torque, bool is_local) 
     set_torque(get_torque(is_local) + torque, is_local);
 }
 
+void NodeElastoChrono::set_mass(double mass) {
+    chobj->SetMass(mass);
+}
+
+double NodeElastoChrono::get_mass() {
+    return chobj->GetMass();
+}
+
+void NodeElastoChrono::set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) {
+    if (!chload66) {
+        chload66 = std::make_shared<chrono::ChLoadAddedMass66>(chobj);
+    }
+    // Convert from IEC convention to Chrono convention.
+    auto mm = rot66_iec2ch * matrix * rot66_iec2ch.transpose();
+    chload66->SetAddedMassMatrix(mm);
+};
+
+Eigen::Matrix<double, 6, 6> NodeElastoChrono::get_added_mass_matrix() const {
+    return rot66_iec2ch.transpose() * chload66->GetAddedMassMatrix() * rot66_iec2ch;
+}
+
 void NodeElastoChrono::set_fixed(bool is_fixed) {
     chobj->SetFixed(is_fixed);
 }
@@ -321,24 +463,8 @@ bool NodeElastoChrono::is_fixed() const {
 
 void NodeElastoChrono::set_properties(const BladeReferencePointElasto& ref, bool fpm) {
     // Convert from IEC convention to Chrono convention.
-    // IEC standard:
-    // x-axis: flapwise pointing towards nacelle,
-    // y-axis : edgewise pointing towards trailing edge,
-    // z-axis : longitudinal pointing towards blade tip.
-    // Chrono convention:
-    // x-axis: longitudinal pointing towards blade tip,
-    // y-axis : edgewise pointing towards trailing edge,
-    // z-axis : flapwise pointing away from nacelle.
-    Eigen::Matrix<double, 3, 3> rot33 = AngleAxisd(PI / 2, Vector3d(0.0, 1.0, 0.0)).toRotationMatrix();
-    Eigen::Matrix<double, 6, 6> rot66 = Eigen::Matrix<double, 6, 6>::Zero();
-    for (int ii = 0; ii < 3; ii++) {
-        for (int jj = 0; jj < 3; jj++) {
-            rot66(ii, jj) = rot33(ii, jj);
-            rot66(ii + 3, jj + 3) = rot33(ii, jj);
-        }
-    }
-    auto mm = rot66 * ref.mass_matrix * rot66.transpose();
-    auto sm = rot66 * ref.stiffness_matrix * rot66.transpose();
+    auto mm = rot66_iec2ch * ref.mass_matrix * rot66_iec2ch.transpose();
+    auto sm = rot66_iec2ch * ref.stiffness_matrix * rot66_iec2ch.transpose();
 
     if (ref.damping_coefficients.size() != 5) {
         throw std::runtime_error("Damping coefficients for blade must be a vector of length 5 (got " +
@@ -481,6 +607,27 @@ void NodeElastoChronoD::accumulate_force(const Vector3d& force, bool is_local) {
 
 void NodeElastoChronoD::accumulate_torque(const Vector3d& torque, bool is_local) {
     set_torque(get_torque(is_local) + torque, is_local);
+}
+
+void NodeElastoChronoD::set_mass(double mass) {
+    chobj->SetMass(mass);
+}
+
+double NodeElastoChronoD::get_mass() {
+    return chobj->GetMass();
+}
+
+void NodeElastoChronoD::set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) {
+    if (!chload66) {
+        chload66 = std::make_shared<chrono::ChLoadAddedMass66>(chobj);
+    }
+    // Convert from IEC convention to Chrono convention.
+    auto mm = rot66_iec2ch * matrix * rot66_iec2ch.transpose();
+    chload66->SetAddedMassMatrix(mm);
+};
+
+Eigen::Matrix<double, 6, 6> NodeElastoChronoD::get_added_mass_matrix() const {
+    return chload66->GetAddedMassMatrix();
 }
 
 void NodeElastoChronoD::set_fixed(bool is_fixed) {
@@ -818,10 +965,15 @@ void LinkMatrixStiffnessDampingChrono::set_damping_matrix(const Eigen::Matrix<do
 
 MeshElastoChrono::MeshElastoChrono() {
     chobj = chrono_types::make_shared<chrono::fea::ChMesh>();
+    chloadcontainer = chrono_types::make_shared<chrono::ChLoadContainer>();
 }
 
 void MeshElastoChrono::add(NodeElasto& node) {
-    chobj->AddNode(dynamic_cast<NodeElastoChronoBase&>(node).chobj);
+    auto& ref = dynamic_cast<NodeElastoChronoBase&>(node);
+    chobj->AddNode(ref.chobj);
+    if (ref.chload66) {
+        chloadcontainer->Add(ref.chload66);
+    }
 }
 
 void MeshElastoChrono::add(ElementElasto& element) {
@@ -831,6 +983,8 @@ void MeshElastoChrono::add(ElementElasto& element) {
 SystemElastoChrono::SystemElastoChrono() {
     chobj = chrono_types::make_shared<chrono::ChSystemSMC>();
     set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
+    chloadcontainer = chrono_types::make_shared<chrono::ChLoadContainer>();
+    chobj->Add(chloadcontainer);
 
     // solver
     auto solver = chrono_types::make_shared<chrono::ChSolverSparseLU>();
@@ -953,11 +1107,16 @@ void SystemElastoChrono::set_gravitational_acceleration(const Vector3d& gravitat
 }
 
 void SystemElastoChrono::add(BodyElasto& body) {
-    chobj->Add(dynamic_cast<BodyElastoChrono&>(body).chobj);
+    auto& ref = dynamic_cast<BodyElastoChrono&>(body);
+    chobj->Add(ref.chobj);
+    if (ref.chload66) {
+        chloadcontainer->Add(ref.chload66);
+    }
 }
 
 void SystemElastoChrono::add(MeshElasto& mesh) {
     chobj->Add(dynamic_cast<MeshElastoChrono&>(mesh).chobj);
+    chobj->Add(dynamic_cast<MeshElastoChrono&>(mesh).chloadcontainer);
 }
 
 void SystemElastoChrono::add(Link& link) {
@@ -973,6 +1132,3 @@ void SystemElastoChrono::add(LinkMatrixStiffnessDamping& link) {
 void SystemElastoChrono::add(SpringLinear& spring) {
     chobj->Add(dynamic_cast<SpringLinearChrono&>(spring).chobj);
 }
-
-}  // namespace elasto
-}  // namespace seahowl

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -172,7 +172,7 @@ class ChLoadLocal66 : public ChLoadCustom {
         // matrices expressed in local system --> transformation needed
         // Chrono sends:
         // - translation components in global system
-        // - rotattion components in global system
+        // - rotation components in global system
         Eigen::Matrix<double, 6, 6> rot66 = Eigen::Matrix<double, 6, 6>::Zero();
         ChMatrix33<> rot33(body_frame->GetRot());
         Eigen::Matrix<double, 3, 3> rotI = Eigen::Matrix<double, 3, 3>::Identity();
@@ -300,6 +300,7 @@ Vector3d EntityDynamicChrono::get_rotational_acceleration(bool is_local) const {
 
 BodyElastoChrono::BodyElastoChrono() {
     chobj = chrono_types::make_shared<chrono::ChBody>();
+    chloadcontainer = chrono_types::make_shared<chrono::ChLoadContainer>();
     EntityDynamicChrono::chobj = chobj;
     set_mass(MASS_NOTSET_VALUE);
     set_inertia_diagonal(Vector3d(MASS_NOTSET_VALUE, MASS_NOTSET_VALUE, MASS_NOTSET_VALUE));
@@ -382,6 +383,7 @@ double BodyElastoChrono::get_mass() {
 void BodyElastoChrono::set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) {
     if (!chload66) {
         chload66 = std::make_shared<chrono::ChLoadLocal66>(chobj);
+        chloadcontainer->Add(chload66);
     }
     chload66->SetAddedMassMatrix(matrix);
 };
@@ -397,6 +399,7 @@ Eigen::Matrix<double, 6, 6> BodyElastoChrono::get_added_mass_matrix() const {
 void BodyElastoChrono::set_damping_matrix(const Eigen::Matrix<double, 6, 6>& matrix) {
     if (!chload66) {
         chload66 = std::make_shared<chrono::ChLoadLocal66>(chobj);
+        chloadcontainer->Add(chload66);
     }
     chload66->SetDampingMatrix(matrix);
 };
@@ -407,6 +410,10 @@ Eigen::Matrix<double, 6, 6> BodyElastoChrono::get_damping_matrix() const {
                                  ", it was not set.");
     }
     return chload66->GetDampingMatrix();
+}
+
+NodeElastoChronoBase::NodeElastoChronoBase() {
+    chloadcontainer = chrono_types::make_shared<chrono::ChLoadContainer>();
 }
 
 NodeElastoChrono::NodeElastoChrono(const Vector3d& position, const Quaternion& rotation) {
@@ -485,6 +492,7 @@ double NodeElastoChrono::get_mass() {
 void NodeElastoChrono::set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) {
     if (!chload66) {
         chload66 = std::make_shared<chrono::ChLoadLocal66>(chobj);
+        chloadcontainer->Add(chload66);
     }
     // Convert from IEC convention to Chrono convention.
     auto mm = rot66_iec2ch * (matrix * rot66_iec2ch.transpose());
@@ -502,6 +510,7 @@ Eigen::Matrix<double, 6, 6> NodeElastoChrono::get_added_mass_matrix() const {
 void NodeElastoChrono::set_damping_matrix(const Eigen::Matrix<double, 6, 6>& matrix) {
     if (!chload66) {
         chload66 = std::make_shared<chrono::ChLoadLocal66>(chobj);
+        chloadcontainer->Add(chload66);
     }
     auto mm = rot66_iec2ch * matrix * rot66_iec2ch.inverse();
     chload66->SetDampingMatrix(mm);
@@ -1038,14 +1047,17 @@ void LinkMatrixStiffnessDampingChrono::set_damping_matrix(const Eigen::Matrix<do
 
 MeshElastoChrono::MeshElastoChrono() {
     chobj = chrono_types::make_shared<chrono::fea::ChMesh>();
-    chloadcontainer = chrono_types::make_shared<chrono::ChLoadContainer>();
+    chloadcontainers.clear();
 }
 
 void MeshElastoChrono::add(NodeElasto& node) {
     auto& ref = dynamic_cast<NodeElastoChronoBase&>(node);
     chobj->AddNode(ref.chobj);
-    if (ref.chload66) {
-        chloadcontainer->Add(ref.chload66);
+    chloadcontainers.push_back(ref.chloadcontainer);
+
+    // if mesh was already added to system, add container to system directly
+    if (chobj->GetSystem() != nullptr) {
+        chobj->GetSystem()->Add(ref.chloadcontainer);
     }
 }
 
@@ -1182,14 +1194,17 @@ void SystemElastoChrono::set_gravitational_acceleration(const Vector3d& gravitat
 void SystemElastoChrono::add(BodyElasto& body) {
     auto& ref = dynamic_cast<BodyElastoChrono&>(body);
     chobj->Add(ref.chobj);
-    if (ref.chload66) {
-        chloadcontainer->Add(ref.chload66);
-    }
+    chobj->Add(ref.chloadcontainer);
 }
 
 void SystemElastoChrono::add(MeshElasto& mesh) {
-    chobj->Add(dynamic_cast<MeshElastoChrono&>(mesh).chobj);
-    chobj->Add(dynamic_cast<MeshElastoChrono&>(mesh).chloadcontainer);
+    auto& mesh_chrono = dynamic_cast<MeshElastoChrono&>(mesh);
+    chobj->Add(mesh_chrono.chobj);
+
+    // add all existing load containers to system
+    for (auto& container : mesh_chrono.chloadcontainers) {
+        chobj->Add(container);
+    }
 }
 
 void SystemElastoChrono::add(Link& link) {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 #include <memory>
 #include <spdlog/spdlog.h>
+#include <typeinfo>
 
 // default mass value for checking if ChBody mass was set.
 const double MASS_NOTSET_VALUE = -1.2345e-12;
@@ -125,23 +126,24 @@ Eigen::Matrix<double, 6, 6> get_iec2ch_rotation_matrix() {
 Eigen::Matrix<double, 6, 6> rot66_iec2ch = get_iec2ch_rotation_matrix();
 
 namespace chrono {
+
 /**
- * @brief Derived Chrono load class for using 6x6 added mass, damping, and stiffness matrices.
+ * @brief Derived Chrono load class for using local 6x6 added mass, damping, and stiffness matrices.
  *
  * (inspired by HydroChrono's ChLoadCustomMultiple implementation, see Chrono and HydroChrono sources for details).
+ * Note: damping matrix here is not equivalent to applying a damping depending on current velocity of a body, this needs
+ to be done explicitly outside of this class.
  */
-class ChLoadAddedMass66 : public ChLoadCustom {
+class ChLoadLocal66 : public ChLoadCustom {
   public:
-    ChLoadAddedMass66(std::shared_ptr<ChLoadable> mloadable) : ChLoadCustom(mloadable) {
-        added_mass_matrix.setZero(6, 6);
-        damping_matrix.setZero(6, 6);
-        stiffness_matrix.setZero(6, 6);
-    };
+    ChLoadLocal66(std::shared_ptr<ChBody> mloadable) : ChLoadCustom(mloadable) { body_frame = mloadable; }
+
+    ChLoadLocal66(std::shared_ptr<fea::ChNodeFEAxyzrot> mloadable) : ChLoadCustom(mloadable) { body_frame = mloadable; }
 
     /**
      * @brief "Virtual" copy constructor (covariant return type). Required from chrono inheritance.
      */
-    virtual ChLoadAddedMass66* Clone() const override { return new ChLoadAddedMass66(*this); }
+    virtual ChLoadLocal66* Clone() const override { return new ChLoadLocal66(*this); }
 
     void SetAddedMassMatrix(const ChMatrixDynamic<double>& matrix) { added_mass_matrix = matrix; }
 
@@ -162,12 +164,34 @@ class ChLoadAddedMass66 : public ChLoadCustom {
                                  ChMatrixRef mK,
                                  ChMatrixRef mR,
                                  ChMatrixRef mM) override {
-        // mass matrix (6x6)
+        // sanity check
+        if (this->LoadGet_ndof_w() != 6) {
+            throw std::runtime_error("6x6 added mass matrix only works with entities with 6 DOFs.");
+        }
+        if (!body_frame) {
+            throw std::runtime_error("6x6 added mass matrix needs to have a body frame attached.");
+        }
+
         jacobians->M = added_mass_matrix;
+
+        // matrices expressed in local system --> transformation needed
+        // Chrono sends:
+        // - translation components in global system
+        // - rotattion components in global system
+        Eigen::Matrix<double, 6, 6> rot66 = Eigen::Matrix<double, 6, 6>::Zero();
+        ChMatrix33<> rot33(body_frame->GetRot());
+        Eigen::Matrix<double, 3, 3> rotI = Eigen::Matrix<double, 3, 3>::Identity();
+        rot66.block<3, 3>(0, 0) = rot33.block(0, 0, 3, 3);
+        rot66.block<3, 3>(3, 3) = rotI.block(0, 0, 3, 3);
+
+        // mass matrix(6x6)
+        jacobians->M = rot66 * added_mass_matrix * rot66.inverse();
+
         // damping matrix terms (6x6)
-        jacobians->R = damping_matrix;
+        jacobians->R = rot66 * damping_matrix * rot66.inverse();
+
         // stiffness matrix terms (6x6)
-        jacobians->K = stiffness_matrix;
+        jacobians->K = rot66 * stiffness_matrix * rot66.inverse();
     };
 
     virtual void LoadIntLoadResidual_Mv(ChVectorDynamic<>& R, const ChVectorDynamic<>& w, const double c) override {
@@ -187,8 +211,10 @@ class ChLoadAddedMass66 : public ChLoadCustom {
                 }
             }
         }
+
         // do computation R=c*M*v
         grouped_cMv = c * this->jacobians->M * grouped_w;
+
         rowQ = 0;
         for (int i = 0; i < loadable->GetSubBlocks(); ++i) {
             if (loadable->IsSubBlockActive(i)) {
@@ -204,9 +230,11 @@ class ChLoadAddedMass66 : public ChLoadCustom {
     virtual bool IsStiff() override { return true; }  // this to force the use of the inertial M, R and K matrices
 
   private:
-    ChMatrixDynamic<double> added_mass_matrix;
-    ChMatrixDynamic<double> damping_matrix;
-    ChMatrixDynamic<double> stiffness_matrix;
+    ChMatrixDynamic<double> added_mass_matrix = Eigen::Matrix<double, 6, 6>::Zero();
+    ChMatrixDynamic<double> damping_matrix = Eigen::Matrix<double, 6, 6>::Zero();
+    ChMatrixDynamic<double> stiffness_matrix = Eigen::Matrix<double, 6, 6>::Zero();
+
+    std::shared_ptr<ChBodyFrame> body_frame;
 };
 
 }  // namespace chrono
@@ -358,12 +386,16 @@ double BodyElastoChrono::get_mass() {
 
 void BodyElastoChrono::set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) {
     if (!chload66) {
-        chload66 = std::make_shared<chrono::ChLoadAddedMass66>(chobj);
+        chload66 = std::make_shared<chrono::ChLoadLocal66>(chobj);
     }
     chload66->SetAddedMassMatrix(matrix);
 };
 
 Eigen::Matrix<double, 6, 6> BodyElastoChrono::get_added_mass_matrix() const {
+    if (!chload66) {
+        throw std::runtime_error("Cannot get added mass matrix for " + std::string(typeid(*this).name()) +
+                                 ", it was not set.");
+    }
     return chload66->GetAddedMassMatrix();
 }
 
@@ -442,7 +474,7 @@ double NodeElastoChrono::get_mass() {
 
 void NodeElastoChrono::set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) {
     if (!chload66) {
-        chload66 = std::make_shared<chrono::ChLoadAddedMass66>(chobj);
+        chload66 = std::make_shared<chrono::ChLoadLocal66>(chobj);
     }
     // Convert from IEC convention to Chrono convention.
     auto mm = rot66_iec2ch * matrix * rot66_iec2ch.transpose();
@@ -450,6 +482,10 @@ void NodeElastoChrono::set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& 
 };
 
 Eigen::Matrix<double, 6, 6> NodeElastoChrono::get_added_mass_matrix() const {
+    if (!chload66) {
+        throw std::runtime_error("Cannot get added mass matrix for " + std::string(typeid(*this).name()) +
+                                 ", it was not set.");
+    }
     return rot66_iec2ch.transpose() * chload66->GetAddedMassMatrix() * rot66_iec2ch;
 }
 
@@ -618,16 +654,15 @@ double NodeElastoChronoD::get_mass() {
 }
 
 void NodeElastoChronoD::set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix) {
-    if (!chload66) {
-        chload66 = std::make_shared<chrono::ChLoadAddedMass66>(chobj);
-    }
-    // Convert from IEC convention to Chrono convention.
-    auto mm = rot66_iec2ch * matrix * rot66_iec2ch.transpose();
-    chload66->SetAddedMassMatrix(mm);
+    throw std::runtime_error("Cannot set added mass matrix for " + std::string(typeid(*this).name()) +
+                             ", not implemented for cable nodes.");
 };
 
 Eigen::Matrix<double, 6, 6> NodeElastoChronoD::get_added_mass_matrix() const {
-    return chload66->GetAddedMassMatrix();
+    if (!chload66) {
+        throw std::runtime_error("Cannot get added mass matrix for " + std::string(typeid(*this).name()) +
+                                 ", it was not set.");
+    }
 }
 
 void NodeElastoChronoD::set_fixed(bool is_fixed) {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -707,10 +707,8 @@ void NodeElastoChronoD::set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>&
 };
 
 Eigen::Matrix<double, 6, 6> NodeElastoChronoD::get_added_mass_matrix() const {
-    if (!chload66) {
-        throw std::runtime_error("Cannot get added mass matrix for " + std::string(typeid(*this).name()) +
-                                 ", it was not set.");
-    }
+    throw std::runtime_error("Cannot get added mass matrix for " + std::string(typeid(*this).name()) +
+                             ", not implemented for cable nodes");
 }
 
 void NodeElastoChronoD::set_damping_matrix(const Eigen::Matrix<double, 6, 6>& matrix) {
@@ -719,10 +717,8 @@ void NodeElastoChronoD::set_damping_matrix(const Eigen::Matrix<double, 6, 6>& ma
 };
 
 Eigen::Matrix<double, 6, 6> NodeElastoChronoD::get_damping_matrix() const {
-    if (!chload66) {
-        throw std::runtime_error("Cannot get damping matrix for " + std::string(typeid(*this).name()) +
-                                 ", it was not set.");
-    }
+    throw std::runtime_error("Cannot get damping matrix for " + std::string(typeid(*this).name()) +
+                             ", not implemented for cable nodes");
 }
 
 void NodeElastoChronoD::set_fixed(bool is_fixed) {

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -185,13 +185,13 @@ class ChLoadLocal66 : public ChLoadCustom {
         rot66.block<3, 3>(3, 3) = rotI.block(0, 0, 3, 3);
 
         // mass matrix(6x6)
-        jacobians->M = rot66 * added_mass_matrix * rot66.inverse();
+        jacobians->M = rot66 * (added_mass_matrix * rot66.inverse());
 
         // damping matrix terms (6x6)
-        jacobians->R = rot66 * damping_matrix * rot66.inverse();
+        jacobians->R = rot66 * (damping_matrix * rot66.inverse());
 
         // stiffness matrix terms (6x6)
-        jacobians->K = rot66 * stiffness_matrix * rot66.inverse();
+        jacobians->K = rot66 * (stiffness_matrix * rot66.inverse());
     };
 
     virtual void LoadIntLoadResidual_Mv(ChVectorDynamic<>& R, const ChVectorDynamic<>& w, const double c) override {
@@ -477,7 +477,7 @@ void NodeElastoChrono::set_added_mass_matrix(const Eigen::Matrix<double, 6, 6>& 
         chload66 = std::make_shared<chrono::ChLoadLocal66>(chobj);
     }
     // Convert from IEC convention to Chrono convention.
-    auto mm = rot66_iec2ch * matrix * rot66_iec2ch.transpose();
+    auto mm = rot66_iec2ch * (matrix * rot66_iec2ch.transpose());
     chload66->SetAddedMassMatrix(mm);
 };
 
@@ -499,8 +499,8 @@ bool NodeElastoChrono::is_fixed() const {
 
 void NodeElastoChrono::set_properties(const BladeReferencePointElasto& ref, bool fpm) {
     // Convert from IEC convention to Chrono convention.
-    auto mm = rot66_iec2ch * ref.mass_matrix * rot66_iec2ch.transpose();
-    auto sm = rot66_iec2ch * ref.stiffness_matrix * rot66_iec2ch.transpose();
+    auto mm = rot66_iec2ch * (ref.mass_matrix * rot66_iec2ch.transpose());
+    auto sm = rot66_iec2ch * (ref.stiffness_matrix * rot66_iec2ch.transpose());
 
     if (ref.damping_coefficients.size() != 5) {
         throw std::runtime_error("Damping coefficients for blade must be a vector of length 5 (got " +

--- a/src/elasto/component_elasto.cpp
+++ b/src/elasto/component_elasto.cpp
@@ -152,6 +152,34 @@ void ComponentElastoFEA::accumulate_element_load(const Vector3d& load,
     node1->accumulate_torque(moment1 + (position + offset - node1->get_position()).cross(load1), false);
 }
 
+void ComponentElastoFEA::accumulate_mass_matrix(const Eigen::Matrix<double, 6, 6>& matrix,
+                                                int element_index,
+                                                double eta) {
+    // sanity check
+    if (element_index >= elements.size() || element_index < 0) {
+        throw std::runtime_error("Element index " + std::to_string(element_index) +
+                                 " does not exist (number of elements: " + std::to_string(elements.size()) + ").");
+    }
+
+    // get position and rotation
+    Vector3d position{0.0, 0.0, 0.0};
+    Quaternion rotation{0.0, 0.0, 0.0, 0.0};
+    evaluate_position_rotation(position, rotation, element_index, eta);
+
+    // apply loads
+    auto& element = elements[element_index];
+    // load on first node
+    double weight0 = 0.5 * abs(eta - 1);
+    auto node0 = element->nodes[0];
+    // load in global reference
+    node0->set_added_mass_matrix(node0->get_added_mass_matrix() + matrix * weight0);
+    // load on second node
+    double weight1 = 0.5 * abs(eta + 1);
+    auto node1 = element->nodes[1];
+    // load in global reference
+    node1->set_added_mass_matrix(node1->get_added_mass_matrix() + matrix * weight1);
+}
+
 std::vector<Vector3d> ComponentElastoFEA::get_nodes_positions() const {
     std::vector<Vector3d> positions;
     for (auto& node : nodes) {

--- a/src/elasto/floater_elasto.cpp
+++ b/src/elasto/floater_elasto.cpp
@@ -28,28 +28,6 @@ void FloaterElasto::presetup(double fraction) {
 }
 
 void FloaterElasto::prestep(double time, double dt) {
-    auto& floater_body = *body_main;
-    floater_body.reset_loads();
-
-    // apply viscous damping
-    // get local velocity (damping matrix expressed in local frame)
-    auto velocity_local = floater_body.get_rotation().inverse() * floater_body.get_velocity();
-    auto velocity_rot_local = floater_body.get_rotational_velocity(true);
-    // make vector of length 6
-    Eigen::Matrix<double, 6, 1> floater_velocity_vector(6);
-    floater_velocity_vector << velocity_local.x(), velocity_local.y(), velocity_local.z(), velocity_rot_local.x(),
-        velocity_rot_local.y(), velocity_rot_local.z();
-    // calculate damping force and moment
-    auto damping_vector = damping_matrix * (-floater_velocity_vector);
-    // project in global frame
-    auto damping_force =
-        floater_body.get_rotation() * seahowl::Vector3d(damping_vector(0), damping_vector(1), damping_vector(2));
-    auto damping_torque =
-        floater_body.get_rotation() * seahowl::Vector3d(damping_vector(3), damping_vector(4), damping_vector(5));
-    // apply damping
-    floater_body.accumulate_force(damping_force, false);
-    floater_body.accumulate_torque(damping_torque, false);
-
     // mooring system prestep
     mooring_system->prestep(time, dt);
 }

--- a/src/elasto/tower_elasto.cpp
+++ b/src/elasto/tower_elasto.cpp
@@ -48,7 +48,11 @@ void TowerElasto::build() {
     build_nodes(discretized_points0);
     // apply properties
     for (int ii = 0; ii < nodes.size(); ii++) {
-        std::dynamic_pointer_cast<NodeElastoChrono>(nodes[ii])->set_properties(discretized_points[ii]);
+        auto& node = nodes[ii];
+        std::dynamic_pointer_cast<NodeElastoChrono>(node)->set_properties(discretized_points[ii]);
+
+        // initialize added mass matrices to zero
+        node->set_added_mass_matrix(Eigen::Matrix<double, 6, 6>::Zero());
     }
 
     build_elements_tapered_timoshenko();
@@ -87,3 +91,11 @@ seahowl::Vector3d TowerElasto::get_tower_base_force() const {
 seahowl::Vector3d TowerElasto::get_tower_top_force() const {
     return elements.back()->get_force(1.0);
 }
+
+void TowerElasto::reset_loads() {
+    ComponentElastoFEA::reset_loads();
+    for (auto& node : nodes) {
+        // reinitialize added mass matrices to zero
+        node->set_added_mass_matrix(Eigen::Matrix<double, 6, 6>::Zero());
+    }
+};

--- a/src/hydro/morison.cpp
+++ b/src/hydro/morison.cpp
@@ -132,7 +132,7 @@ double MacCamyFuchsTable::interpolateCmBinarySearch(double D) {
 void MorisonNode::compute_fluid_loads(const env::FluidModel& fluid_model, double time) {
     // reset total load
     load = Vector3d(0.0, 0.0, 0.0);
-    load_fluid = Vector3d(0.0, 0.0, 0.0);
+    load_noacc = Vector3d(0.0, 0.0, 0.0);
     added_mass_matrix.setZero();
 
     auto position = get_position();
@@ -161,7 +161,7 @@ void MorisonNode::compute_fluid_loads(const env::FluidModel& fluid_model, double
         0.5 * fluid_density * coeff_drag_normal * diameter * velocity_relative_normal.norm() * velocity_relative_normal;
     auto load_drag_axial = 0.5 * fluid_density * coefficients.drag_axial * diameter * PI *
                            velocity_relative_axial.norm() * velocity_relative_axial;
-    load_fluid += load_drag_normal + load_drag_axial;
+    load_noacc += load_drag_normal + load_drag_axial;
 
     if (coefficients.inertia_factor != 0.0) {
         // fluid acceleration
@@ -185,7 +185,7 @@ void MorisonNode::compute_fluid_loads(const env::FluidModel& fluid_model, double
                                      (acceleration_fluid + coeff_added_mass_normal * acceleration_fluid_normal +
                                       coefficients.added_mass_axial * acceleration_fluid_axial);
 
-        load_fluid += load_added_mass_fluid * coefficients.inertia_factor;
+        load_noacc += load_added_mass_fluid * coefficients.inertia_factor;
 
         added_mass_matrix(0, 0) = fluid_density * area * coeff_added_mass_normal;
         added_mass_matrix(1, 1) = fluid_density * area * coeff_added_mass_normal;
@@ -200,8 +200,8 @@ void MorisonNode::compute_fluid_loads(const env::FluidModel& fluid_model, double
     // buoyancy
     Vector3d gravitational_acceleration{0.0, 0.0, -9.81};
     auto load_buoyancy = fluid_density * area * (-gravitational_acceleration);
-    load_fluid += load_buoyancy * coefficients.buoyancy_factor;
-    load += load_fluid;
+    load_noacc += load_buoyancy * coefficients.buoyancy_factor;
+    load += load_noacc;
 }
 
 MorisonElement::MorisonElement(const MorisonNode& node1, const MorisonNode& node2) : node1(node1), node2(node2) {
@@ -210,6 +210,10 @@ MorisonElement::MorisonElement(const MorisonNode& node1, const MorisonNode& node
 
 Vector3d MorisonElement::get_load() const {
     return 0.5 * (node1.load + node2.load) * length;
+}
+
+Vector3d MorisonElement::get_load_noacc() const {
+    return 0.5 * (node1.load_noacc + node2.load_noacc) * length;
 }
 
 Eigen::Matrix<double, 6, 6> MorisonElement::get_added_mass_matrix() const {

--- a/src/hydro/morison.cpp
+++ b/src/hydro/morison.cpp
@@ -132,6 +132,8 @@ double MacCamyFuchsTable::interpolateCmBinarySearch(double D) {
 void MorisonNode::compute_fluid_loads(const env::FluidModel& fluid_model, double time) {
     // reset total load
     load = Vector3d(0.0, 0.0, 0.0);
+    load_fluid = Vector3d(0.0, 0.0, 0.0);
+    added_mass_matrix.setZero();
 
     auto position = get_position();
     auto velocity = get_velocity();
@@ -159,39 +161,47 @@ void MorisonNode::compute_fluid_loads(const env::FluidModel& fluid_model, double
         0.5 * fluid_density * coeff_drag_normal * diameter * velocity_relative_normal.norm() * velocity_relative_normal;
     auto load_drag_axial = 0.5 * fluid_density * coefficients.drag_axial * diameter * PI *
                            velocity_relative_axial.norm() * velocity_relative_axial;
-    load += load_drag_normal + load_drag_axial;
+    load_fluid += load_drag_normal + load_drag_axial;
 
     if (coefficients.inertia_factor != 0.0) {
         // fluid acceleration
         auto acceleration_fluid = fluid_model.get_fluid_acceleration(position, time);
+        auto acceleration_fluid_axial = dir * acceleration_fluid.dot(dir);
+        auto acceleration_fluid_normal = acceleration_fluid - acceleration_fluid_axial;
         // relative acceleration
         auto acceleration = get_acceleration() * coefficients.nodal_acceleration_factor;
-        auto acceleration_relative = acceleration_fluid - acceleration;
-        auto acceleration_relative_axial = dir * acceleration_relative.dot(dir);
-        auto acceleration_relative_normal = acceleration_relative - acceleration_relative_axial;
+        auto acceleration_axial = dir * acceleration.dot(dir);
+        auto acceleration_normal = acceleration - acceleration_axial;
 
-        // added mass (with Cm = 1 + Ca)
-        auto load_added_mass_fluid = fluid_density * area * acceleration_fluid;
         double coeff_added_mass_normal;
-
         // Diffraction is relevant for dense fluids. For the air, the MacCamy and Fuchs correction not applicable.
         if (coefficients.use_MacCamyFuchs_correction && fluid_density > 500.0) {
             coeff_added_mass_normal = myMCFtable.interpolateCmBinarySearch(diameter) - 1.0;
         } else {
             coeff_added_mass_normal = coefficients.added_mass_normal;
         }
-        auto load_added_mass_normal = fluid_density * area * coeff_added_mass_normal * acceleration_relative_normal;
-        auto load_added_mass_axial = fluid_density * area * coefficients.added_mass_axial * acceleration_relative_axial;
-        // total inertia load
-        auto load_inertia =
-            (load_added_mass_fluid + load_added_mass_normal + load_added_mass_axial) * coefficients.inertia_factor;
-        load += load_inertia;
+        // added mass (with Cm = 1 + Ca)
+        auto load_added_mass_fluid = fluid_density * area *
+                                     (acceleration_fluid + coeff_added_mass_normal * acceleration_fluid_normal +
+                                      coefficients.added_mass_axial * acceleration_fluid_axial);
+
+        load_fluid += load_added_mass_fluid * coefficients.inertia_factor;
+
+        added_mass_matrix(0, 0) = fluid_density * area * coeff_added_mass_normal;
+        added_mass_matrix(1, 1) = fluid_density * area * coeff_added_mass_normal;
+        added_mass_matrix(2, 2) = fluid_density * area * coefficients.added_mass_axial;
+
+        // contributions from structure acceleration (Ca)
+        auto load_added_mass_normal = -fluid_density * area * coeff_added_mass_normal * acceleration_normal;
+        auto load_added_mass_axial = -fluid_density * area * coefficients.added_mass_axial * acceleration_axial;
+        load += (load_added_mass_normal + load_added_mass_axial) * coefficients.inertia_factor;
     }
 
     // buoyancy
     Vector3d gravitational_acceleration{0.0, 0.0, -9.81};
     auto load_buoyancy = fluid_density * area * (-gravitational_acceleration);
-    load += load_buoyancy * coefficients.buoyancy_factor;
+    load_fluid += load_buoyancy * coefficients.buoyancy_factor;
+    load += load_fluid;
 }
 
 MorisonElement::MorisonElement(const MorisonNode& node1, const MorisonNode& node2) : node1(node1), node2(node2) {
@@ -200,6 +210,10 @@ MorisonElement::MorisonElement(const MorisonNode& node1, const MorisonNode& node
 
 Vector3d MorisonElement::get_load() const {
     return 0.5 * (node1.load + node2.load) * length;
+}
+
+Eigen::Matrix<double, 6, 6> MorisonElement::get_added_mass_matrix() const {
+    return 0.5 * (node1.added_mass_matrix + node2.added_mass_matrix) * length;
 }
 
 Vector3d MorisonElement::get_position() const {

--- a/src/io/read_json.cpp
+++ b/src/io/read_json.cpp
@@ -868,15 +868,17 @@ void populate_turbine_from_json(const std::string& filepath,
             if (dm.size() != 6) {
                 throw std::runtime_error("Viscous damping matrix for floater body has to be defined as 6x6 matrices.");
             }
+            Eigen::Matrix<double, 6, 6> damping_matrix;
             for (int irow = 0; irow < 6; irow++) {
                 if (dm[irow].size() != 6) {
                     throw std::runtime_error(
                         "Viscous damping matrix for floater body has to be defined as 6x6 matrices.");
                 }
                 for (int icol = 0; icol < 6; icol++) {
-                    floater_elasto.damping_matrix(irow, icol) = dm[irow][icol];
+                    damping_matrix(irow, icol) = dm[irow][icol];
                 }
             }
+            floater_elasto.body_main->set_damping_matrix(damping_matrix);
 
             // core floater
             auto floater_core_ptr = std::make_shared<seahowl::core::Floater>(floater_elasto, floater_hydro);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_FILES
 	unit_tests/test_bemt.cpp
 	unit_tests/test_blade.cpp
 	unit_tests/test_components.cpp
+	unit_tests/test_entities.cpp
 	unit_tests/test_rotor.cpp
 	unit_tests/test_tower.cpp
 	unit_tests/test_turbine.cpp

--- a/tests/unit_tests/data/test_controller/ref/test_controller.csv
+++ b/tests/unit_tests/data/test_controller/ref/test_controller.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:26921e4068b52b002604ab8bae6ec8d3a080014ba63fcd9eac84b5b1022328f6
-size 426788
+oid sha256:012bf9b4c8eca3a03678596df65e64230f4f03b0f202bfeb49414b637b286897
+size 434658

--- a/tests/unit_tests/data/test_entities/ref/test_entities_added_mass_damping.csv
+++ b/tests/unit_tests/data/test_entities/ref/test_entities_added_mass_damping.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01c3a0d2b069f9fc3207b01eed7212a2ff8dd812bb6c984ecc83e7acf2d50dfd
+size 129555

--- a/tests/unit_tests/data/test_entities/ref/test_entities_added_mass_damping.csv
+++ b/tests/unit_tests/data/test_entities/ref/test_entities_added_mass_damping.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01c3a0d2b069f9fc3207b01eed7212a2ff8dd812bb6c984ecc83e7acf2d50dfd
-size 129555
+oid sha256:b05290adec96e27ec132009b921f6adc5ca1918258b25b24015f8c662dd0e4f2
+size 129254

--- a/tests/unit_tests/data/test_morison/ref/test_morison_analytical_comparison.csv
+++ b/tests/unit_tests/data/test_morison/ref/test_morison_analytical_comparison.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cb111aa2537d8c6123fe474c1756ebc26e259e6561783a0e27d4b1ef3bc394f
+size 74384

--- a/tests/unit_tests/data/test_morison/ref/test_morison_tower.csv
+++ b/tests/unit_tests/data/test_morison/ref/test_morison_tower.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5f3edebeca41027213e8642af6e7e41fba6d0df69b62309d93322a773aa0897
+size 43439

--- a/tests/unit_tests/data/test_turbine/ref/test_turbine_rpm_initial_pitch.csv
+++ b/tests/unit_tests/data/test_turbine/ref/test_turbine_rpm_initial_pitch.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a76a7c9b9982d4f6c14c0081a4b6ea410edc09ba3f14ce3cb4d4f6dfaef993a
-size 16134
+oid sha256:20aa31413ab06a69ea54e0f4512d3c6da5927ae80b7198412f1e551bffc0c87f
+size 16636

--- a/tests/unit_tests/data/test_turbine/ref/test_turbine_rpm_initial_pitch.csv
+++ b/tests/unit_tests/data/test_turbine/ref/test_turbine_rpm_initial_pitch.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:20aa31413ab06a69ea54e0f4512d3c6da5927ae80b7198412f1e551bffc0c87f
-size 16636
+oid sha256:e6d64a7b0e3273f43713e1c3930cad8a689dffc3d26905d2f6e776b5ae33a5f8
+size 16135

--- a/tests/unit_tests/test_entities.cpp
+++ b/tests/unit_tests/test_entities.cpp
@@ -1,0 +1,108 @@
+#include "fixture_components.h"
+
+#include <seahowl/elasto/chrono_adapters.h>
+#include <seahowl/commons/numerics.h>
+
+#include <gtest/gtest.h>
+#include <filesystem>  // C++17
+using std::filesystem::path;
+
+using namespace seahowl;
+using namespace seahowl::elasto;
+
+// The fixture for testing
+class TestEntities : public FixtureComponents {
+  protected:
+    TestEntities() : FixtureComponents() {
+        ref_dir /= "test_entities/ref";
+        test_dir /= "test_entities/test";
+    }
+};
+
+TEST_F(TestEntities, added_mass_damping) {
+    double dt = 0.1;
+    double duration = 30.0;
+
+    // system
+    auto system_elasto = SystemElastoChrono();
+    system_elasto.set_gravitational_acceleration(Vector3d(0.0, 0.0, -9.81));
+
+    // bodies
+    std::vector<seahowl::elasto::BodyElastoChrono> bodies;
+    for (int ii; ii < 7; ii++) {
+        // create body
+        bodies.push_back(seahowl::elasto::BodyElastoChrono());
+        auto& body = bodies.back();
+        system_elasto.add(body);
+        // mass and inertia
+        body.set_mass(1.0);
+        Eigen::Matrix<double, 3, 3> matrix_inertia = Eigen::Matrix<double, 3, 3>::Zero();
+        matrix_inertia(0, 0) = 1.0;
+        matrix_inertia(1, 1) = 1.0;
+        matrix_inertia(2, 2) = 1.0;
+        body.set_inertia_matrix(matrix_inertia);
+    }
+
+    double added_mass_value = 3.0;
+    double damping_value = 0.1;
+    Eigen::Matrix<double, 6, 6> matrix_am = Eigen::Matrix<double, 6, 6>::Zero();
+    Eigen::Matrix<double, 6, 6> matrix_damping = Eigen::Matrix<double, 6, 6>::Zero();
+    matrix_am(2, 2) = added_mass_value;
+    matrix_am(5, 5) = added_mass_value;
+    matrix_damping(2, 2) = damping_value;
+    matrix_damping(5, 5) = damping_value;
+
+    seahowl::Quaternion rot(seahowl::AngleAxisd(-seahowl::PI / 2.0, seahowl::Vector3d(0.0, 1.0, 0.0)));
+
+    // body 1: added mass matrix
+    bodies[1].set_added_mass_matrix(matrix_am);
+
+    // body 2: added mass matrix and rotation
+    bodies[2].set_added_mass_matrix(matrix_am);
+    bodies[2].set_rotation(rot);
+
+    // body 3: damping matrix
+    bodies[3].set_damping_matrix(matrix_damping);
+
+    // body 4: damping matrix and rotation
+    bodies[4].set_damping_matrix(matrix_damping);
+    bodies[4].set_rotation(rot);
+
+    // body 5: damping and added mass matrices
+    bodies[5].set_damping_matrix(matrix_damping);
+    bodies[5].set_added_mass_matrix(matrix_am);
+
+    // body 6: damping and added mass matrices and rotation
+    bodies[6].set_damping_matrix(matrix_damping);
+    bodies[6].set_added_mass_matrix(matrix_am);
+    bodies[6].set_rotation(rot);
+
+    for (auto& body : bodies) {
+        body.set_torque(seahowl::Vector3d(0.0, 0.0, 10.0), false);  // add torque in global Z
+    }
+
+    double current_time = 0.0;
+
+    // Setup TestFwDataSet
+    TestFrameworkDataset test_dataset({false, (ref_dir / "test_entities_added_mass_damping.csv").generic_string(),
+                                       (test_dir / "test_entities_added_mass_damping.test.csv").generic_string()});
+
+    test_dataset.test_csv.add_function("time (s)", [&current_time] { return current_time; });
+    int idx_body = 0;
+    for (auto& body : bodies) {
+        test_dataset.test_csv.add_function("z pos body" + std::to_string(idx_body) + " (m)",
+                                           [&body] { return body.get_position(); });
+        test_dataset.test_csv.add_function("velocity rotation body" + std::to_string(idx_body) + " (rad/s)",
+                                           [&body] { return body.get_rotational_velocity(true); });
+        idx_body += 1;
+    }
+
+    // loop
+    while (current_time <= duration) {
+        test_dataset.test_csv.write_row();
+        system_elasto.step(dt);
+        current_time += dt;
+    }
+
+    EvaluateTest(test_dataset);
+}

--- a/tests/unit_tests/test_morison.cpp
+++ b/tests/unit_tests/test_morison.cpp
@@ -1,6 +1,12 @@
 #include "fixture_components.h"
 
 #include <seahowl/hydro/morison.h>
+#include <seahowl/env/wave_models.h>
+#include <seahowl/core/simulation.h>
+#ifdef HAVE_HYDROCHRONO
+    #include <seahowl/hydro/hydrochrono_adapter.h>
+    #include <hydroc/hydro_forces.h>
+#endif
 
 #include <gtest/gtest.h>
 #include <filesystem>  // C++17
@@ -16,6 +22,105 @@ class TestMorison : public FixtureComponents {
         test_dir /= "test_morison/test";
     }
 };
+
+#ifdef HAVE_HYDROCHRONO
+TEST_F(TestMorison, analytical_comparison) {
+    double rho = 1025.0;
+    auto position = seahowl::Vector3d(0.0, 0.0, -2.5);
+    double duration = 30.0;
+    double dt = 0.1;
+    double wave_height = 5.0;
+    double wave_period = 10.0;
+    double water_depth = 50.0;
+    double diameter = 5.0;
+
+    // create Morison coefficients
+    auto coefficients = seahowl::hydro::HydroCoefficients();
+    coefficients.drag_normal = 1.2;
+    coefficients.drag_axial = 0.0;
+    coefficients.added_mass_normal = 0.63;
+    coefficients.added_mass_axial = 0.0;
+    coefficients.buoyancy_factor = 0.0;
+
+    // create Morison node 1
+    auto node1 = seahowl::hydro::MorisonNode();
+    node1.diameter = diameter;
+    node1.coefficients = coefficients;
+    node1.set_position(position);
+
+    // create Morison node 2
+    auto node2 = seahowl::hydro::MorisonNode();
+    node2.diameter = diameter;
+    node2.coefficients = coefficients;
+    node2.set_position(position + seahowl::Vector3d(10.0, 0.0, 0.0));  // for element of length 10.0
+
+    // create Morison element
+    auto element = seahowl::hydro::MorisonElement(node1, node2);
+
+    // create Morison node 3 (node with a given rotation)
+    auto node3 = seahowl::hydro::MorisonNode();
+    node3.diameter = diameter;
+    node3.coefficients = coefficients;
+    node3.set_position(position);
+    seahowl::Quaternion rot;
+    rot = seahowl::AngleAxisd(80.0 / seahowl::PI, seahowl::Vector3d::UnitX()) *
+          seahowl::AngleAxisd(70.0 / seahowl::PI, seahowl::Vector3d::UnitY()) *
+          seahowl::AngleAxisd(-100.0 / seahowl::PI, seahowl::Vector3d::UnitZ());
+    node3.set_rotation(rot);
+
+    // environmental conditions
+    auto wave_model = seahowl::env::WaveModelHydroChrono();
+    auto waves_hydrochrono = std::make_shared<RegularWave>();
+    waves_hydrochrono->regular_wave_amplitude_ = wave_height / 2.0;
+    waves_hydrochrono->regular_wave_omega_ = 2 * seahowl::PI / wave_period;
+    waves_hydrochrono->mwl_ = 0.0;
+    waves_hydrochrono->water_depth_ = water_depth;
+    waves_hydrochrono->Initialize();
+    wave_model.waves = waves_hydrochrono;
+
+    // values to store
+    auto load_analytical = seahowl::Vector3d(0.0, 0.0, 0.0);
+    double time_current = 0.0;
+
+    // add functions to record values over time for the test
+    TestFrameworkDataset test_dataset({false, (ref_dir / "test_morison_analytical_comparison.csv").generic_string(),
+                                       (test_dir / "test_morison_analytical_comparison.test.csv").generic_string()});
+    test_dataset.test_csv.add_function("time (s)", [&time_current] { return time_current; });
+    test_dataset.test_csv.add_function("fluid velocity (m/s)", [&wave_model, &time_current, &position] {
+        return wave_model.get_fluid_velocity(position, time_current);
+    });
+    test_dataset.test_csv.add_function("fluid acceleration (m/s2)", [&wave_model, &time_current, &position] {
+        return wave_model.get_fluid_acceleration(position, time_current);
+    });
+    test_dataset.test_csv.add_function("load node1 (N/m)", [&node1] { return node1.load; });
+    test_dataset.test_csv.add_function("load node1 analytical (N/m)", [&load_analytical] { return load_analytical; });
+    test_dataset.test_csv.add_function("load node2 (N/m)", [&node2] { return node2.load; });
+    test_dataset.test_csv.add_function("load element (N)", [&element] { return element.get_load(); });
+    test_dataset.test_csv.add_function("load node3 (N/m)", [&node2] { return node2.load; });
+
+    while (time_current <= duration) {
+        // compute loads
+        node1.compute_fluid_loads(wave_model, time_current);
+        node2.compute_fluid_loads(wave_model, time_current);
+        node3.compute_fluid_loads(wave_model, time_current);
+
+        // compute loads with analytical formula
+        auto fluid_velocity = wave_model.get_fluid_velocity(position, time_current);
+        auto fluid_acceleration = wave_model.get_fluid_acceleration(position, time_current);
+        load_analytical[0] =
+            0.5 * rho * coefficients.drag_normal * node1.diameter * abs(fluid_velocity[0]) * fluid_velocity[0] +
+            rho * (1.0 + coefficients.added_mass_normal) * PI * pow(node1.diameter, 2) / 4.0 * fluid_acceleration[0];
+        load_analytical[2] =
+            0.5 * rho * coefficients.drag_axial * node1.diameter * abs(fluid_velocity[2]) * fluid_velocity[2] +
+            rho * (1.0 + coefficients.added_mass_axial) * PI * pow(node1.diameter, 2) / 4.0 * fluid_acceleration[2];
+
+        // store values
+        test_dataset.test_csv.write_row();
+        time_current += dt;
+    }
+    EvaluateTest(test_dataset);
+}
+#endif
 
 TEST_F(TestMorison, MCF_Table) {
     double table_Y;

--- a/tests/unit_tests/test_morison.cpp
+++ b/tests/unit_tests/test_morison.cpp
@@ -120,6 +120,111 @@ TEST_F(TestMorison, analytical_comparison) {
     }
     EvaluateTest(test_dataset);
 }
+
+TEST_F(TestMorison, tower_morison) {
+    // make simulation object
+    auto simulation = seahowl::core::Simulation();
+    simulation.dt = 0.1;
+    simulation.duration = 50.0;
+    simulation.outputs->dt_output = 9999.9;  // no output, using custom CSV
+    simulation.outputs->has_csv = false;
+    simulation.outputs->has_gui = false;
+    simulation.outputs->has_vtk = false;
+
+    double rho = 1025.0;
+    double wave_height = 5.0;
+    double wave_period = 10.0;
+    double water_depth = 50.0;
+
+    // create Morison coefficients
+    auto coefficients = seahowl::hydro::HydroCoefficients();
+    coefficients.drag_normal = 1.0;
+    coefficients.drag_axial = 1.0;
+    coefficients.added_mass_normal = 1.0;
+    coefficients.added_mass_axial = 1.0;
+    coefficients.buoyancy_factor = 0.0;
+
+    // environmental conditions
+    auto wave_model = std::make_shared<seahowl::env::WaveModelHydroChrono>();
+    auto waves_hydrochrono = std::make_shared<RegularWave>();
+    waves_hydrochrono->regular_wave_amplitude_ = wave_height / 2.0;
+    waves_hydrochrono->regular_wave_omega_ = 2 * seahowl::PI / wave_period;
+    waves_hydrochrono->mwl_ = 0.0;
+    waves_hydrochrono->water_depth_ = water_depth;
+    waves_hydrochrono->Initialize();
+    wave_model->waves = waves_hydrochrono;
+    simulation.system_core->fluid_model = wave_model;
+
+    // tower
+    auto tower_elasto = std::make_shared<seahowl::elasto::TowerElasto>();
+    simulation.system_core->elasto.add(tower_elasto);
+    auto tower_fluid = std::make_shared<seahowl::aero::TowerAero>();
+    simulation.system_core->aero.add(tower_fluid);
+    auto tower = std::make_shared<seahowl::core::Tower>(*tower_elasto, *tower_fluid);
+    simulation.system_core->add(tower);
+    // properties
+    auto density = 7850.0;
+    auto young_modulus = 2.11e11;
+    auto poisson_ratio = 0.3;
+    double diameter = 10.0;
+    double thickness = 0.055;
+    double zbottom = -50.0;  // bottom of tower
+    double ztop = -5.0;      // top of tower (keep it below wave trough)
+    // bottom
+    auto ref1_elasto = seahowl::elasto::TowerReferencePointElasto();
+    ref1_elasto.set_properties_cylinder(density, young_modulus, poisson_ratio, diameter, thickness, false);
+    ref1_elasto.coordinates = seahowl::Vector3d(0.0, 0.0, zbottom);
+    ref1_elasto.fraction = 0.0;
+    ref1_elasto.damping_coefficients = {0.1, 0.1, 0.1, 0.1, 0.0};
+    auto ref1_fluid = seahowl::aero::TowerReferencePointAero();
+    ref1_fluid.diameter = diameter;
+    ref1_fluid.coefficients = coefficients;
+    ref1_fluid.coordinates = seahowl::Vector3d(0.0, 0.0, zbottom);
+    ref1_fluid.fraction = 0.0;
+    // top
+    auto ref2_elasto = seahowl::elasto::TowerReferencePointElasto();
+    ref2_elasto.set_properties_cylinder(density, young_modulus, poisson_ratio, diameter, thickness, false);
+    ref2_elasto.coordinates = seahowl::Vector3d(0.0, 0.0, ztop);
+    ref2_elasto.fraction = 1.0;
+    ref2_elasto.damping_coefficients = {0.1, 0.1, 0.1, 0.1, 0.0};
+    auto ref2_fluid = seahowl::aero::TowerReferencePointAero();
+    ref2_fluid.diameter = diameter;
+    ref2_fluid.coefficients = coefficients;
+    ref2_fluid.coordinates = seahowl::Vector3d(0.0, 0.0, ztop);
+    ref2_fluid.fraction = 1.0;
+    //
+    tower_elasto->reference_points = {ref1_elasto, ref2_elasto};
+    tower_elasto->discretization_fractions = {10};
+    tower_fluid->reference_points = {ref1_fluid, ref2_fluid};
+    tower_fluid->discretization_fractions = {50};
+    //
+    tower->build();
+
+    // fix bottom of tower
+    tower_elasto->nodes.front()->set_fixed(true);
+
+    // add functions to record values over time for the test
+    TestFrameworkDataset test_dataset({false, (ref_dir / "test_morison_tower.csv").generic_string(),
+                                       (test_dir / "test_morison_tower.test.csv").generic_string()});
+    test_dataset.test_csv.add_function("time (s)", [&simulation] { return simulation.system_core->get_time(); });
+    test_dataset.test_csv.add_function("tower base moment (N)",
+                                       [&tower_elasto] { return tower_elasto->get_tower_base_moment(); });
+    test_dataset.test_csv.add_function("tower base force (N)",
+                                       [&tower_elasto] { return tower_elasto->get_tower_base_force(); });
+
+    simulation.system_core->elasto.do_statics(true, 10);
+    simulation.initialize();
+    // store initial values
+    test_dataset.test_csv.write_row();
+    while (simulation.system_core->get_time() <= simulation.duration) {
+        // compute loads
+        simulation.step();
+
+        // store values
+        test_dataset.test_csv.write_row();
+    }
+    EvaluateTest(test_dataset);
+}
 #endif
 
 TEST_F(TestMorison, MCF_Table) {


### PR DESCRIPTION
This PR allows for stabilization of the added mass effect for towers/piles by sending the terms depending on structural acceleration of the structure on the LHS (inside the mass matrix) instead of the RHS (applying it as an external load). It is also possible now to set a damping matrix (as well as added mass matrix) directly on a body or node.
Note that 2 tests were affected but this is due to numerical precision on axial torque (very negligible) rather than actual significant change in results.

Tests added:
- Added mass and damping on bodies
- Morison calculation vs analytical solution