### PR TITLE
Update from Chrono 8.0.0 to 9.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,7 +461,8 @@ if(SEAHOWL_ENABLE_IRRLICHT)
     find_package(PNG CONFIG REQUIRED)
     find_package(JPEG REQUIRED)
     find_package(BZip2 REQUIRED)
-    target_link_libraries(seahowl_core PRIVATE PNG::PNG JPEG::JPEG BZip2::BZip2)
+    find_package(Irrlicht CONFIG REQUIRED)
+    target_link_libraries(seahowl_core PRIVATE PNG::PNG JPEG::JPEG BZip2::BZip2 Irrlicht)
 endif(SEAHOWL_ENABLE_IRRLICHT)
 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -203,7 +203,7 @@ make
 
 ### Core dependencies
 
-- Chrono (8.0.0): https://github.com/projectchrono/chrono
+- Chrono (9.0.1): https://github.com/projectchrono/chrono
 - nlohmann-json (v3.10.5): https://github.com/nlohmann/json
 - spdlog (v1.12.0): https://github.com/gabime/spdlog
 
@@ -214,7 +214,7 @@ make
 
 - AeroDyn (v4.0.2): https://github.com/OpenFAST/openfast
 - InflowWind (v4.0.2): https://github.com/OpenFAST/openfast
-- HydroChrono (v0.2.5): https://github.com/NREL/HydroChrono
+- HydroChrono (v0.2.6): https://github.com/NREL/HydroChrono
 
 #### Documentation
 

--- a/data/IEA15MW/onshore/turbine.json
+++ b/data/IEA15MW/onshore/turbine.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "aero": {
     "solver": "BEMT",
     "options": {

--- a/external/bash/dep-install-HydroChrono.cfg
+++ b/external/bash/dep-install-HydroChrono.cfg
@@ -1,7 +1,7 @@
 NAME="HydroChrono"
 ORDER=30
 GIT_URL="https://github.com/NREL/HydroChrono.git"
-GIT_TAG="v0.2.5"
+GIT_TAG="v0.2.6"
 OPTION="-DCMAKE_PREFIX_PATH=../../../install \
         -DHDF5_DIR=../../../install/share/cmake \
         -DHYDROCHRONO_ENABLE_IRRLICHT=OFF \

--- a/external/bash/dep-install-chrono.cfg
+++ b/external/bash/dep-install-chrono.cfg
@@ -1,7 +1,7 @@
 NAME="chrono"
 ORDER=20
 GIT_URL="https://github.com/projectchrono/chrono.git"
-GIT_TAG="8.0.0"
+GIT_TAG="9.0.1"
 OPTION="-DBUILD_TESTING=ON \
        -DBUILD_BENCHMARKING=OFF \
        -DENABLE_HDF5=OFF \

--- a/external/vcpkg/ports/chrono/chrono_custom_command.patch
+++ b/external/vcpkg/ports/chrono/chrono_custom_command.patch
@@ -1,8 +1,8 @@
 diff --git a/src/chrono_irrlicht/CMakeLists.txt b/src/chrono_irrlicht/CMakeLists.txt
-index acffe0cb6..9a188a5bc 100644
+index d6d9d47d6..ead5d5848 100644
 --- a/src/chrono_irrlicht/CMakeLists.txt
 +++ b/src/chrono_irrlicht/CMakeLists.txt
-@@ -168,34 +168,34 @@ endif()
+@@ -167,38 +167,38 @@ endif()
  # appropriate directory (depending on the build type); however, we use
  # copy_if_different.
  
@@ -11,9 +11,9 @@ index acffe0cb6..9a188a5bc 100644
 -  IF(DEFINED ENV{CONDA_BUILD})
 -    SET(CH_IRRLICHT_DLL "$ENV{PREFIX}/Library/bin/Irrlicht.dll")
 -  ELSEIF("${CH_COMPILER}" STREQUAL "COMPILER_MSVC")
--    SET(CH_IRRLICHT_DLL "${IRRLICHT_ROOT}/bin/Win32-VisualStudio/Irrlicht.dll")
+-    SET(CH_IRRLICHT_DLL "${IRRLICHT_INSTALL_DIR}/bin/Win32-VisualStudio/Irrlicht.dll")
 -  ELSEIF("${CH_COMPILER}" STREQUAL "COMPILER_MSVC_X64")
--    SET(CH_IRRLICHT_DLL "${IRRLICHT_ROOT}/bin/Win64-VisualStudio/Irrlicht.dll")
+-    SET(CH_IRRLICHT_DLL "${IRRLICHT_INSTALL_DIR}/bin/Win64-VisualStudio/Irrlicht.dll")
 -  ENDIF()
 -
 -  ADD_CUSTOM_COMMAND(
@@ -34,34 +34,42 @@ index acffe0cb6..9a188a5bc 100644
 -  SET(CH_IRRLICHT_DLL "${CH_IRRLICHT_DLL}" PARENT_SCOPE)
 -
 -ENDIF()
-+#IF(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-+#
-+#  IF(DEFINED ENV{CONDA_BUILD})
-+#    SET(CH_IRRLICHT_DLL "$ENV{PREFIX}/Library/bin/Irrlicht.dll")
-+#  ELSEIF("${CH_COMPILER}" STREQUAL "COMPILER_MSVC")
-+#    SET(CH_IRRLICHT_DLL "${IRRLICHT_ROOT}/bin/Win32-VisualStudio/Irrlicht.dll")
-+#  ELSEIF("${CH_COMPILER}" STREQUAL "COMPILER_MSVC_X64")
-+#    SET(CH_IRRLICHT_DLL "${IRRLICHT_ROOT}/bin/Win64-VisualStudio/Irrlicht.dll")
-+#  ENDIF()
-+#
-+#  ADD_CUSTOM_COMMAND(
-+#    TARGET ChronoEngine_irrlicht POST_BUILD
-+#    COMMAND ${CMAKE_COMMAND} -E make_directory
-+#            "${CMAKE_BINARY_DIR}/bin/$<CONFIGURATION>"
-+#    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-+#            "${CH_IRRLICHT_DLL}"
-+#            "${CMAKE_BINARY_DIR}/bin/$<CONFIGURATION>"
-+#    MAIN_DEPENDENCY ChronoEngine_irrlicht
-+#    COMMENT "Copying Irrlicht DLL..."
-+#  )
-+#
-+#  # copy the Irrlicht dll into the installed package to be on the safe side 
-+#  install(FILES "${CH_IRRLICHT_DLL}" DESTINATION bin)
-+#
-+#  # Make variable visible from outside this directory
-+#  SET(CH_IRRLICHT_DLL "${CH_IRRLICHT_DLL}" PARENT_SCOPE)
-+#
-+#ENDIF()
+-
+-if(CH_STATIC)
+-  SET(CH_IRRLICHT_LIB "${IRRLICHT_LIBRARY}" PARENT_SCOPE)
+-endif()
++# IF(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
++
++#   IF(DEFINED ENV{CONDA_BUILD})
++#     SET(CH_IRRLICHT_DLL "$ENV{PREFIX}/Library/bin/Irrlicht.dll")
++#   ELSEIF("${CH_COMPILER}" STREQUAL "COMPILER_MSVC")
++#     SET(CH_IRRLICHT_DLL "${IRRLICHT_INSTALL_DIR}/bin/Win32-VisualStudio/Irrlicht.dll")
++#   ELSEIF("${CH_COMPILER}" STREQUAL "COMPILER_MSVC_X64")
++#     SET(CH_IRRLICHT_DLL "${IRRLICHT_INSTALL_DIR}/bin/Win64-VisualStudio/Irrlicht.dll")
++#   ENDIF()
++
++#   ADD_CUSTOM_COMMAND(
++#     TARGET ChronoEngine_irrlicht POST_BUILD
++#     COMMAND ${CMAKE_COMMAND} -E make_directory
++#             "${CMAKE_BINARY_DIR}/bin/$<CONFIGURATION>"
++#     COMMAND ${CMAKE_COMMAND} -E copy_if_different
++#             "${CH_IRRLICHT_DLL}"
++#             "${CMAKE_BINARY_DIR}/bin/$<CONFIGURATION>"
++#     MAIN_DEPENDENCY ChronoEngine_irrlicht
++#     COMMENT "Copying Irrlicht DLL..."
++#   )
++
++#   # copy the Irrlicht dll into the installed package to be on the safe side 
++#   install(FILES "${CH_IRRLICHT_DLL}" DESTINATION bin)
++
++#   # Make variable visible from outside this directory
++#   SET(CH_IRRLICHT_DLL "${CH_IRRLICHT_DLL}" PARENT_SCOPE)
++
++# ENDIF()
++
++# if(CH_STATIC)
++#   SET(CH_IRRLICHT_LIB "${IRRLICHT_LIBRARY}" PARENT_SCOPE)
++# endif()
+ 
  
  #-------------------------------------------------------------------------------
- # Install the ChronoEngine_irrlicht library

--- a/external/vcpkg/ports/chrono/portfile.cmake
+++ b/external/vcpkg/ports/chrono/portfile.cmake
@@ -1,15 +1,15 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://github.com/projectchrono/chrono.git
-    REF 30cd3f2702cb58182e46d5b2724d2d2850a50e21
+    REF 2617649bf687456328a122b63dc0bb64df91394a
     PATCHES
       "chrono_custom_command.patch"
 )
 
 if(VCPKG_BUILD_TYPE STREQUAL "Debug")
-    set(IRRLICHT_ROOT "${_VCPKG_INSTALLED_DIR}/${TARGET_TRIPLET}/debug")
+    set(IRRLICHT_INSTALL_DIR "${_VCPKG_INSTALLED_DIR}/${TARGET_TRIPLET}/debug")
 else()
-    set(IRRLICHT_ROOT "${_VCPKG_INSTALLED_DIR}/${TARGET_TRIPLET}")
+    set(IRRLICHT_INSTALL_DIR "${_VCPKG_INSTALLED_DIR}/${TARGET_TRIPLET}")
 endif()
 
 
@@ -31,7 +31,7 @@ vcpkg_cmake_configure(
         -DENABLE_MODULE_COSIMULATION=OFF
 
         # hack needed explicitly because of the way IRRLICHT_ROOT is set in Chrono 8.0.0
-        -DIRRLICHT_ROOT="${IRRLICHT_ROOT}"
+        -DIRRLICHT_INSTALL_DIR="${IRRLICHT_INSTALL_DIR}"
 )
 
 

--- a/external/vcpkg/ports/chrono/portfile.cmake
+++ b/external/vcpkg/ports/chrono/portfile.cmake
@@ -12,6 +12,7 @@ else()
     set(IRRLICHT_INSTALL_DIR "${_VCPKG_INSTALLED_DIR}/${TARGET_TRIPLET}")
 endif()
 
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -41,3 +42,8 @@ vcpkg_cmake_install()
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/share/chrono")
 
 vcpkg_cmake_config_fixup()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(APPEND "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage"
+    "Link with system library: Ws2_32.lib\n")
+endif()

--- a/external/vcpkg/ports/chrono/vcpkg.json
+++ b/external/vcpkg/ports/chrono/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "chrono",
-  "version-string": "8.0.0",
+  "version-string": "9.0.1",
   "description": "",
   "homepage": "https://projectchrono.org",
   "dependencies": [

--- a/external/vcpkg/ports/hydrochrono/portfile.cmake
+++ b/external/vcpkg/ports/hydrochrono/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://github.com/NREL/HydroChrono.git
-    REF 3a191dc328f3ec6d8e3e295a2365f43b7ef2e6a8
+    REF 7ea31390117d9f1a0c38ec449e19ba17239699a9
 )
 
 vcpkg_cmake_configure(

--- a/external/vcpkg/ports/hydrochrono/vcpkg.json
+++ b/external/vcpkg/ports/hydrochrono/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hydrochrono",
-  "version-string": "0.2.5",
+  "version-string": "0.2.6",
   "description": "",
   "homepage": "https://nrel.github.io/HydroChrono",
   "dependencies": [

--- a/external/vcpkg/vcpkg.json
+++ b/external/vcpkg/vcpkg.json
@@ -30,11 +30,11 @@
     },
     {
       "name": "chrono",
-      "version>=": "8.0.0"
+      "version>=": "9.0.1"
     },
     {
       "name": "hydrochrono",
-      "version>=": "0.2.5"
+      "version>=": "0.2.6"
     },
     {
       "name": "openfast",

--- a/src/elasto/chrono_adapters.cpp
+++ b/src/elasto/chrono_adapters.cpp
@@ -3,7 +3,7 @@
 #include "seahowl/elasto/reference_point_elasto.h"
 #include "seahowl/elasto/entities_elasto.h"
 
-#include <chrono/core/ChVector.h>
+#include <chrono/core/ChVector3.h>
 #include <chrono/core/ChMatrix.h>
 #include <chrono/fea/ChBeamSectionTaperedTimoshenkoFPM.h>
 #include <chrono/fea/ChElementBeamTaperedTimoshenkoFPM.h>
@@ -11,8 +11,8 @@
 #include <chrono/physics/ChLinkMate.h>
 #include <chrono/physics/ChLoadsBody.h>
 #include <chrono/physics/ChLoadContainer.h>
-#include <chrono/fea/ChLinkPointPoint.h>
-#include <chrono/fea/ChLinkPointFrame.h>
+#include <chrono/fea/ChLinkNodeNode.h>
+#include <chrono/fea/ChLinkNodeFrame.h>
 #include <chrono/physics/ChLinkRevolute.h>
 #include <chrono/fea/ChMesh.h>
 #include <chrono/physics/ChSystemSMC.h>
@@ -30,10 +30,10 @@ const double MASS_NOTSET_VALUE = -1.2345e-12;
 using namespace seahowl;
 using namespace seahowl::elasto;
 
-chrono::ChVector<double> vec2ch(const Vector3d& vector_in) {
-    return chrono::ChVector<double>(vector_in[0], vector_in[1], vector_in[2]);
+chrono::ChVector3<double> vector2ch(const Vector3d& vector_in) {
+    return chrono::ChVector3<double>(vector_in[0], vector_in[1], vector_in[2]);
 }
-Vector3d ch2vec(const chrono::ChVector<double>& vector_in) {
+Vector3d ch2vec(const chrono::ChVector3<double>& vector_in) {
     return Vector3d(vector_in[0], vector_in[1], vector_in[2]);
 }
 
@@ -75,7 +75,7 @@ chrono::ChQuaternion<double> node_iec2ch(const Quaternion& quaternion_in) {
     return quat2ch(quaternion_in * Quaternion(cos(angle / 2), 0, sin(angle / 2), 0));
 }
 
-Vector3d vec_ch2iec(const chrono::ChVector<double>& vector_in) {
+Vector3d vec_ch2iec(const chrono::ChVector3<double>& vector_in) {
     // Convert from Chrono standard ro IEC standard.
     // IEC convention:
     // x-axis: flapwise pointing towards nacelle,
@@ -152,7 +152,7 @@ class ChLoadLocal66 : public ChLoadCustom {
     // compute external forces manually
     virtual void ComputeQ(ChState* state_x, ChStateDelta* state_w) override {
         // sanity check
-        if (this->LoadGet_ndof_w() != 6) {
+        if (this->LoadGetNumCoordsVelLevel() != 6) {
             throw std::runtime_error("6x6 added mass matrix only works with entities with 6 DOFs.");
         }
 
@@ -167,12 +167,12 @@ class ChLoadLocal66 : public ChLoadCustom {
         rot66.block<3, 3>(3, 3) = rotI.block(0, 0, 3, 3);
 
         // reset load_Q
-        load_Q = ChVectorDynamic<>(this->LoadGet_ndof_w()).setZero();
+        load_Q = ChVectorDynamic<>(this->LoadGetNumCoordsVelLevel()).setZero();
 
         // damping force
-        auto vv = body_frame->GetPos_dt();
-        auto rv = body_frame->GetWvel_loc();
-        ChVectorDynamic<> vvv(this->LoadGet_ndof_w());
+        auto vv = body_frame->GetPosDt();
+        auto rv = body_frame->GetAngVelLocal();
+        ChVectorDynamic<> vvv(this->LoadGetNumCoordsVelLevel());
         for (int ii = 0; ii < 3; ii++) {
             vvv[ii] = vv[ii];
             vvv[ii + 3] = rv[ii];
@@ -181,11 +181,7 @@ class ChLoadLocal66 : public ChLoadCustom {
     };
 
     // compute jacobians manually
-    virtual void ComputeJacobian(ChState* state_x,
-                                 ChStateDelta* state_w,
-                                 ChMatrixRef mK,
-                                 ChMatrixRef mR,
-                                 ChMatrixRef mM) override {
+    virtual void ComputeJacobian(ChState* state_x, ChStateDelta* state_w) override {
         // matrices expressed in local system --> transformation needed
         // Chrono sends:
         // - translation components in global system
@@ -197,23 +193,23 @@ class ChLoadLocal66 : public ChLoadCustom {
         rot66.block<3, 3>(3, 3) = rotI.block(0, 0, 3, 3);
 
         // mass matrix(6x6)
-        jacobians->M = rot66 * (added_mass_matrix * rot66.inverse());
+        m_jacobians->M = rot66 * (added_mass_matrix * rot66.inverse());
 
         // damping matrix terms (6x6)
-        jacobians->R = rot66 * (damping_matrix * rot66.inverse());
+        m_jacobians->R = rot66 * (damping_matrix * rot66.inverse());
 
         // stiffness matrix terms (6x6) - keeping it to zero here
-        jacobians->K = Eigen::Matrix<double, 6, 6>::Zero();
+        m_jacobians->K = Eigen::Matrix<double, 6, 6>::Zero();
     };
 
     virtual void LoadIntLoadResidual_Mv(ChVectorDynamic<>& R, const ChVectorDynamic<>& w, const double c) override {
-        if (!this->jacobians)
+        if (!this->m_jacobians)
             return;
         // fetch w as a contiguous vector
-        ChVectorDynamic<> grouped_w(this->LoadGet_ndof_w());
-        ChVectorDynamic<> grouped_cMv(this->LoadGet_ndof_w());
+        ChVectorDynamic<> grouped_w(LoadGetNumCoordsVelLevel());
+        ChVectorDynamic<> grouped_cMv(LoadGetNumCoordsVelLevel());
         unsigned int rowQ = 0;
-        for (int i = 0; i < loadable->GetSubBlocks(); ++i) {
+        for (int i = 0; i < loadable->GetNumSubBlocks(); ++i) {
             if (loadable->IsSubBlockActive(i)) {
                 unsigned int moffset = loadable->GetSubBlockOffset(i);
 
@@ -225,10 +221,10 @@ class ChLoadLocal66 : public ChLoadCustom {
         }
 
         // do computation R=c*M*v
-        grouped_cMv = c * this->jacobians->M * grouped_w;
+        grouped_cMv = c * m_jacobians->M * grouped_w;
 
         rowQ = 0;
-        for (int i = 0; i < loadable->GetSubBlocks(); ++i) {
+        for (int i = 0; i < loadable->GetNumSubBlocks(); ++i) {
             if (loadable->IsSubBlockActive(i)) {
                 unsigned int moffset = loadable->GetSubBlockOffset(i);
                 for (unsigned int row = 0; row < loadable->GetSubBlockSize(i); ++row) {
@@ -254,8 +250,8 @@ class ChLoadLocal66 : public ChLoadCustom {
 class ChLoadForceTorque : public ChLoadCustom {
   public:
     ChLoadForceTorque(std::shared_ptr<ChLoadable> mloadable) : ChLoadCustom(mloadable) {
-        chload_force = ChVector<double>(0.0, 0.0, 0.0);
-        chload_torque = ChVector<double>(0.0, 0.0, 0.0);
+        chload_force = ChVector3<double>(0.0, 0.0, 0.0);
+        chload_torque = ChVector3<double>(0.0, 0.0, 0.0);
     }
 
     /**
@@ -263,15 +259,15 @@ class ChLoadForceTorque : public ChLoadCustom {
      */
     virtual ChLoadForceTorque* Clone() const override { return new ChLoadForceTorque(*this); }
 
-    void SetForce(const ChVector<double>& force) { chload_force = force; }
-    void SetTorque(const ChVector<double>& torque) { chload_torque = torque; }
-    ChVector<double> GetForce() { return chload_force; }
-    ChVector<double> GetTorque() { return chload_torque; }
+    void SetForce(const ChVector3<double>& force) { chload_force = force; }
+    void SetTorque(const ChVector3<double>& torque) { chload_torque = torque; }
+    ChVector3<double> GetForce() { return chload_force; }
+    ChVector3<double> GetTorque() { return chload_torque; }
 
     // compute external forces manually
     virtual void ComputeQ(ChState* state_x, ChStateDelta* state_w) override {
         // reset load_Q
-        int ndof = this->LoadGet_ndof_w();
+        int ndof = this->LoadGetNumCoordsVelLevel();
         load_Q = ChVectorDynamic<>(ndof).setZero();
         load_Q[0] = chload_force[0];
         load_Q[1] = chload_force[1];
@@ -286,14 +282,14 @@ class ChLoadForceTorque : public ChLoadCustom {
     virtual bool IsStiff() override { return false; }
 
   private:
-    ChVector<double> chload_force;
-    ChVector<double> chload_torque;
+    ChVector3<double> chload_force;
+    ChVector3<double> chload_torque;
 };
 
 }  // namespace chrono
 
 void EntityDynamicChrono::set_position(const Vector3d& position) {
-    chobj->SetPos(vec2ch(position));
+    chobj->SetPos(vector2ch(position));
 }
 
 Vector3d EntityDynamicChrono::get_position() const {
@@ -309,50 +305,50 @@ Quaternion EntityDynamicChrono::get_rotation() const {
 }
 
 void EntityDynamicChrono::set_velocity(const Vector3d& velocity) {
-    chobj->SetPos_dt(vec2ch(velocity));
+    chobj->SetPosDt(vector2ch(velocity));
 }
 
 Vector3d EntityDynamicChrono::get_velocity() const {
-    return ch2vec(chobj->GetPos_dt());
+    return ch2vec(chobj->GetPosDt());
 }
 
 void EntityDynamicChrono::set_acceleration(const Vector3d& acceleration) {
-    chobj->SetPos_dtdt(vec2ch(acceleration));
+    chobj->SetPosDt2(vector2ch(acceleration));
 }
 
 Vector3d EntityDynamicChrono::get_acceleration() const {
-    return ch2vec(chobj->GetPos_dtdt());
+    return ch2vec(chobj->GetPosDt2());
 }
 
 void EntityDynamicChrono::set_rotational_velocity(const Vector3d& rotational_velocity, bool is_local) {
     if (is_local) {
-        chobj->SetWvel_loc(vec2ch(rotational_velocity));
+        chobj->SetAngVelLocal(vector2ch(rotational_velocity));
     } else {
-        chobj->SetWvel_par(vec2ch(rotational_velocity));
+        chobj->SetAngVelParent(vector2ch(rotational_velocity));
     }
 }
 
 Vector3d EntityDynamicChrono::get_rotational_velocity(bool is_local) const {
     if (is_local) {
-        return ch2vec(chobj->GetWvel_loc());
+        return ch2vec(chobj->GetAngVelLocal());
     } else {
-        return ch2vec(chobj->GetWvel_par());
+        return ch2vec(chobj->GetAngVelParent());
     }
 }
 
 void EntityDynamicChrono::set_rotational_acceleration(const Vector3d& rotational_acceleration, bool is_local) {
     if (is_local) {
-        chobj->SetWacc_loc(vec2ch(rotational_acceleration));
+        chobj->SetAngAccLocal(vector2ch(rotational_acceleration));
     } else {
-        chobj->SetWacc_par(vec2ch(rotational_acceleration));
+        chobj->SetAngAccParent(vector2ch(rotational_acceleration));
     }
 }
 
 Vector3d EntityDynamicChrono::get_rotational_acceleration(bool is_local) const {
     if (is_local) {
-        return ch2vec(chobj->GetWacc_loc());
+        return ch2vec(chobj->GetAngAccLocal());
     } else {
-        return ch2vec(chobj->GetWacc_par());
+        return ch2vec(chobj->GetAngAccParent());
     }
 }
 
@@ -371,7 +367,7 @@ void BodyElastoChrono::set_mass(double mass) {
 }
 
 void BodyElastoChrono::set_inertia_diagonal(const Vector3d& inertia) {
-    chobj->SetInertiaXX(vec2ch(inertia));
+    chobj->SetInertiaXX(vector2ch(inertia));
 }
 
 void BodyElastoChrono::set_inertia_matrix(const Eigen::Matrix<double, 3, 3>& inertia) {
@@ -383,19 +379,19 @@ Eigen::Matrix<double, 3, 3> BodyElastoChrono::get_inertia_matrix() const {
 }
 
 void BodyElastoChrono::reset_loads() {
-    chobj->Empty_forces_accumulators();
+    chobj->EmptyAccumulators();
 }
 
 void BodyElastoChrono::reset_loads_internals() {
-    chloads_internals->SetForce(chrono::Vector(0.0, 0.0, 0.0));
-    chloads_internals->SetTorque(chrono::Vector(0.0, 0.0, 0.0));
+    chloads_internals->SetForce(chrono::ChVector3(0.0, 0.0, 0.0));
+    chloads_internals->SetTorque(chrono::ChVector3(0.0, 0.0, 0.0));
 }
 
 Vector3d BodyElastoChrono::get_force(bool is_local) const {
     if (is_local) {
-        return get_rotation().inverse() * ch2vec(chobj->Get_accumulated_force());
+        return get_rotation().inverse() * ch2vec(chobj->GetAccumulatedForce());
     } else {
-        return ch2vec(chobj->Get_accumulated_force());
+        return ch2vec(chobj->GetAccumulatedForce());
     }
 }
 
@@ -409,9 +405,9 @@ Vector3d BodyElastoChrono::get_force_internals(bool is_local) const {
 
 Vector3d BodyElastoChrono::get_torque(bool is_local) const {
     if (is_local) {
-        return ch2vec(chobj->Get_accumulated_torque());
+        return ch2vec(chobj->GetAccumulatedTorque());
     } else {
-        return get_rotation() * ch2vec(chobj->Get_accumulated_torque());
+        return get_rotation() * ch2vec(chobj->GetAccumulatedTorque());
     }
 }
 
@@ -424,24 +420,24 @@ Vector3d BodyElastoChrono::get_torque_internals(bool is_local) const {
 }
 
 void BodyElastoChrono::set_force(const Vector3d& force, bool is_local) {
-    auto torque = get_torque(true);      // get previously accumulated torque
-    chobj->Empty_forces_accumulators();  // empty accumulated forces and torques
-    accumulate_torque(torque, true);     // set previously accumulated torque
+    auto torque = get_torque(true);   // get previously accumulated torque
+    chobj->EmptyAccumulators();       // empty accumulated forces and torques
+    accumulate_torque(torque, true);  // set previously accumulated torque
     accumulate_force(force, is_local);
 }
 
 void BodyElastoChrono::set_torque(const Vector3d& torque, bool is_local) {
-    auto force = get_force(false);       // get previously accumulated force
-    chobj->Empty_forces_accumulators();  // empty accumulated forces and torques
-    accumulate_force(force, false);      // set previously accumulated force
+    auto force = get_force(false);   // get previously accumulated force
+    chobj->EmptyAccumulators();      // empty accumulated forces and torques
+    accumulate_force(force, false);  // set previously accumulated force
     accumulate_torque(torque, is_local);
 }
 
 void BodyElastoChrono::accumulate_force(const Vector3d& force, bool is_local) {
     if (is_local) {
-        chobj->Accumulate_force(force, Vector3d(0.0, 0.0, 0.0), is_local);
+        chobj->AccumulateForce(force, Vector3d(0.0, 0.0, 0.0), is_local);
     } else {
-        chobj->Accumulate_force(force, chobj->GetPos(), is_local);
+        chobj->AccumulateForce(force, chobj->GetPos(), is_local);
     }
 }
 
@@ -455,7 +451,7 @@ void BodyElastoChrono::accumulate_force_internals(const Vector3d& force, bool is
 }
 
 void BodyElastoChrono::accumulate_torque(const Vector3d& torque, bool is_local) {
-    chobj->Accumulate_torque(torque, is_local);
+    chobj->AccumulateTorque(torque, is_local);
 }
 
 void BodyElastoChrono::accumulate_torque_internals(const Vector3d& torque, bool is_local) {
@@ -468,11 +464,11 @@ void BodyElastoChrono::accumulate_torque_internals(const Vector3d& torque, bool 
 }
 
 void BodyElastoChrono::set_fixed(bool is_fixed) {
-    chobj->SetBodyFixed(is_fixed);
+    chobj->SetFixed(is_fixed);
 }
 
 bool BodyElastoChrono::is_fixed() const {
-    return chobj->GetBodyFixed();
+    return chobj->IsFixed();
 }
 
 double BodyElastoChrono::get_mass() {
@@ -533,7 +529,7 @@ NodeElastoChronoBase::NodeElastoChronoBase() {
 
 NodeElastoChrono::NodeElastoChrono(const Vector3d& position, const Quaternion& rotation) {
     chobj = chrono_types::make_shared<chrono::fea::ChNodeFEAxyzrot>(
-        chrono::ChFrame<>(vec2ch(position), node_iec2ch(rotation)));
+        chrono::ChFrame<>(vector2ch(position), node_iec2ch(rotation)));
     EntityDynamicChrono::chobj = chobj;
     NodeElastoChronoBase::chobj = chobj;
 
@@ -550,7 +546,7 @@ Quaternion NodeElastoChrono::get_rotation() const {
 }
 
 Vector3d NodeElastoChrono::get_direction() const {
-    return ch2vec(chobj->TransformDirectionLocalToParent(chrono::ChVector<double>(1.0, 0.0, 0.0)));
+    return ch2vec(chobj->TransformDirectionLocalToParent(chrono::ChVector3<double>(1.0, 0.0, 0.0)));
 }
 
 void NodeElastoChrono::reset_loads() {
@@ -559,8 +555,8 @@ void NodeElastoChrono::reset_loads() {
 }
 
 void NodeElastoChrono::reset_loads_internals() {
-    chloads_internals->SetForce(chrono::Vector(0.0, 0.0, 0.0));
-    chloads_internals->SetTorque(chrono::Vector(0.0, 0.0, 0.0));
+    chloads_internals->SetForce(chrono::ChVector3(0.0, 0.0, 0.0));
+    chloads_internals->SetTorque(chrono::ChVector3(0.0, 0.0, 0.0));
 }
 
 Vector3d NodeElastoChrono::get_force(bool is_local) const {
@@ -597,9 +593,9 @@ Vector3d NodeElastoChrono::get_torque_internals(bool is_local) const {
 
 void NodeElastoChrono::set_force(const Vector3d& force, bool is_local) {
     if (is_local) {
-        chobj->SetForce(vec2ch(get_rotation() * force));
+        chobj->SetForce(vector2ch(get_rotation() * force));
     } else {
-        chobj->SetForce(vec2ch(force));
+        chobj->SetForce(vector2ch(force));
     }
 }
 
@@ -734,7 +730,7 @@ void NodeElastoChrono::set_properties(const BladeReferencePointElasto& ref, bool
         sectionFPM->SetMassMatrixFPM(mm);
         sectionFPM->SetStiffnessMatrixFPM(sm);
         // damping
-        sectionFPM->SetBeamRaleyghDamping(damping_coefficients);
+        sectionFPM->SetRayleighDamping(damping_coefficients);
     } else {
         section = chrono_types::make_shared<chrono::fea::ChBeamSectionTimoshenkoAdvancedGeneric>();
         // offsets
@@ -747,16 +743,16 @@ void NodeElastoChrono::set_properties(const BladeReferencePointElasto& ref, bool
         // inertias per unit length in this order: mIyy, mIzz, mIyz, mQy, mQz
         section->SetInertiasPerUnitLength(mm(4, 4), mm(5, 5), -mm(4, 5), mm(0, 4), -mm(0, 5));
         // axial
-        section->SetXtorsionRigidity(sm(3, 3));
+        section->SetTorsionRigidityX(sm(3, 3));
         section->SetAxialRigidity(sm(0, 0));
         // flap
-        section->SetYbendingRigidity(sm(4, 4));
-        section->SetYshearRigidity(sm(1, 1));
+        section->SetBendingRigidityY(sm(4, 4));
+        section->SetShearRigidityY(sm(1, 1));
         // edge
-        section->SetZbendingRigidity(sm(5, 5));
-        section->SetZshearRigidity(sm(2, 2));
-        // damping
-        section->SetBeamRaleyghDamping(damping_coefficients);
+        section->SetBendingRigidityZ(sm(5, 5));
+        section->SetShearRigidityZ(sm(2, 2));
+        // damping=
+        section->SetRayleighDamping(damping_coefficients);
     }
 }
 
@@ -768,13 +764,13 @@ void NodeElastoChrono::set_properties(const TowerReferencePointElasto& ref) {
     section->SetInertiasPerUnitLength(ref.inertia_foreaft, ref.inertia_sideside, 0.0, 0.0, 0.0);
     // axial
     section->SetAxialRigidity(ref.stiffness_axial);
-    section->SetXtorsionRigidity(ref.stiffness_torsion);
+    section->SetTorsionRigidityX(ref.stiffness_torsion);
     // foreaft
-    section->SetYbendingRigidity(ref.stiffness_foreaft);
-    section->SetZshearRigidity(ref.stiffness_foreaft_shear);
+    section->SetBendingRigidityY(ref.stiffness_foreaft);
+    section->SetShearRigidityZ(ref.stiffness_foreaft_shear);
     // sideside
-    section->SetZbendingRigidity(ref.stiffness_sideside);
-    section->SetYshearRigidity(ref.stiffness_sideside_shear);
+    section->SetBendingRigidityZ(ref.stiffness_sideside);
+    section->SetShearRigidityY(ref.stiffness_sideside_shear);
     chrono::fea::DampingCoefficients damping_coefficients;
     // damping coefficients: IEC -> Chrono convention
     // Timoshenko beams in Chrono use Rayleigh cofficients squared
@@ -784,11 +780,11 @@ void NodeElastoChrono::set_properties(const TowerReferencePointElasto& ref) {
     damping_coefficients.bt = sqrt(ref.damping_torsion);
     // mass-proportional coefficient
     damping_coefficients.alpha = ref.damping_mass;
-    section->SetBeamRaleyghDamping(damping_coefficients);
+    section->SetRayleighDamping(damping_coefficients);
 }
 
 NodeElastoChronoD::NodeElastoChronoD(const Vector3d& position, const Vector3d& direction) {
-    chobj = chrono_types::make_shared<chrono::fea::ChNodeFEAxyzD>(vec2ch(position), vec2ch(direction));
+    chobj = std::make_shared<chrono::fea::ChNodeFEAxyzD>(vector2ch(position), vector2ch(direction));
     NodeElastoChronoBase::chobj = chobj;
 
     chloads_internals = chrono_types::make_shared<chrono::ChLoadForceTorque>(chobj);
@@ -797,7 +793,7 @@ NodeElastoChronoD::NodeElastoChronoD(const Vector3d& position, const Vector3d& d
 
 void NodeElastoChronoD::set_rotation(const Quaternion& rotation) {
     // set rotation assuming direction of node to be local Z
-    chobj->SetD(vec2ch(rotation * Vector3d(0.0, 0.0, 1.0)));
+    chobj->SetSlope1(vector2ch(rotation * Vector3d(0.0, 0.0, 1.0)));
 }
 
 Quaternion NodeElastoChronoD::get_rotation() const {
@@ -807,7 +803,7 @@ Quaternion NodeElastoChronoD::get_rotation() const {
 }
 
 Vector3d NodeElastoChronoD::get_direction() const {
-    return ch2vec(chobj->GetD());
+    return ch2vec(chobj->GetSlope1());
 }
 
 void NodeElastoChronoD::reset_loads() {
@@ -816,8 +812,8 @@ void NodeElastoChronoD::reset_loads() {
 }
 
 void NodeElastoChronoD::reset_loads_internals() {
-    chloads_internals->SetForce(chrono::Vector(0.0, 0.0, 0.0));
-    chloads_internals->SetTorque(chrono::Vector(0.0, 0.0, 0.0));
+    chloads_internals->SetForce(chrono::ChVector3(0.0, 0.0, 0.0));
+    chloads_internals->SetTorque(chrono::ChVector3(0.0, 0.0, 0.0));
 }
 
 Vector3d NodeElastoChronoD::get_force(bool is_local) const {
@@ -850,7 +846,7 @@ void NodeElastoChronoD::set_force(const Vector3d& force, bool is_local) {
     if (is_local) {
         throw std::runtime_error("Cannot set force locally for ChNodeFEAxyzD.");
     } else {
-        chobj->SetForce(vec2ch(force));
+        chobj->SetForce(vector2ch(force));
     }
 }
 
@@ -926,7 +922,7 @@ bool NodeElastoChronoD::is_fixed() const {
 }
 
 void NodeElastoChronoD::set_position(const Vector3d& position) {
-    chobj->SetPos(vec2ch(position));
+    chobj->SetPos(vector2ch(position));
 }
 
 Vector3d NodeElastoChronoD::get_position() const {
@@ -934,19 +930,19 @@ Vector3d NodeElastoChronoD::get_position() const {
 }
 
 void NodeElastoChronoD::set_velocity(const Vector3d& velocity) {
-    chobj->SetPos_dt(vec2ch(velocity));
+    chobj->SetPosDt(vector2ch(velocity));
 }
 
 Vector3d NodeElastoChronoD::get_velocity() const {
-    return ch2vec(chobj->GetPos_dt());
+    return ch2vec(chobj->GetPosDt());
 }
 
 void NodeElastoChronoD::set_acceleration(const Vector3d& acceleration) {
-    chobj->SetPos_dtdt(vec2ch(acceleration));
+    chobj->SetPosDt2(vector2ch(acceleration));
 }
 
 Vector3d NodeElastoChronoD::get_acceleration() const {
-    return ch2vec(chobj->GetPos_dtdt());
+    return ch2vec(chobj->GetPosDt2());
 }
 
 void NodeElastoChronoD::set_rotational_velocity(const Vector3d& rotational_velocity, bool is_local) {
@@ -974,7 +970,7 @@ void ElementElastoChrono::set_nodes(std::shared_ptr<NodeElasto> node1, std::shar
 }
 
 void ElementElastoChrono::evaluate_position_rotation(double eta, Vector3d& position, Quaternion& rotation) const {
-    auto chvec = vec2ch(position);
+    auto chvec = vector2ch(position);
     auto chquat = quat2ch(rotation);
     chobj->EvaluateSectionFrame(eta, chvec, chquat);
     position[0] = chvec[0];
@@ -984,8 +980,8 @@ void ElementElastoChrono::evaluate_position_rotation(double eta, Vector3d& posit
 }
 
 void ElementElastoChrono::evaluate_force_torque(double eta, Vector3d& force, Vector3d& torque) const {
-    auto chforce = vec2ch(force);
-    auto chtorque = vec2ch(torque);
+    auto chforce = vector2ch(force);
+    auto chtorque = vector2ch(torque);
     chobj->EvaluateSectionForceTorque(eta, chforce, chtorque);
     // convert Chrono convention to IEC
     force = vec_ch2iec(chforce);
@@ -1087,11 +1083,11 @@ void ElementMooringElastoChrono::set_properties(double density,
     auto section = chrono_types::make_shared<chrono::fea::ChBeamSectionCable>();
     chobj->SetSection(section);
     section->SetDensity(density);
-    double area = chrono::CH_C_PI * pow(diameter, 2) / 4.0;
+    double area = chrono::CH_PI * pow(diameter, 2) / 4.0;
     section->SetDiameter(diameter);
     double young_modulus = stiffness_axial / area;
     section->SetYoungModulus(young_modulus);
-    section->SetI(stiffness_bending / young_modulus);
+    section->SetInertia(stiffness_bending / young_modulus);
 }
 
 void ElementMooringElastoChrono::set_rest_length(double rest_length) {
@@ -1108,8 +1104,8 @@ SpringLinearChrono::SpringLinearChrono() {
 
 void SpringLinearChrono::initialize(const BodyElasto& body1, const BodyElasto& body2) {
     chobj->Initialize(dynamic_cast<const BodyElastoChrono&>(body1).chobj,
-                      dynamic_cast<const BodyElastoChrono&>(body2).chobj, true, chrono::ChVector<double>(0.0, 0.0, 0.0),
-                      chrono::ChVector<double>(0.0, 0.0, 0.0));
+                      dynamic_cast<const BodyElastoChrono&>(body2).chobj, true,
+                      chrono::ChVector3<double>(0.0, 0.0, 0.0), chrono::ChVector3<double>(0.0, 0.0, 0.0));
 }
 
 void SpringLinearChrono::initialize_with_anchors(const BodyElasto& body1,
@@ -1118,7 +1114,8 @@ void SpringLinearChrono::initialize_with_anchors(const BodyElasto& body1,
                                                  const Vector3d& anchor1,
                                                  const Vector3d& anchor2) {
     chobj->Initialize(dynamic_cast<const BodyElastoChrono&>(body1).chobj,
-                      dynamic_cast<const BodyElastoChrono&>(body2).chobj, local, vec2ch(anchor1), vec2ch(anchor2));
+                      dynamic_cast<const BodyElastoChrono&>(body2).chobj, local, vector2ch(anchor1),
+                      vector2ch(anchor2));
 }
 
 void SpringLinearChrono::set_rest_length(double rest_length) {
@@ -1158,18 +1155,20 @@ void LinkChrono::set_constraints(bool surge, bool sway, bool heave, bool roll, b
 }
 
 Vector3d LinkChrono::get_reaction_force() const {
-    return ch2vec(chobj->Get_react_force());
+    auto wrench = chobj->GetReaction2();
+    return ch2vec(wrench.force);
 }
 
 Vector3d LinkChrono::get_reaction_torque() const {
-    return ch2vec(chobj->Get_react_torque());
+    auto wrench = chobj->GetReaction2();
+    return ch2vec(wrench.torque);
 }
 
 LinkChronoCable::LinkChronoCable() {}
 
 void LinkChronoCable::initialize(const Entity& entity1, const Entity& entity2) {
     try {
-        auto link = chrono_types::make_shared<chrono::fea::ChLinkPointFrame>();
+        auto link = chrono_types::make_shared<chrono::fea::ChLinkNodeFrame>();
         auto node = dynamic_cast<const NodeElastoChronoD&>(entity1);
         auto body = dynamic_cast<const BodyElastoChrono&>(entity2);
         link->Initialize(node.chobj, body.chobj);
@@ -1179,7 +1178,7 @@ void LinkChronoCable::initialize(const Entity& entity1, const Entity& entity2) {
     } catch (const std::bad_cast& e) {
     }
     try {
-        auto link = chrono_types::make_shared<chrono::fea::ChLinkPointFrame>();
+        auto link = chrono_types::make_shared<chrono::fea::ChLinkNodeFrame>();
         auto body = dynamic_cast<const BodyElastoChrono&>(entity1);
         auto node = dynamic_cast<const NodeElastoChronoD&>(entity2);
         link->Initialize(node.chobj, body.chobj);
@@ -1189,7 +1188,7 @@ void LinkChronoCable::initialize(const Entity& entity1, const Entity& entity2) {
     } catch (const std::bad_cast& e) {
     }
     try {
-        auto link = chrono_types::make_shared<chrono::fea::ChLinkPointPoint>();
+        auto link = chrono_types::make_shared<chrono::fea::ChLinkNodeNode>();
         auto node1 = dynamic_cast<const NodeElastoChronoD&>(entity1);
         auto node2 = dynamic_cast<const NodeElastoChronoD&>(entity2);
         link->Initialize(node1.chobj, node2.chobj);
@@ -1208,11 +1207,13 @@ void LinkChronoCable::set_constraints(bool surge, bool sway, bool heave, bool ro
 }
 
 Vector3d LinkChronoCable::get_reaction_force() const {
-    return ch2vec(chobj->Get_react_force());
+    auto wrench = chobj->GetReaction2();
+    return ch2vec(wrench.force);
 }
 
 Vector3d LinkChronoCable::get_reaction_torque() const {
-    return ch2vec(chobj->Get_react_torque());
+    auto wrench = chobj->GetReaction2();
+    return ch2vec(wrench.torque);
 }
 
 class ChFunctionArray : public chrono::ChFunction {
@@ -1222,7 +1223,7 @@ class ChFunctionArray : public chrono::ChFunction {
 
     virtual ChFunctionArray* Clone() const override { return new ChFunctionArray(*this); }
 
-    virtual double Get_y(double x) const override {
+    virtual double GetVal(double x) const override {
         if (x >= time_array.back()) {
             return values_array.back();
         } else if (x <= time_array.front()) {
@@ -1291,11 +1292,11 @@ void ActuatorRotationChrono::set_control_timeseries(const std::vector<double>& t
 }
 
 double ActuatorRotationChrono::get_control_value(double time) const {
-    return std::dynamic_pointer_cast<ChFunctionArray>(chfunc)->Get_y(time);
+    return std::dynamic_pointer_cast<ChFunctionArray>(chfunc)->GetVal(time);
 }
 
 double ActuatorRotationChrono::get_angle() const {
-    return chobj->GetMotorRot();
+    return chobj->GetMotorAngle();
 }
 
 void ActuatorRotationChrono::impose_value_constant(double value) {
@@ -1326,7 +1327,7 @@ void ActuatorRotationChrono::initialize_links() {
     // actuator link
     auto body1ref = dynamic_cast<BodyElastoChrono&>(*body_worker);
     auto body2ref = dynamic_cast<BodyElastoChrono&>(*body_controller);
-    auto chframe0 = chrono::ChFrame<double>(chrono::Vector(0.0, 0.0, 0.0), quat2ch(reference_rotation));
+    auto chframe0 = chrono::ChFrame<double>(chrono::ChVector3(0.0, 0.0, 0.0), quat2ch(reference_rotation));
     chobj->Initialize(body1ref.chobj, body2ref.chobj, true, chframe0, chframe0);
 }
 
@@ -1344,7 +1345,7 @@ void LinkMatrixStiffnessDampingChrono::initialize(const Entity& entity1, const E
 
         // instantiate Chrono object
         chobj = chrono_types::make_shared<chrono::ChLoadBodyBodyBushingGeneric>(
-            body1.chobj, body2.chobj, body2.chobj->GetFrame_COG_to_abs(), stiffness_matrix, damping_matrix);
+            body1.chobj, body2.chobj, body2.chobj->GetFrameCOMToAbs(), stiffness_matrix, damping_matrix);
     } catch (const std::bad_cast& e) {
         throw std::runtime_error("Cannot link these entities with cable link.");
     }
@@ -1427,7 +1428,7 @@ void SystemElastoChrono::assemble() {
 
     // warnings for properties that were not set
     int body_idx = 0;
-    for (auto& body : chobj->Get_bodylist()) {
+    for (auto& body : chobj->GetBodies()) {
         if (body->GetMass() == MASS_NOTSET_VALUE) {
             spdlog::warn("Body (index {} in elasto system) mass was not set, making it massless.", body_idx);
             body->SetMass(0.0);
@@ -1437,7 +1438,7 @@ void SystemElastoChrono::assemble() {
             inertia_matrix(2, 2) == MASS_NOTSET_VALUE && inertia_matrix.sum() == 3 * MASS_NOTSET_VALUE) {
             spdlog::warn("Body (index {} in elasto system) inertia matrix mass was not set, making a null matrix.",
                          body_idx);
-            body->SetInertiaXX(chrono::ChVector<double>(0.0, 0.0, 0.0));
+            body->SetInertiaXX(chrono::ChVector3<double>(0.0, 0.0, 0.0));
         }
         body_idx += 1;
     }
@@ -1496,11 +1497,11 @@ void SystemElastoChrono::do_statics(bool linear, int nonlinear_steps) {
 };
 
 Vector3d SystemElastoChrono::get_gravitational_acceleration() const {
-    return ch2vec(chobj->Get_G_acc());
+    return ch2vec(chobj->GetGravitationalAcceleration());
 }
 
 void SystemElastoChrono::set_gravitational_acceleration(const Vector3d& gravitational_acceleration) {
-    chobj->Set_G_acc(gravitational_acceleration);
+    chobj->SetGravitationalAcceleration(gravitational_acceleration);
 }
 
 void SystemElastoChrono::add(BodyElasto& body) {

--- a/src/io/viz_insitu_irrlicht.cpp
+++ b/src/io/viz_insitu_irrlicht.cpp
@@ -45,15 +45,15 @@ void VisualizationInSituIrrlicht::initialize_elasto(seahowl::elasto::SystemElast
     }
 
     // meshes
-    for (auto mesh : system_chrono->Get_meshlist()) {
+    for (auto mesh : system_chrono->GetMeshes()) {
         // beams
-        auto beams_visu = chrono_types::make_shared<chrono::ChVisualShapeFEA>(mesh);
+        auto beams_visu = std::make_shared<chrono::ChVisualShapeFEA>(mesh);
         beams_visu->SetFEMdataType(chrono::ChVisualShapeFEA::DataType::ELEM_BEAM_MZ);
         beams_visu->SetColorscaleMinMax(-0.4, 0.4);
         mesh->AddVisualShapeFEA(beams_visu);
 
         // nodes
-        auto nodes_visu = chrono_types::make_shared<chrono::ChVisualShapeFEA>(mesh);
+        auto nodes_visu = std::make_shared<chrono::ChVisualShapeFEA>(mesh);
         nodes_visu->SetFEMglyphType(chrono::ChVisualShapeFEA::GlyphType::NODE_DOT_POS);
         nodes_visu->SetFEMdataType(chrono::ChVisualShapeFEA::DataType::NODE_DISP_Y);
         nodes_visu->SetSymbolsThickness(1.5);
@@ -62,7 +62,7 @@ void VisualizationInSituIrrlicht::initialize_elasto(seahowl::elasto::SystemElast
         mesh->AddVisualShapeFEA(nodes_visu);
 
         // nodes coordinate system
-        auto nodes_visu2 = chrono_types::make_shared<chrono::ChVisualShapeFEA>(mesh);
+        auto nodes_visu2 = std::make_shared<chrono::ChVisualShapeFEA>(mesh);
         nodes_visu2->SetFEMglyphType(chrono::ChVisualShapeFEA::GlyphType::NODE_CSYS);
         nodes_visu2->SetFEMdataType(chrono::ChVisualShapeFEA::DataType::NONE);
         nodes_visu2->SetSymbolsThickness(10.0);
@@ -93,8 +93,8 @@ void VisualizationInSituIrrlicht::draw() {
     application_irrlicht->Render();
 
     // draw bodies
-    for (auto body : system_chrono->Get_bodylist()) {
-        chrono::irrlicht::tools::drawCircle(application_irrlicht.get(), 5.0, body->GetCoord());
+    for (auto body : system_chrono->GetBodies()) {
+        chrono::irrlicht::tools::drawCircle(application_irrlicht.get(), 5.0, body->GetCoordsys());
     }
     chrono::irrlicht::tools::drawAllCOGs(application_irrlicht.get(), 5.0);
 

--- a/tests/unit_tests/data/test_aerodyn/ref/test_aerodyn_rpm_initial_pitch.csv
+++ b/tests/unit_tests/data/test_aerodyn/ref/test_aerodyn_rpm_initial_pitch.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d468fa503dce29694c065c0cbb2607596c6b9a66e71b3cabe9ea774fdf1810bd
+oid sha256:c2bc852cf0633cbfd5c4eac7d98bfeff6097a2b38c60753fc89b2eb4d0ff6a1e
 size 16154

--- a/tests/unit_tests/data/test_bemt/ref/test_bemt_tower_shadow_check.csv
+++ b/tests/unit_tests/data/test_bemt/ref/test_bemt_tower_shadow_check.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:75a26938ab2e2b779c8555a5ff207166021efb64bb2932510aba22b6aa46825a
+oid sha256:1a4cf6c7ef06da2b7245201908ce74b234e192f28a71130db3a5bde09fe5be3a
 size 266

--- a/tests/unit_tests/data/test_blade/ref/test_blade_edgewise_deflection.csv
+++ b/tests/unit_tests/data/test_blade/ref/test_blade_edgewise_deflection.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88dac4dc32939cfa24f1959c6163c338b2819e14c737748fe4d349124075ea14
+oid sha256:b3a9becbf15e317b87317a7b6e9c781acc7b609058a630a374f21cc82de03d4c
 size 38

--- a/tests/unit_tests/data/test_controller/ref/test_collective_pitch_control.csv
+++ b/tests/unit_tests/data/test_controller/ref/test_collective_pitch_control.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d611877da50e74810302bc578d90174c48c9e6cd6d1deafbbd1196e1f9aba610
-size 265814
+oid sha256:d3d9a0473b1d2331367ad6cea1e45f3c1b45b765b1bd09728fcb06a90bbd5326
+size 265805

--- a/tests/unit_tests/data/test_controller/ref/test_collective_pitch_control_snap.csv
+++ b/tests/unit_tests/data/test_controller/ref/test_collective_pitch_control_snap.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f604d5d21039a2ddb093af9578719f487608bc36101d0e9b1456586271f8c8ee
-size 265800
+oid sha256:9f5bf732ba503b65fb905d287fa594edcb13213ed34f2142d2a69a4370e4ae80
+size 265785

--- a/tests/unit_tests/data/test_controller/ref/test_controller.csv
+++ b/tests/unit_tests/data/test_controller/ref/test_controller.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:604177adee22818e602fbfd6c69c351b27695367a2e946db3ee4a783ce3456f0
-size 427459
+oid sha256:67fbf4e4e0e6f100e40e4bd5ae7f1792b6cca43915c7530b60c029d6e18db1a7
+size 426370

--- a/tests/unit_tests/data/test_controller/ref/test_controller_actuator_disk.csv
+++ b/tests/unit_tests/data/test_controller/ref/test_controller_actuator_disk.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65517044aa6e46c9eea5a9e67e36e94a5cab9c8e785659e8903929edc9de85fe
+oid sha256:1f9e1b0bb95dcfd71f0b905ea579cdd7d15a3267baffd05e2c2b29da8f9c7a8d
 size 24259

--- a/tests/unit_tests/data/test_controller/ref/test_individual_pitch_control.csv
+++ b/tests/unit_tests/data/test_controller/ref/test_individual_pitch_control.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f40c3764fce1dcbee5f77b8fbcb9adcd6ea5bc7b1846320d70561d7b61ddbf8
-size 266159
+oid sha256:66147c82279f88c26725844a1732476af2cd358fafd1ba16bb2215a9e6a7e801
+size 266126

--- a/tests/unit_tests/data/test_controller/ref/test_yaw_control.csv
+++ b/tests/unit_tests/data/test_controller/ref/test_yaw_control.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:013145a00387b15ad9b285cf6397875ef54d7fd087704294e7311c564a0c63bc
+oid sha256:48ee5f07ed1a704be57625b96d96abaf80086541111e3f076ddd46ce01c97bff
 size 68307

--- a/tests/unit_tests/data/test_controller/ref/test_yaw_control_snap.csv
+++ b/tests/unit_tests/data/test_controller/ref/test_yaw_control_snap.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:25fcbc4816d994cc96985a2d90cb1fb9aefeafd0a251388af8cda7dc8d3b8fe0
+oid sha256:cc5feb5ec6df95f50d00e288a402dd87746fd879f6d77cce31493a142378c4cc
 size 66554

--- a/tests/unit_tests/data/test_entities/ref/test_entities_added_mass_damping.csv
+++ b/tests/unit_tests/data/test_entities/ref/test_entities_added_mass_damping.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba545a7a34687a66abea0cdb79f4ca925b1d60062b03508546f8cb84e5347372
-size 128834
+oid sha256:e0574f8c71439b60577cc6c8d73877968e34b507052aadee5ca4b0e28852d8de
+size 129084

--- a/tests/unit_tests/data/test_inflowwind/ref/test_inflowwind_rpm_initial_pitch.csv
+++ b/tests/unit_tests/data/test_inflowwind/ref/test_inflowwind_rpm_initial_pitch.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b14d0b28ee5c1d8aa37615553851bef14afc71329e152780b2bd548bc6ada3f
+oid sha256:538298fee47e282682f875d8feb51156f021045001ac2313564f863a3c0c2cfd
 size 9919

--- a/tests/unit_tests/data/test_morison/ref/test_morison_tower.csv
+++ b/tests/unit_tests/data/test_morison/ref/test_morison_tower.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be81e919c183f91e4892f828b2bac4f5adae0601103e313d0b588495edceeb40
+oid sha256:caa9b03d954605fd5987c5339bcae656e89099f8a29291213d3add570bd4c674
 size 43444

--- a/tests/unit_tests/data/test_tower/ref/test_tower_mass.csv
+++ b/tests/unit_tests/data/test_tower/ref/test_tower_mass.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dd237c86baa857356770bd46f91eab3403679b88de4ae7da55cf120552df7742
+oid sha256:f4d2adef1ab0df0d8a9e1ec06205ad8feb9087567c1df80981255540d7c3c373
 size 26

--- a/tests/unit_tests/data/test_turbine/ref/test_turbine_actuator_disk.csv
+++ b/tests/unit_tests/data/test_turbine/ref/test_turbine_actuator_disk.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e2ef00d9ed2ccd4fade012b051f65e0a2ee4539e597164bd85c46fbd722f1975
+oid sha256:41a1f53dcc7eaff8c810c98f1420f0dc851592b20bb6119ff796cb56df9cd9ef
 size 14165

--- a/tests/unit_tests/data/test_turbine/ref/test_turbine_controller_target_rpm.csv
+++ b/tests/unit_tests/data/test_turbine/ref/test_turbine_controller_target_rpm.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba0ae1b48bd8aae0a9f1bb5587ca9004702572803f08ee873d7e4927e8a225d1
+oid sha256:a77b0ccbc5f9ce92c04cf4eed13a91909be5bb128fe4ffa0c3bdf6e22e76837f
 size 39841

--- a/tests/unit_tests/data/test_turbine/ref/test_turbine_multiturbines.csv
+++ b/tests/unit_tests/data/test_turbine/ref/test_turbine_multiturbines.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:363bfc78835389935c5f963087a56bef4a57a18bf4a3896dca63b66d4e3589c8
+oid sha256:3a8c870698dfeba73bced0b11f4e992076f53cae2739ae6be6f61eb5b9ed12cf
 size 18965

--- a/tests/unit_tests/data/test_turbine/ref/test_turbine_rpm_initial_pitch.csv
+++ b/tests/unit_tests/data/test_turbine/ref/test_turbine_rpm_initial_pitch.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5721c65aed7d9c345e551b8a5ece1e04872028fa63a911d94c58eb9273e749ec
+oid sha256:604078f3823e5cf964c03e861985cedc2ec8f0a3dc7cc96319c281f4dd1c0b90
 size 38622

--- a/tests/unit_tests/data/test_turbine/ref/test_turbine_rpm_initial_pitch_fpm.csv
+++ b/tests/unit_tests/data/test_turbine/ref/test_turbine_rpm_initial_pitch_fpm.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e8c274a6c37cbbb9740bad5ade95e4aed417799c8ccf7cca099183a496ab950c
+oid sha256:1e97dc6125729d1c64c6f64f4c6b3768d75b19fdaa2e0b097b70f1112db83670
 size 38619

--- a/tests/unit_tests/data/test_turbine/ref/test_turbine_rpm_initial_pitch_rigid_rotor.csv
+++ b/tests/unit_tests/data/test_turbine/ref/test_turbine_rpm_initial_pitch_rigid_rotor.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d5f5a0d965c56c2f5d77a7773ebe3e3cfbb194fbdf591074023a556fea80dc38
+oid sha256:492c403e5e01bb8f271e991124d01597b4b5b7713cd2ea4cc882128d1f5de85d
 size 38722

--- a/tests/unit_tests/fixture_components.h
+++ b/tests/unit_tests/fixture_components.h
@@ -78,7 +78,7 @@ class FixtureComponents : public ::testing::Test {
     path TESTDIR;
     path ref_dir;
     path test_dir;
-    double rel_error = 1e-2;
+    double rel_error = 1e-3;
     double abs_error = 1e-6;
     bool dump_test_to_reference = false;
 };


### PR DESCRIPTION
This PR updates elasto solver from Chrono 8.0.0 to 9.0.1.
This new version ensures deterministic results between runs (Chrono 8.0.0 had some minor numerical differences between runs when using Chrono::fea).
The tests were all passing after the update but several test result reference files have been updated since it is now non-varying between runs. The relative tolerance has also been tighten from 1e-2 to 1e-3.