### PR TITLE
Mc/shaft torque components

### DIFF
--- a/include/seahowl/elasto/rotor_elasto.h
+++ b/include/seahowl/elasto/rotor_elasto.h
@@ -180,6 +180,16 @@ class RotorNacelleAssemblyElasto : public ComponentElasto {
     double get_axial_torque() const;
 
     /**
+     * @brief Returns the lateral torque of the rotor (y component) [Nm]
+     */
+    double get_lateral_torque_y() const;
+
+    /**
+     * @brief Returns the lateral torque of the rotor (z component) [Nm]
+     */
+    double get_lateral_torque_z() const;
+
+    /**
      * @brief Returns the axial thrust of the rotor [N]
      */
     double get_axial_thrust() const;

--- a/src/elasto/rotor_elasto.cpp
+++ b/src/elasto/rotor_elasto.cpp
@@ -285,6 +285,26 @@ double RotorNacelleAssemblyElasto::get_axial_torque() const {
     return react_torque.x();
 }
 
+double RotorNacelleAssemblyElasto::get_lateral_torque_y() const {
+    // get reaction torque from all blades linked to hub
+    // those links are already in the hub body reference frame
+    auto react_torque = Vector3d(0.0, 0.0, 0.0);
+    for (auto& blade : rotor->blades) {
+        react_torque += blade->link_blade->get_reaction_torque();
+    }
+    return react_torque.y();
+}
+
+double RotorNacelleAssemblyElasto::get_lateral_torque_z() const {
+    // get reaction torque from all blades linked to hub
+    // those links are already in the hub body reference frame
+    auto react_torque = Vector3d(0.0, 0.0, 0.0);
+    for (auto& blade : rotor->blades) {
+        react_torque += blade->link_blade->get_reaction_torque();
+    }
+    return react_torque.z();
+}
+
 void RotorNacelleAssemblyElasto::accumulate_electrical_torque(double torque) {
     rotor->body_hub->accumulate_torque_internals(Vector3d(-torque, 0.0, 0.0), true);
     body_shaft->accumulate_torque_internals(Vector3d(torque, 0.0, 0.0), true);

--- a/src/io/output_manager.cpp
+++ b/src/io/output_manager.cpp
@@ -63,6 +63,10 @@ void add_basic_turbine_info_to_csv(seahowl::io::CustomCSV& custom_csv, seahowl::
     custom_csv.add_function("torque elec [Nm]", [&turbine]() { return turbine.controller->get_torque_elec(); });
     custom_csv.add_function("axial thrust [N]", [&turbine]() { return turbine.rna.elasto.get_axial_thrust(); });
     custom_csv.add_function("axial torque [Nm]", [&turbine]() { return turbine.rna.elasto.get_axial_torque(); });
+    custom_csv.add_function("lateral torque y [Nm]",
+                            [&turbine]() { return turbine.rna.elasto.get_lateral_torque_y(); });
+    custom_csv.add_function("lateral torque z [Nm]",
+                            [&turbine]() { return turbine.rna.elasto.get_lateral_torque_z(); });
     custom_csv.add_function("rotor azimuth [rad]", [&turbine]() { return turbine.rna.elasto.get_azimuth(); });
     custom_csv.add_function("tower base moment [Nm]",
                             [&turbine]() { return turbine.tower.elasto.get_tower_base_moment(); });


### PR DESCRIPTION
Extends RotorNacelleAssemblyElasto with get_lateral_torque_y() and get_lateral_torque_z(), returning the y and z components of the reaction torque summed from all blade-to-hub links (in the hub body frame). The existing get_axial_torque() covers the x component.

Both new components are exposed through the basic turbine CSV output as lateral torque y [Nm] and lateral torque z [Nm], alongside the existing axial torque [Nm] channel.

Changes

include/seahowl/elasto/rotor_elasto.h: declare the two new getters.
src/elasto/rotor_elasto.cpp: implement them.
src/io/output_manager.cpp: register them in add_basic_turbine_info_to_csv.
No behavioural changes to existing outputs or dynamics — purely additive.