### PR TITLE
Handle libdiscon when many turbines on GNU

### DIFF
--- a/include/seahowl/servo/controller_discon.h
+++ b/include/seahowl/servo/controller_discon.h
@@ -26,6 +26,8 @@ class DisconInterface {
     float& m_pitch = avrSWAP[41];   ///<@brief Pitch return controller states
     float& m_torque = avrSWAP[46];  ///<@brief Torque return controller states
 
+    ~DisconInterface();
+
     /// <summary>
     /// Reset Controller state as initial
     ///
@@ -43,11 +45,9 @@ class DisconInterface {
     /// <summary>
     /// Initialize the controller parameters
     /// </summary>
-    /// <param name="dt">timestep</param>
-    /// <param name="omega">rotor speed</param>
-    /// <param name="pitch">pitch collective</param>
-    /// <param name="nblades">number of blades</param>
-    virtual void Init(const std::string& libfile = u8"");
+    /// <param name="libfile">DISCON library path.</param>
+    /// <param name="tmp_folder">Folder for temporary DISCON libraries.</param>
+    virtual void Init(const std::string& libfile = u8"", const std::string& tmp_folder = u8"./output/tmp_discon");
 
     /// <summary>
     /// Call the DISCON controller
@@ -176,7 +176,11 @@ class DisconInterface {
     typedef void (*DISCON_routine)(float* avrSWAP, int* aviFAIL, char* accINFILE, char* avcOUTNAME, char* avcMSG);
     DISCON_routine DISCON;
 
+    // for DLL handling
     bool has_dll = false;
+    bool copied_dll = false;
+    std::string path_dll = "";
+    void* handler;
 
     static constexpr size_t MAX_SWAP = 500;
 

--- a/src/aero/aerodyn_adapter.cpp
+++ b/src/aero/aerodyn_adapter.cpp
@@ -267,11 +267,11 @@ void AeroDynInflowLib::CheckError() {
     if (ErrStat == 0) {
         return;
     } else if (ErrStat == 1) {
-        spdlog::info("AeroDyn INFO: {}.", ErrMsg);
+        spdlog::info("AeroDyn INFO: \"{}\".", ErrMsg);
     } else if (ErrStat == 2) {
-        spdlog::warn("AeroDyn WARNING: {}", ErrMsg);
+        spdlog::warn("AeroDyn WARNING: \"{}\".", ErrMsg);
     } else {
-        throw std::runtime_error("AeroDyn ERROR: " + std::string(ErrMsg));
+        throw std::runtime_error("AeroDyn ERROR: \"" + std::string(ErrMsg) + "\".");
     }
 }
 

--- a/src/env/inflowwind_adapter.cpp
+++ b/src/env/inflowwind_adapter.cpp
@@ -94,11 +94,11 @@ void InflowWindLib::CheckError() {
     if (ErrStat == 0) {
         return;
     } else if (ErrStat == 1) {
-        spdlog::info("InflowWind INFO: {}.", ErrMsg);
+        spdlog::info("InflowWind INFO: \"{}\".", ErrMsg);
     } else if (ErrStat == 2) {
-        spdlog::warn("InflowWind WARNING: {}.", ErrMsg);
+        spdlog::warn("InflowWind WARNING: \"{}\".", ErrMsg);
     } else {
-        throw std::runtime_error("InflowWind ERROR: " + std::string(ErrMsg));
+        throw std::runtime_error("InflowWind ERROR: \"" + std::string(ErrMsg) + "\".");
     }
 }
 

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -121,12 +121,7 @@ void seahowl::servo::ControllerDISCON::initialize(double time, double dt, const 
 
     seahowl::io::utils::check_file_exists(libfile);
 
-#ifndef __gnu_linux__
-    // if not on gnu, first copy the DLL in case there are several turbines using the same file.
-    libfile = seahowl::io::utils::copy_file_and_increment(libfile, output_folder + "/tmp");
-#endif
-
-    pImpl.Init(libfile);
+    pImpl.Init(libfile, output_folder + "/tmp_discon");
 
     spdlog::debug("Finished initialization of DISCON controller.");
 }
@@ -366,7 +361,21 @@ static std::vector<discon::ParamDef> ArrayInfo{
     {164, "in", 'R', "Yaw bearing angular acceleration", "rad/s2"}};
 }  // namespace discon
 
-void seahowl::servo::DisconInterface::Init(const std::string& libfile) {
+seahowl::servo::DisconInterface::~DisconInterface() {
+    if (handler) {
+#ifdef __unix__
+        dlclose(handler);
+#elif _WIN32
+        FreeLibrary((HMODULE)handler);
+#endif
+    }
+    if (copied_dll && path_dll != "") {
+        // remove copied discon library, if it exists.
+        std::filesystem::remove(path_dll);
+    }
+}
+
+void seahowl::servo::DisconInterface::Init(const std::string& libfile, const std::string& tmp_folder) {
     if (libfile != "") {
         if (!std::filesystem::exists(std::filesystem::path(libfile)) && libfile != "") {
             throw std::runtime_error("DISCON: dynamic library path for DISCON routine does not exist: " + libfile +
@@ -374,18 +383,40 @@ void seahowl::servo::DisconInterface::Init(const std::string& libfile) {
         }
         has_dll = true;
         // Load dynamic library and point to DISCON routine
+        spdlog::debug("DISCON: loading library {}.", libfile);
 #ifdef __unix__
-    #ifdef __gnu_linux__
-        void* handler = dlmopen(LM_ID_NEWLM, libfile.c_str(), RTLD_LAZY);
-    #else
-        void* handler = dlopen(libfile.c_str(), RTLD_LAZY);
-    #endif
+        handler = dlopen(libfile.c_str(), RTLD_NOLOAD | RTLD_LAZY);
+        if (handler) {
+            // library already loaded, first copy the library and load it with the new path.
+            auto newlibfile = seahowl::io::utils::copy_file_and_increment(libfile, tmp_folder);
+            spdlog::debug("DISCON: copied {} to {}.", libfile, newlibfile);
+            copied_dll = true;
+            path_dll = newlibfile;
+            handler = dlopen(newlibfile.c_str(), RTLD_LAZY);
+        } else {
+            // load library
+            copied_dll = false;
+            path_dll = libfile;
+            handler = dlopen(libfile.c_str(), RTLD_LAZY);
+        }
         DISCON = (DISCON_routine)dlsym(handler, "DISCON");
+#elif _WIN32
+        handler = (void*)GetModuleHandle(libfile.c_str());
+        if (handler) {
+            // library already loaded, first copy the library and load it with the new path.
+            auto newlibfile = seahowl::io::utils::copy_file_and_increment(libfile, tmp_folder);
+            spdlog::debug("DISCON: copied {} to {}.", libfile, newlibfile);
+            copied_dll = true;
+            path_dll = newlibfile;
+            handler = LoadLibrary(newlibfile.c_str());
+        } else {
+            copied_dll = false;
+            path_dll = libfile;
+            handler = (void*)LoadLibrary(libfile.c_str());
+        }
+        DISCON = (DISCON_routine)GetProcAddress((HMODULE)handler, "DISCON");
 #endif
-#ifdef _WIN32
-        HMODULE handler = LoadLibrary(libfile.c_str());
-        DISCON = (DISCON_routine)GetProcAddress(handler, "DISCON");
-#endif
+        spdlog::debug("DISCON: loaded {}.", path_dll);
     } else {
         spdlog::warn("DISCON: no dynamic library transmitted to DISCON interface.");
     }

--- a/src/servo/controller_discon.cpp
+++ b/src/servo/controller_discon.cpp
@@ -640,4 +640,13 @@ void seahowl::servo::DisconInterface::Call() {
     if (has_dll) {
         DISCON(avrSWAP, &aviFAIL, accINFILE, avcOUTNAME, avcMSG);
     }
+
+    // handle error, if any.
+    if (aviFAIL == 0) {
+        return;
+    } else if (aviFAIL > 0) {
+        spdlog::warn("DISCON WARNING: \"{}\".", avcMSG);
+    } else if (aviFAIL < 0) {
+        throw std::runtime_error("DISCON ERROR: \"" + std::string(avcMSG) + "\".");
+    }
 }

--- a/tests/unit_tests/test_controller.cpp
+++ b/tests/unit_tests/test_controller.cpp
@@ -338,6 +338,47 @@ TEST_F(TestController, IEA15) {
     EvaluateTest(test_dataset);
 }
 
+TEST_F(TestController, discon_50turbines) {
+    // make simulation object
+    auto simulation = seahowl::core::Simulation();
+    simulation.dt = 0.05;
+    simulation.duration = 0.1;
+    simulation.outputs->dt_output = 9999.9;  // no output, using custom CSV
+    simulation.outputs->has_csv = false;
+    simulation.outputs->has_gui = false;
+    simulation.outputs->has_vtk = false;
+
+    auto& system_core = *simulation.system_core;
+    auto& system_elasto = system_core.elasto;
+
+    // add turbine to system
+    for (int ii = 0; ii < 50; ii++) {
+        seahowl::io::add_turbine_to_system_from_json((DATADIR / "IEA15MW/onshore/turbine_rigid.json").generic_string(),
+                                                     system_core);
+        system_core.turbines.back()->elasto.translate(seahowl::Vector3d(200.0 * ii, 200.0 * ii, 0.0));
+    }
+    // statics
+    system_elasto.do_statics(true, 10);
+
+    // add wind model
+    auto wind_model = std::make_shared<seahowl::env::ConstantWind>();
+    system_core.fluid_model = wind_model;
+    wind_model->shear_coefficient = 0.12;
+    wind_model->reference_height = system_core.turbines[0]->elasto.rna.rotor->body_hub->get_position().z();
+    wind_model->set_wind_velocity(seahowl::Vector3d(12.0, 0.0, 0.0));
+
+    // initialize simulation
+    simulation.initialize();
+
+    // simulation loop
+    while (system_core.get_time() < simulation.duration) {
+        // simulation step
+        simulation.step();
+    }
+
+    // this test will throw an error if discon libraries cannot be loaded.
+}
+
 TEST_F(TestController, actuator_disk) {
     // general options
     bool visualization_on = true;


### PR DESCRIPTION
This PR is for handling dynamically loaded libdiscon libraries when compiled on GNU. There was an issue with dlmopen due to number of namespaces limitation.
With this new workflow, the libdiscon file is first copied if already loaded by the same process, and then deleted when exiting the application cleanly.